### PR TITLE
fetch and render form instance

### DIFF
--- a/app/controllers/form/instance.js
+++ b/app/controllers/form/instance.js
@@ -1,0 +1,33 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { keepLatestTask } from 'ember-concurrency';
+import { inject as service } from '@ember/service';
+
+export default class FormInstanceController extends Controller {
+  @tracked sourceTriples;
+  @tracked errorMessage;
+  @service router;
+
+  registerObserver() {
+    this.model.formStore.registerObserver(() => {
+      this.sourceTriples = this.model.formStore.serializeDataMergedGraph(
+        this.model.graphs.sourceGraph
+      );
+    });
+  }
+
+  get isSaving() {
+    return this.save.isRunning;
+  }
+
+  @keepLatestTask
+  *save() {
+    // TODO
+  }
+
+  @action
+  async saveInstance() {
+    this.save.perform();
+  }
+}

--- a/app/controllers/form/new.js
+++ b/app/controllers/form/new.js
@@ -2,9 +2,12 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { keepLatestTask } from 'ember-concurrency';
+import { inject as service } from '@ember/service';
 
 export default class FormNewController extends Controller {
   @tracked sourceTriples;
+  @tracked errorMessage;
+  @service router;
 
   registerObserver() {
     this.model.formStore.registerObserver(() => {
@@ -22,16 +25,34 @@ export default class FormNewController extends Controller {
   *save() {
     const triples = this.sourceTriples;
     const definition = this.model.definition;
+    this.errorMessage = null;
     // post triples to backend
-    yield fetch(`/form-content/${definition.id}`, {
+    const result = yield fetch(`/form-content/${definition.id}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/vnd.api+json',
       },
       body: JSON.stringify({
         contentTtl: triples,
+        instanceUri: this.model.sourceNode.value,
       }),
     });
+
+    if (!result.ok) {
+      this.errorMessage =
+        'Er ging iets mis bij het opslaan van het formulier. Probeer het later opnieuw.';
+      return;
+    }
+
+    const { id } = yield result.json();
+
+    if (!id) {
+      this.errorMessage =
+        'Het formulier werd niet correct opgeslagen. Probeer het later opnieuw.';
+      return;
+    }
+
+    this.router.transitionTo('form.instance', definition.id, id);
   }
 
   @action

--- a/app/router.js
+++ b/app/router.js
@@ -41,5 +41,7 @@ Router.map(function () {
   });
   this.route('form', { path: '/form/:id' }, function () {
     this.route('new');
+    this.route('instance', { path: '/instance/:instance_id' });
+    this.route('edit');
   });
 });

--- a/app/routes/form.js
+++ b/app/routes/form.js
@@ -8,7 +8,6 @@ export default class FormRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    return this.router.replaceWith('form.new');
   }
 
   async model({ id: semanticFormID }) {

--- a/app/routes/form/instance.js
+++ b/app/routes/form/instance.js
@@ -1,0 +1,56 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { RDF, FORM } from '@lblod/submission-form-helpers';
+import { NamedNode } from 'rdflib';
+import { ForkingStore } from '@lblod/ember-submission-form-fields';
+import { FORM_GRAPH, META_GRAPH, SOURCE_GRAPH } from '../../utils/constants';
+
+export default class FormInstanceRoute extends Route {
+  @service store;
+  async model(params) {
+    const definition = this.modelFor('form');
+    const { formDataTtl, instanceUri } = await this.retrieveFormInstance(
+      definition.id,
+      params.instance_id
+    );
+
+    const formStore = new ForkingStore();
+
+    const graphs = {
+      formGraph: FORM_GRAPH,
+      metaGraph: META_GRAPH,
+      sourceGraph: SOURCE_GRAPH,
+    };
+
+    this.loadForm(definition, formStore, formDataTtl, graphs);
+
+    const formNode = formStore.any(
+      undefined,
+      RDF('type'),
+      FORM('Form'),
+      FORM_GRAPH
+    );
+    const sourceNode = new NamedNode(instanceUri);
+
+    return {
+      instance: instanceUri,
+      definition,
+      form: formNode,
+      formStore,
+      graphs,
+      sourceNode,
+    };
+  }
+
+  async loadForm(definition, store, instance, graphs) {
+    store.parse(definition.formTtl, graphs.formGraph, 'text/turtle');
+    store.parse(definition.metaTtl || '', graphs.metaGraph, 'text/turtle');
+    store.parse(instance || '', graphs.sourceGraph, 'text/turtle');
+  }
+
+  async retrieveFormInstance(formId, id) {
+    const response = await fetch(`/form-content/${formId}/instances/${id}`);
+    const { formDataTtl, instanceUri } = await response.json();
+    return { formDataTtl, instanceUri };
+  }
+}

--- a/app/routes/form/instance.js
+++ b/app/routes/form/instance.js
@@ -42,6 +42,11 @@ export default class FormInstanceRoute extends Route {
     };
   }
 
+  setupController(controller) {
+    super.setupController(...arguments);
+    controller.registerObserver();
+  }
+
   async loadForm(definition, store, instance, graphs) {
     store.parse(definition.formTtl, graphs.formGraph, 'text/turtle');
     store.parse(definition.metaTtl || '', graphs.metaGraph, 'text/turtle');

--- a/app/templates/form/instance.hbs
+++ b/app/templates/form/instance.hbs
@@ -1,10 +1,10 @@
-{{page-title "New"}}
+{{page-title "Instance"}}
 <div class="au-c-main-container">
   <div
     class="au-c-main-container__content au-c-main-container__content--scroll"
   >
-    <div class="au-o-layout">
-      <section class="au-o-region-large">
+    <section class="au-o-region-large">
+      <div class="au-o-layout">
         <RdfForm
           @groupClass="au-o-grid__item"
           @form={{@model.form}}
@@ -18,20 +18,15 @@
           class="au-u-max-width-medium"
         />
         {{outlet}}
-
-      </section>
-      {{#if this.errorMessage}}
-        <AuAlert @skin="error" @title="Fout" @icon="alert-triangle">
-          {{this.errorMessage}}
-        </AuAlert>
-      {{/if}}
-
-      <AuButton {{on "click" this.createInstance}} @disabled={{this.isSaving}}>
+      </div>
+    </section>
+    <div class="au-o-layout">
+      {{!-- <AuButton {{on "click" this.createInstance}} @disabled={{this.isSaving}}>
         Bewaar
-      </AuButton>
-
-      <section class="au-o-region-large">
-
+      </AuButton> --}}
+    </div>
+    <section class="au-o-region-large">
+      <div class="au-o-layout">
         <AuHeading
           @level="2"
           @skin="3"
@@ -40,8 +35,7 @@
         <p>
           {{this.sourceTriples}}
         </p>
-
-      </section>
-    </div>
+      </div>
+    </section>
   </div>
 </div>

--- a/app/templates/form/instance.hbs
+++ b/app/templates/form/instance.hbs
@@ -3,8 +3,8 @@
   <div
     class="au-c-main-container__content au-c-main-container__content--scroll"
   >
-    <section class="au-o-region-large">
-      <div class="au-o-layout">
+    <div class="au-o-layout">
+      <section class="au-o-region-large">
         <RdfForm
           @groupClass="au-o-grid__item"
           @form={{@model.form}}
@@ -18,15 +18,12 @@
           class="au-u-max-width-medium"
         />
         {{outlet}}
-      </div>
-    </section>
-    <div class="au-o-layout">
-      {{!-- <AuButton {{on "click" this.createInstance}} @disabled={{this.isSaving}}>
+
+      </section>
+      <AuButton {{on "click" this.saveInstance}} @disabled={{this.isSaving}}>
         Bewaar
-      </AuButton> --}}
-    </div>
-    <section class="au-o-region-large">
-      <div class="au-o-layout">
+      </AuButton>
+      <section class="au-o-region-large">
         <AuHeading
           @level="2"
           @skin="3"
@@ -35,7 +32,7 @@
         <p>
           {{this.sourceTriples}}
         </p>
-      </div>
-    </section>
+      </section>
+    </div>
   </div>
 </div>

--- a/tests/unit/controllers/form/instance-test.js
+++ b/tests/unit/controllers/form/instance-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-lmb/tests/helpers';
+
+module('Unit | Controller | form/instance', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:form/instance');
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/routes/form/instance-test.js
+++ b/tests/unit/routes/form/instance-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-lmb/tests/helpers';
+
+module('Unit | Route | form/instance', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:form/instance');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
This passes the uri of the instance to be created to the form service and expects the service to return the uuid of the instance. It then transitions to the (new) instance route, rendering the same form instance, fetched from the server in case additional content is added server-side that we don't know about. this isn't the case right now but allows for future extensions.