### PR TITLE
Fix deprecations

### DIFF
--- a/app/components/contact-form.hbs
+++ b/app/components/contact-form.hbs
@@ -4,13 +4,12 @@
     <ul>
       {{#each this.subjectOptions as |option|}}
         <li>
-          <AuControlRadio
-            @label={{option.label}}
+          <AuRadio
             @value={{or option.subject option.label}}
             @name="contact-subject"
             @onChange={{fn (mut this.selected) option}}
-            checked={{eq this.subject option}}
-          />
+            @checked={{eq this.subject option}}
+          >{{option.label}}</AuRadio>
         </li>
       {{/each}}
     </ul>

--- a/app/components/mandatenbeheer/fractie-table-row.hbs
+++ b/app/components/mandatenbeheer/fractie-table-row.hbs
@@ -27,7 +27,7 @@
       </AuButton>
     </AuButtonGroup>
     {{else}}
-      <AuButton {{on "click" (fn (mut this.editMode) true)}} @skin="tertiary">
+      <AuButton {{on "click" (fn (mut this.editMode) true)}} @skin="link">
         <AuIcon @icon="pencil" @alignment="left" />
         Bewerk
       </AuButton>

--- a/app/components/mandatenbeheer/mandatarissen-totals.hbs
+++ b/app/components/mandatenbeheer/mandatarissen-totals.hbs
@@ -1,5 +1,5 @@
 <div class="{{if this.isOpen "js-accordion--open"}}">
-<AuButton @skin="tertiary" class="au-c-button--toggle" {{on 'click' this.toggleOpen}}>
+<AuButton @skin="link" class="au-c-button--toggle" {{on 'click' this.toggleOpen}}>
   Toon totalen per orgaan
   <AuIcon @icon="nav-down" @alignment="right" />
 </AuButton>

--- a/app/components/rdf-form-fields/accountability-table/table-row.hbs
+++ b/app/components/rdf-form-fields/accountability-table/table-row.hbs
@@ -105,7 +105,7 @@
 
   </td>
   <td style="vertical-align: middle;" {{!template-lint-disable no-inline-styles}}>
-    <AuButton @hideText="true" @icon="bin" @skin="tertiary" @alert="true" @disabled={{@disabled}}
+    <AuButton @hideText="true" @icon="bin" @skin="link" @alert="true" @disabled={{@disabled}}
       {{on "click" this.removeEntry}}>
       <AuIcon @icon="bin" @alignment="left"/>
       Verwijder rij

--- a/app/components/shared/persoon/create-persoon.hbs
+++ b/app/components/shared/persoon/create-persoon.hbs
@@ -139,22 +139,20 @@
         </AuLabel>
         <div class="au-o-grid au-o-grid--tiny">
           <div class="au-o-grid__item au-u-1-2 au-u-1-4@medium">
-            <AuControlRadio
-              @label="Vrouw"
-              checked={{this.isFemale}}
+            <AuRadio
+              @checked={{this.isFemale}}
               @value={{this.female}}
               @onChange={{this.setGender}}
               @name="gender"
-            />
+            >Vrouw</AuRadio>
           </div>
           <div class="au-o-grid__item au-u-1-2 au-u-1-4@medium">
-            <AuControlRadio
-              @label="Man"
-              checked={{this.isMale}}
+            <AuRadio
+              @checked={{this.isMale}}
               @value={{this.male}}
               @name="gender"
               @onChange={{this.setGender}}
-            />
+            >Man</AuRadio>
           </div>
           {{#if this.errors.geslacht}}
             <AuHelpText @error="true">{{this.errors.geslacht}}</AuHelpText>

--- a/app/components/shared/persoon/persoon-search-form-pagination.hbs
+++ b/app/components/shared/persoon/persoon-search-form-pagination.hbs
@@ -8,7 +8,7 @@
         {{#if this.hasMultiplePages}}
           {{#unless this.isFirstPage}}
             <li class="au-c-pagination__list-item">
-              <AuButton @skin="tertiary" {{on "click" (fn this.changePage @links.prev)}}>
+              <AuButton @skin="link" {{on "click" (fn this.changePage @links.prev)}}>
                 <AuIcon @icon="nav-left" @alignment="left" />
                 vorige
                 <span class="au-u-hidden-visually"> {{@size}} resultaten</span>
@@ -17,7 +17,7 @@
           {{/unless}}
           {{#unless this.isLastPage}}
             <li class="au-c-pagination__list-item">
-              <AuButton @skin="tertiary" {{on "click" (fn this.changePage @links.next)}}>
+              <AuButton @skin="link" {{on "click" (fn this.changePage @links.next)}}>
                 volgende
                 <span class="au-u-hidden-visually"> {{@size}} resultaten</span>
                 <AuIcon @icon="nav-right" @alignment="right" />

--- a/app/components/shared/persoon/persoon-search-form.hbs
+++ b/app/components/shared/persoon/persoon-search-form.hbs
@@ -82,7 +82,7 @@
           <AuAlert @title="Komt het zoekresultaat niet overeen met wat u zocht?" @skin="info" @size="tiny" class="au-u-margin-top-small">
             <p>
               Kijk uw zoekopdracht na of
-              <AuButton @skin="tertiary" {{on 'click' this.handleCreatePersonClick}} class="au-c-link">
+              <AuButton @skin="link" {{on 'click' this.handleCreatePersonClick}} class="au-c-link">
                 <AuIcon @icon="add" @alignment="left" />
                 voeg een nieuwe persoon toe
               </AuButton>.
@@ -92,7 +92,7 @@
           <AuAlert @title='"{{this.searchTerms}}" bestaat mogelijk nog niet.' @skin="info" @size="tiny">
             <p>
               Kijk uw zoekopdracht na of
-              <AuButton @skin="tertiary" {{on 'click' this.handleCreatePersonClick}} class="au-c-link">
+              <AuButton @skin="link" {{on 'click' this.handleCreatePersonClick}} class="au-c-link">
                 <AuIcon @icon="add" @alignment="left" />
                 voeg een nieuwe persoon toe
               </AuButton>.
@@ -103,7 +103,7 @@
         <AuContent>
           <p class="au-c-text-info">
             Zoek een reeds gekende persoon in de databank van het loket op naam of op rijksregisternummer,<br>of
-            <AuButton @skin="tertiary" {{on 'click' this.handleCreatePersonClick}}>
+            <AuButton @skin="link" {{on 'click' this.handleCreatePersonClick}}>
               <AuIcon @icon="add" @alignment="left" />
               voeg een nieuwe persoon toe
             </AuButton>.

--- a/app/templates/mandatenbeheer/fracties.hbs
+++ b/app/templates/mandatenbeheer/fracties.hbs
@@ -85,19 +85,19 @@
               </thead>
               <tbody>
                 {{#if this.newFractie}}
-                  {{mandatenbeheer/fractie-table-row
-                      onCancel=this.cancelEdit
-                      onSave=(perform this.saveFractie)
-                      fractie=this.newFractie
-                      editMode=true
-                  }}
+                  <Mandatenbeheer::FractieTableRow
+                    @onCancel={{this.cancelEdit}}
+                    @onSave={{(perform this.saveFractie)}}
+                    @fractie={{this.newFractie}}
+                    @editMode={{true}}
+                  />
                 {{/if}}
                 {{#each this.model as |row|}}
-                  {{mandatenbeheer/fractie-table-row
-                      onCancel=this.cancelEdit
-                      onSave=(perform this.saveFractie)
-                      fractie=row
-                  }}
+                  <Mandatenbeheer::FractieTableRow
+                    @onCancel={{this.cancelEdit}}
+                    @onSave={{(perform this.saveFractie)}}
+                    @fractie={{row}}
+                  />
                 {{else}}
                   {{#unless this.newFractie}}
                     <tr>


### PR DESCRIPTION
LMB-51
There are still a few deprecations left, for example the following two:
[AuInput] The `@value` argument is deprecated. Use the `value` attribute and the `{{on}}` modifier instead.
[AuInput] The masking feature is deprecated. Use the `{{au-inputmask}}` modifier instead.

The masking feature should be solvable, but I couldn't get my head around it, the @value one is a bit more widespread and difficult to solve in a decent amount of time.

There also is some old syntax that the linter is complaining about, but it would turn into a much bigger effort to fix these than it is actually worth. (Old component extensions etc.).