### PR TITLE
Moved Container Styling Out Of instance and new-instance Components

### DIFF
--- a/app/components/form/instance.hbs
+++ b/app/components/form/instance.hbs
@@ -1,56 +1,48 @@
 {{#if this.initialized}}
-  <div class="au-c-main-container">
-    <div
-      class="au-c-main-container__content au-c-main-container__content--scroll"
-    >
-      <div class="au-o-layout">
-        <section class="au-o-region-large">
-          <RdfForm
-            @groupClass="au-o-grid__item"
-            @form={{this.formInfo.form}}
-            @show={{(not this.isEditable)}}
-            @graphs={{this.formInfo.graphs}}
-            @sourceNode={{this.formInfo.sourceNode}}
-            @formStore={{this.formInfo.formStore}}
-            @forceShowErrors={{true}}
-            @useNewListingLayout={{true}}
-            @level={{2}}
-            class="au-u-max-width-medium {{unless this.isEditable 'disabled'}}"
-          />
-          {{yield}}
-        </section>
+  <section>
+    <RdfForm
+      @groupClass="au-o-grid__item"
+      @form={{this.formInfo.form}}
+      @show={{(not this.isEditable)}}
+      @graphs={{this.formInfo.graphs}}
+      @sourceNode={{this.formInfo.sourceNode}}
+      @formStore={{this.formInfo.formStore}}
+      @forceShowErrors={{true}}
+      @useNewListingLayout={{true}}
+      @level={{2}}
+      class="au-u-max-width-medium {{unless this.isEditable 'disabled'}}"
+    />
+    {{yield}}
+  </section>
 
-        {{#if this.isEditable}}
-          <AuToolbar as |Group|>
-            <Group>
-              <AuButtonGroup>
-                <AuButton
-                  {{on "click" this.saveInstance}}
-                  @disabled={{this.isSaving}}
-                >
-                  Pas aan
-                </AuButton>
-                {{#if @onCancel}}
-                  <AuButton {{on "click" this.cancel}} @skin="secondary">
-                    Annuleer
-                  </AuButton>
-                {{/if}}
-              </AuButtonGroup>
-            </Group>
-          </AuToolbar>
+  {{#if this.isEditable}}
+    <AuToolbar as |Group|>
+      <Group>
+        <AuButtonGroup>
+          <AuButton
+            {{on "click" this.saveInstance}}
+            @disabled={{this.isSaving}}
+          >
+            Pas aan
+          </AuButton>
+          {{#if @onCancel}}
+            <AuButton {{on "click" this.cancel}} @skin="secondary">
+              Annuleer
+            </AuButton>
+          {{/if}}
+        </AuButtonGroup>
+      </Group>
+    </AuToolbar>
 
-          <section class="au-o-region-large">
-            <AuHeading
-              @level="2"
-              @skin="3"
-              class="au-u-margin-bottom"
-            >Content</AuHeading>
-            <Form::FormattedTriples @triples={{this.sourceTriples}} />
-          </section>
-        {{/if}}
-      </div>
-    </div>
-  </div>
+    <section class="au-u-margin-top-large">
+      <AuHeading
+        @level="2"
+        @skin="3"
+        class="au-u-margin-bottom"
+      >Content</AuHeading>
+      <Form::FormattedTriples @triples={{this.sourceTriples}} />
+    </section>
+  {{/if}}
 
 {{else}}
   <div>loading...</div>

--- a/app/components/form/new-instance.hbs
+++ b/app/components/form/new-instance.hbs
@@ -1,65 +1,56 @@
 {{#if this.initialized}}
-  <div class="au-c-main-container">
-    <div
-      class="au-c-main-container__content au-c-main-container__content--scroll"
-    >
-      <div class="au-o-layout">
-        <section class="au-o-region-large">
-          <RdfForm
-            @groupClass="au-o-grid__item"
-            @form={{this.formInfo.form}}
-            @show={{false}}
-            @graphs={{this.formInfo.graphs}}
-            @sourceNode={{this.formInfo.sourceNode}}
-            @formStore={{this.formInfo.formStore}}
-            @forceShowErrors={{true}}
-            @useNewListingLayout={{true}}
-            @level={{2}}
-            class="au-u-max-width-medium"
-          />
-          {{yield}}
+  <section>
+    <RdfForm
+      @groupClass="au-o-grid__item"
+      @form={{this.formInfo.form}}
+      @show={{false}}
+      @graphs={{this.formInfo.graphs}}
+      @sourceNode={{this.formInfo.sourceNode}}
+      @formStore={{this.formInfo.formStore}}
+      @forceShowErrors={{true}}
+      @useNewListingLayout={{true}}
+      @level={{2}}
+      class="au-u-max-width-medium"
+    />
+    {{yield}}
+  </section>
 
-        </section>
-        {{#if this.errorMessage}}
-          <AuAlert @skin="error" @title="Fout" @icon="alert-triangle">
-            {{this.errorMessage}}
-          </AuAlert>
+  {{#if this.errorMessage}}
+    <AuAlert @skin="error" @title="Fout" @icon="alert-triangle">
+      {{this.errorMessage}}
+    </AuAlert>
+  {{/if}}
+
+  <AuToolbar as |Group|>
+    <Group>
+      <AuButtonGroup>
+        <AuButton
+          {{on "click" this.createInstance}}
+          @disabled={{this.isSaving}}
+        >
+          Bewaar
+        </AuButton>
+        {{#if @onCancel}}
+          <AuButton
+            {{on "click" this.cancel}}
+            @skin="secondary"
+            {{!-- @disabled={{not @cancel}} --}}
+          >
+            Annuleer
+          </AuButton>
         {{/if}}
+      </AuButtonGroup>
+    </Group>
+  </AuToolbar>
 
-        <AuToolbar as |Group|>
-          <Group>
-            <AuButtonGroup>
-              <AuButton
-                {{on "click" this.createInstance}}
-                @disabled={{this.isSaving}}
-              >
-                Bewaar
-              </AuButton>
-              {{#if @onCancel}}
-                <AuButton
-                  {{on "click" this.cancel}}
-                  @skin="secondary"
-                  {{!-- @disabled={{not @cancel}} --}}
-                >
-                  Annuleer
-                </AuButton>
-              {{/if}}
-            </AuButtonGroup>
-          </Group>
-        </AuToolbar>
-
-        <section class="au-o-region-large">
-
-          <AuHeading
-            @level="2"
-            @skin="3"
-            class="au-u-margin-bottom"
-          >Content</AuHeading>
-          <Form::FormattedTriples @triples={{this.sourceTriples}} />
-        </section>
-      </div>
-    </div>
-  </div>
+  <section class="au-u-margin-top-large">
+    <AuHeading
+      @level="2"
+      @skin="3"
+      class="au-u-margin-bottom"
+    >Content</AuHeading>
+    <Form::FormattedTriples @triples={{this.sourceTriples}} />
+  </section>
 {{else}}
   <div>loading...</div>
 {{/if}}

--- a/app/components/mandatenbeheer/mandataris/mandataris-edit-prompt.hbs
+++ b/app/components/mandatenbeheer/mandataris/mandataris-edit-prompt.hbs
@@ -29,21 +29,23 @@
     </div>
   </div>
 {{/unless}}
-<div class="au-o-grid__item">
-  {{#if this.isTerminating}}
-    <Form::Instance
-      @instanceId={{@mandataris.id}}
-      @form={{@mandatarisEindeEditForm}}
-      @onSave={{this.onSave}}
-      @onCancel={{this.cancel}}
-    />
-  {{else if this.isCorrecting}}
-    <Form::Instance
-      @instanceId={{@mandataris.id}}
-      @form={{@mandatarisEditForm}}
-      @onSave={{this.onSave}}
-      @onCancel={{this.cancel}}
-      @buildMetaTtl={{this.buildMetaTtl}}
-    />
-  {{/if}}
+<div class="au-o-region-large">
+  <div class="au-o-grid__item">
+    {{#if this.isTerminating}}
+      <Form::Instance
+        @instanceId={{@mandataris.id}}
+        @form={{@mandatarisEindeEditForm}}
+        @onSave={{this.onSave}}
+        @onCancel={{this.cancel}}
+      />
+    {{else if this.isCorrecting}}
+      <Form::Instance
+        @instanceId={{@mandataris.id}}
+        @form={{@mandatarisEditForm}}
+        @onSave={{this.onSave}}
+        @onCancel={{this.cancel}}
+        @buildMetaTtl={{this.buildMetaTtl}}
+      />
+    {{/if}}
+  </div>
 </div>

--- a/app/components/mandatenbeheer/mandataris/mandataris-edit-prompt.hbs
+++ b/app/components/mandatenbeheer/mandataris/mandataris-edit-prompt.hbs
@@ -30,22 +30,20 @@
   </div>
 {{/unless}}
 <div class="au-o-region-large">
-  <div class="au-o-grid__item">
-    {{#if this.isTerminating}}
-      <Form::Instance
-        @instanceId={{@mandataris.id}}
-        @form={{@mandatarisEindeEditForm}}
-        @onSave={{this.onSave}}
-        @onCancel={{this.cancel}}
-      />
-    {{else if this.isCorrecting}}
-      <Form::Instance
-        @instanceId={{@mandataris.id}}
-        @form={{@mandatarisEditForm}}
-        @onSave={{this.onSave}}
-        @onCancel={{this.cancel}}
-        @buildMetaTtl={{this.buildMetaTtl}}
-      />
-    {{/if}}
-  </div>
+  {{#if this.isTerminating}}
+    <Form::Instance
+      @instanceId={{@mandataris.id}}
+      @form={{@mandatarisEindeEditForm}}
+      @onSave={{this.onSave}}
+      @onCancel={{this.cancel}}
+    />
+  {{else if this.isCorrecting}}
+    <Form::Instance
+      @instanceId={{@mandataris.id}}
+      @form={{@mandatarisEditForm}}
+      @onSave={{this.onSave}}
+      @onCancel={{this.cancel}}
+      @buildMetaTtl={{this.buildMetaTtl}}
+    />
+  {{/if}}
 </div>

--- a/app/templates/leidinggevendenbeheer/bestuursfunctie/contact-info.hbs
+++ b/app/templates/leidinggevendenbeheer/bestuursfunctie/contact-info.hbs
@@ -6,11 +6,15 @@
   </Group>
 </AuToolbar>
 
-<Form::Instance
-  @instanceId={{@model.info.id}}
-  @form={{@model.form}}
-  @onSave={{this.save}}
-/>
+<div class="au-c-main-container__content au-c-main-container__content--scroll">
+  <div class="au-o-box">
+    <Form::Instance
+      @instanceId={{@model.info.id}}
+      @form={{@model.form}}
+      @onSave={{this.save}}
+    />
+  </div>
+</div>
 
 <AuToolbar @border="top" @size="large" as |Group|>
   <Group>

--- a/app/templates/leidinggevendenbeheer/bestuursfunctie/functionarissen/edit.hbs
+++ b/app/templates/leidinggevendenbeheer/bestuursfunctie/functionarissen/edit.hbs
@@ -12,11 +12,13 @@
   <div class="au-o-box">
     <Person::Card @persoon={{@model.functionaris.isBestuurlijkeAliasVan}} />
 
-    <Form::Instance
-      @instanceId={{@model.instanceId}}
-      @form={{@model.form}}
-      @onSave={{this.save}}
-    />
+    <div class="au-u-margin-top">
+      <Form::Instance
+        @instanceId={{@model.instanceId}}
+        @form={{@model.form}}
+        @onSave={{this.save}}
+      />
+    </div>
   </div>
 </div>
 

--- a/app/templates/leidinggevendenbeheer/bestuursfunctie/functionarissen/new.hbs
+++ b/app/templates/leidinggevendenbeheer/bestuursfunctie/functionarissen/new.hbs
@@ -4,11 +4,15 @@
   </Group>
 </AuToolbar>
 
-<Form::NewInstance
-  @onCreate={{this.create}}
-  @form={{@model.form}}
-  @buildSourceTtl={{this.buildSourceTtl}}
-/>
+<div class="au-c-body-container au-c-body-container--scroll">
+  <div class="au-o-box">
+    <Form::NewInstance
+      @onCreate={{this.create}}
+      @form={{@model.form}}
+      @buildSourceTtl={{this.buildSourceTtl}}
+    />
+  </div>
+</div>
 
 <AuToolbar @border="top" @size="large" as |Group|>
   <Group>

--- a/app/templates/mandatenbeheer/fracties/edit.hbs
+++ b/app/templates/mandatenbeheer/fracties/edit.hbs
@@ -5,11 +5,15 @@
   </Group>
 </AuToolbar>
 
-<Form::Instance
-  @instanceId={{this.model.instanceId}}
-  @form={{this.model.form}}
-  @onSave={{this.onSave}}
-/>
+<div class="au-c-body-container au-c-body-container--scroll">
+  <div class="au-o-box">
+    <Form::Instance
+      @instanceId={{this.model.instanceId}}
+      @form={{this.model.form}}
+      @onSave={{this.onSave}}
+    />
+  </div>
+</div>
 
 <AuToolbar @border="top" @size="large" as |Group|>
   <Group>

--- a/app/templates/mandatenbeheer/fracties/new.hbs
+++ b/app/templates/mandatenbeheer/fracties/new.hbs
@@ -4,11 +4,15 @@
   </Group>
 </AuToolbar>
 
-<Form::NewInstance
-  @onCreate={{this.onCreate}}
-  @form={{this.model.form}}
-  @buildSourceTtl={{this.buildSourceTtl}}
-/>
+<div class="au-c-body-container au-c-body-container--scroll">
+  <div class="au-o-box">
+    <Form::NewInstance
+      @onCreate={{this.onCreate}}
+      @form={{this.model.form}}
+      @buildSourceTtl={{this.buildSourceTtl}}
+    />
+  </div>
+</div>
 
 <AuToolbar @border="top" @size="large" as |Group|>
   <Group>

--- a/app/templates/mandatenbeheer/mandatarissen/new.hbs
+++ b/app/templates/mandatenbeheer/mandatarissen/new.hbs
@@ -4,11 +4,15 @@
   </Group>
 </AuToolbar>
 
-<Form::NewInstance
-  @onCreate={{this.onCreate}}
-  @form={{@model.mandatarisNewForm}}
-  @buildMetaTtl={{this.buildMetaTtl}}
-/>
+<div class="au-c-body-container au-c-body-container--scroll">
+  <div class="au-o-box">
+    <Form::NewInstance
+      @onCreate={{this.onCreate}}
+      @form={{@model.mandatarisNewForm}}
+      @buildMetaTtl={{this.buildMetaTtl}}
+    />
+  </div>
+</div>
 
 <AuToolbar @border="top" @size="large" as |Group|>
   <Group>

--- a/app/templates/organen/beheer/edit.hbs
+++ b/app/templates/organen/beheer/edit.hbs
@@ -6,11 +6,15 @@
   </Group>
 </AuToolbar>
 
-<Form::Instance
-  @instanceId={{this.model.instanceId}}
-  @form={{this.model.form}}
-  @onSave={{this.onSave}}
-/>
+<div class="au-c-main-container">
+  <div class="au-o-box">
+    <Form::Instance
+      @instanceId={{this.model.instanceId}}
+      @form={{this.model.form}}
+      @onSave={{this.onSave}}
+    />
+  </div>
+</div>
 
 <AuToolbar @border="top" @size="large" as |Group|>
   <Group>

--- a/app/templates/organen/beheer/new.hbs
+++ b/app/templates/organen/beheer/new.hbs
@@ -5,11 +5,15 @@
   </Group>
 </AuToolbar>
 
-<Form::NewInstance
-  @onCreate={{this.onCreate}}
-  @form={{this.model.form}}
-  @buildSourceTtl={{this.buildSourceTtl}}
-/>
+<div class="au-c-body-container au-c-body-container--scroll">
+  <div class="au-o-box">
+    <Form::NewInstance
+      @onCreate={{this.onCreate}}
+      @form={{this.model.form}}
+      @buildSourceTtl={{this.buildSourceTtl}}
+    />
+  </div>
+</div>
 
 <AuToolbar @border="top" @size="large" as |Group|>
   <Group>

--- a/app/templates/organen/orgaan.hbs
+++ b/app/templates/organen/orgaan.hbs
@@ -26,11 +26,12 @@
     @form={{this.model.form}}
     @isEditable={{false}}
   />
+
+  <AuToolbar class="au-u-margin-top" as |Group|>
+    <Group>
+      <AuButton @skin="secondary" {{on "click" this.edit}}>Pas aan</AuButton>
+    </Group>
+  </AuToolbar>
 </div>
-<AuToolbar @size="large" as |Group|>
-  <Group>
-    <AuButton @skin="secondary" {{on "click" this.edit}}>Pas aan</AuButton>
-  </Group>
-</AuToolbar>
 
 {{outlet}}


### PR DESCRIPTION
Moved au-c-main-container and other padding and margin styling to outside the instance and new-instance component.
![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/55446974/3003ba28-2596-4729-9856-08ce3dd42c1f)
