### PR TITLE
[LMB-25] allow creating form instances

### DIFF
--- a/app/controllers/form/new.js
+++ b/app/controllers/form/new.js
@@ -1,5 +1,7 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { keepLatestTask } from 'ember-concurrency';
 
 export default class FormNewController extends Controller {
   @tracked sourceTriples;
@@ -10,5 +12,30 @@ export default class FormNewController extends Controller {
         this.model.graphs.sourceGraph
       );
     });
+  }
+
+  get isSaving() {
+    return this.save.isRunning;
+  }
+
+  @keepLatestTask
+  *save() {
+    const triples = this.sourceTriples;
+    const definition = this.model.definition;
+    // post triples to backend
+    yield fetch(`/form-content/${definition.id}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+      },
+      body: JSON.stringify({
+        contentTtl: triples,
+      }),
+    });
+  }
+
+  @action
+  async createInstance() {
+    this.save.perform();
   }
 }

--- a/app/routes/form.js
+++ b/app/routes/form.js
@@ -4,8 +4,10 @@ import { inject as service } from '@ember/service';
 export default class FormRoute extends Route {
   @service store;
   @service router;
+  @service session;
 
-  beforeModel() {
+  beforeModel(transition) {
+    this.session.requireAuthentication(transition, 'login');
     return this.router.replaceWith('form.new');
   }
 

--- a/app/routes/form/new.js
+++ b/app/routes/form/new.js
@@ -3,10 +3,8 @@ import { inject as service } from '@ember/service';
 import { RDF, FORM } from '@lblod/submission-form-helpers';
 import { NamedNode } from 'rdflib';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
-
-const FORM_GRAPH = new NamedNode('http://data.lblod.info/form');
-const META_GRAPH = new NamedNode('http://data.lblod.info/metagraph');
-const SOURCE_GRAPH = new NamedNode(`http://data.lblod.info/sourcegraph`);
+import { FORM_GRAPH, META_GRAPH, SOURCE_GRAPH } from '../../utils/constants';
+import { v4 as uuid } from 'uuid';
 
 export default class FormNewRoute extends Route {
   @service store;
@@ -15,7 +13,8 @@ export default class FormNewRoute extends Route {
     const instance = this.store.createRecord('form-instance', {
       definition: this.modelFor('form'),
       sourceTtl: '',
-      uri: 'http://data.lblod.info/form-data/instances/1',
+      // TODO allow forms to define their own prefix for uri generation: LMB-38
+      uri: `http://data.lblod.info/form-data/instances/${uuid()}`,
     });
 
     const formStore = new ForkingStore();
@@ -38,6 +37,7 @@ export default class FormNewRoute extends Route {
 
     return {
       instance,
+      definition,
       form: formNode,
       formStore,
       graphs,

--- a/app/templates/form/new.hbs
+++ b/app/templates/form/new.hbs
@@ -20,6 +20,11 @@
         {{outlet}}
       </div>
     </section>
+    <div class="au-o-layout">
+      <AuButton {{on "click" this.createInstance}} @disabled={{this.isSaving}}>
+        Bewaar
+      </AuButton>
+    </div>
     <section class="au-o-region-large">
       <div class="au-o-layout">
         <AuHeading

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -1,0 +1,5 @@
+import { NamedNode } from 'rdflib';
+
+export const FORM_GRAPH = new NamedNode('http://data.lblod.info/form');
+export const META_GRAPH = new NamedNode('http://data.lblod.info/metagraph');
+export const SOURCE_GRAPH = new NamedNode(`http://data.lblod.info/sourcegraph`);


### PR DESCRIPTION
This PR builds on top of https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/1, please review that one first!

This adds the possibility to send the create call in the form/new route. This call simply sends the form source graph to the backend.