### PR TITLE
track activation status of a bestuursorgaan

### DIFF
--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -5,6 +5,11 @@ export default class BestuursorgaanModel extends Model {
   @attr naam;
   @attr('date') bindingStart;
   @attr('date') bindingEinde;
+  @attr('date') deactivatedAt;
+
+  get isActive() {
+    return !this.deactivatedAt;
+  }
 
   @belongsTo('bestuurseenheid', {
     async: true,


### PR DESCRIPTION
![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/1076194/7cdad432-7041-4834-ba9a-6d809adcffe5)
![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/1076194/16e6bb54-e44c-4c10-a270-2d45f74f7acb)
Will add the controls to change this in a separate PR once the view of a bestuursorgaan exists