### PR TITLE
LMB-127 mandataris - split mandaten

### DIFF
--- a/app/components/mandatenbeheer/mandataris/mandataris-summary.hbs
+++ b/app/components/mandatenbeheer/mandataris/mandataris-summary.hbs
@@ -6,6 +6,10 @@
   </div>
   <div class="au-o-grid__item au-u-2-5 au-u-text-right">
     <AuButton
+      @skin={{if this.editing "primary" "secondary"}}
+      {{on "click" this.linkToDetailPage}}
+    >Details</AuButton>
+    <AuButton
       @skin={{if this.editing "secondary" "primary"}}
       {{on "click" this.edit}}
     >{{if this.editing "Sluit" "Pas aan"}}</AuButton>

--- a/app/components/mandatenbeheer/mandataris/mandataris-summary.js
+++ b/app/components/mandatenbeheer/mandataris/mandataris-summary.js
@@ -1,8 +1,10 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 export default class MandatenbeheerMandatarisSummaryComponent extends Component {
+  @service router;
   @tracked editing = false;
 
   get rol() {
@@ -30,5 +32,10 @@ export default class MandatenbeheerMandatarisSummaryComponent extends Component 
   @action
   edit() {
     this.editing = !this.editing;
+  }
+
+  @action
+  linkToDetailPage() {
+    this.router.transitionTo('under-construction');
   }
 }

--- a/app/components/mandatenbeheer/mandataris/mandataris-view.hbs
+++ b/app/components/mandatenbeheer/mandataris/mandataris-view.hbs
@@ -4,20 +4,42 @@
 
 <div class="au-o-box">
   <AuHeading @level="3" @skin="4">
-    Lijst van alle mandaten
+    Huidige mandaten
   </AuHeading>
 
   <AuHr />
 
   <ul class="au-c-list-vertical">
     {{#each @mandatarissen as |mandataris|}}
-      <Mandatenbeheer::Mandataris::MandatarisSummary
-        @mandataris={{mandataris}}
-        @bestuursorgaan={{@bestuursorgaan}}
-        @mandatarisEindeEditForm={{@mandatarisEindeEditForm}}
-        @mandatarisEditForm={{@mandatarisEditForm}}
-      />
-      <AuHr />
+      {{#if mandataris.isActive}}
+        <Mandatenbeheer::Mandataris::MandatarisSummary
+          @mandataris={{mandataris}}
+          @bestuursorgaan={{@bestuursorgaan}}
+          @mandatarisEindeEditForm={{@mandatarisEindeEditForm}}
+          @mandatarisEditForm={{@mandatarisEditForm}}
+        />
+        <AuHr />
+      {{/if}}
+    {{/each}}
+  </ul>
+
+  <AuHeading @level="3" @skin="4">
+    Beëindigde mandaten
+  </AuHeading>
+
+  <AuHr />
+
+  <ul class="au-c-list-vertical">
+    {{#each @mandatarissen as |mandataris|}}
+      {{#unless mandataris.isActive}}
+        <Mandatenbeheer::Mandataris::MandatarisSummary
+          @mandataris={{mandataris}}
+          @bestuursorgaan={{@bestuursorgaan}}
+          @mandatarisEindeEditForm={{@mandatarisEindeEditForm}}
+          @mandatarisEditForm={{@mandatarisEditForm}}
+        />
+        <AuHr />
+      {{/unless}}
     {{/each}}
   </ul>
 

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -55,12 +55,12 @@ export default class MandatarisModel extends AgentInPosition {
     );
   }
   get isActive() {
-    if (!this.endDate) {
+    if (!this.einde) {
       return true;
     }
 
-    const today = moment(new Date()).format('YYYY-MM-DD');
-    if (this.endDate > today) {
+    const today = moment(new Date());
+    if (this.einde > today) {
       return true;
     }
     return false;

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -1,5 +1,6 @@
 import { attr, belongsTo, hasMany } from '@ember-data/model';
 import AgentInPosition from './agent-in-position';
+import moment from 'moment';
 
 // INHERITS FROM AGENT-IN-POSITION
 export default class MandatarisModel extends AgentInPosition {
@@ -52,6 +53,17 @@ export default class MandatarisModel extends AgentInPosition {
       (uri) =>
         uri == 'http://mu.semte.ch/vocabularies/ext/mandatenExtractorService'
     );
+  }
+  get isActive() {
+    if (!this.endDate) {
+      return true;
+    }
+
+    const today = moment(new Date()).format('YYYY-MM-DD');
+    if (this.endDate > today) {
+      return true;
+    }
+    return false;
   }
 }
 

--- a/app/router.js
+++ b/app/router.js
@@ -102,6 +102,8 @@ Router.map(function () {
     });
   });
 
+  this.route('under-construction');
+
   this.route('error/404', {
     path: '/*wildcard',
   });

--- a/app/templates/under-construction.hbs
+++ b/app/templates/under-construction.hbs
@@ -1,0 +1,4 @@
+<Error
+  @statusCode="Page under construction"
+  @statusMessage="This page is still under construction, please come back later."
+/>


### PR DESCRIPTION
This PR splits mandaten of a certain mandataris into two categories, active ones and inactive ones. 
There is also an additional detail button for mandaten, but this just refers to an under construction page for now.

![Screenshot 2024-02-21 at 16 20 43](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/43848896/1001c1c5-c6a2-42a3-8253-b4b43f967f0b)

The layout and routing will be updated in the future in another story.