### PR TITLE
collapse mandaten, disable change state if ended

### DIFF
--- a/app/components/mandatarissen/mandataris-edit-prompt.hbs
+++ b/app/components/mandatarissen/mandataris-edit-prompt.hbs
@@ -2,16 +2,32 @@
   <div class="au-o-grid__item au-u-1-2">
     <AuContent @skin="small">
       <AuHeading @level="4" @skin="5">Wijziging huidige situatie</AuHeading>
-      <p>Indien de mandataris wordt vervangen, of de huidige
-        <strong>status, fractie, rangorde of bevoegdheid</strong>
-        verandert:
-      </p>
-      <ul>
-        <li>beëindig dit mandaat door de einddatum in te vullen;</li>
-        <li><strong>start een nieuw mandaat</strong>
-          met de gewijzigde situatie.</li>
-      </ul>
-      <AuButton {{on "click" this.changeStatus}}>Verander status</AuButton>
+      {{#if this.mandaatHasEnded}}
+        <p>
+          Dit mandaat werd beëindigd en kan niet meer gewijzigd worden. Indien
+          deze status niet correct is, gebruik de 'corrigeer fouten'
+          functionaliteit hiernaast.
+        </p>
+        <p>
+          Indien er een nieuw mandaat toegevoegd moet worden, bijvoorbeeld na
+          een periode waarin het mandaat niet actief was, voeg een nieuw mandaat
+          toe.
+        </p>
+      {{else}}
+        <p>Indien de mandataris wordt vervangen, of de huidige
+          <strong>status, fractie, rangorde of bevoegdheid</strong>
+          verandert:
+        </p>
+        <ul>
+          <li>beëindig dit mandaat door de einddatum in te vullen;</li>
+          <li><strong>start een nieuw mandaat</strong>
+            met de gewijzigde situatie.</li>
+        </ul>
+      {{/if}}
+      <AuButton
+        @disabled={{this.mandaatHasEnded}}
+        {{on "click" this.changeStatus}}
+      >Verander status</AuButton>
     </AuContent>
   </div>
   <div class="au-o-grid__item au-u-1-2">

--- a/app/components/mandatarissen/mandataris-edit-prompt.hbs
+++ b/app/components/mandatarissen/mandataris-edit-prompt.hbs
@@ -46,7 +46,7 @@
 
 <AuModal
   @title={{(concat
-    "Verander Toestand " @mandataris.bekleedt.bestuursfunctie.label
+    "Verander Status " @mandataris.bekleedt.bestuursfunctie.label
   )}}
   @modalOpen={{this.isChanging}}
   @closable={{true}}

--- a/app/components/mandatarissen/mandataris-edit-prompt.hbs
+++ b/app/components/mandatarissen/mandataris-edit-prompt.hbs
@@ -2,7 +2,17 @@
   <div class="au-o-grid__item au-u-1-2">
     <AuContent @skin="small">
       <AuHeading @level="4" @skin="5">Wijziging huidige situatie</AuHeading>
-      {{#if this.mandaatHasEnded}}
+      {{#if @mandataris.isActive}}
+        <p>Indien de mandataris wordt vervangen, of de huidige
+          <strong>status, fractie, rangorde of bevoegdheid</strong>
+          verandert:
+        </p>
+        <ul>
+          <li>beëindig dit mandaat;</li>
+          <li><strong>start een nieuw mandaat</strong>
+            met de gewijzigde situatie.</li>
+        </ul>
+      {{else}}
         <p>
           Dit mandaat werd beëindigd en kan niet meer gewijzigd worden. Indien
           deze status niet correct is, gebruik de 'corrigeer fouten'
@@ -13,19 +23,9 @@
           een periode waarin het mandaat niet actief was, voeg een nieuw mandaat
           toe.
         </p>
-      {{else}}
-        <p>Indien de mandataris wordt vervangen, of de huidige
-          <strong>status, fractie, rangorde of bevoegdheid</strong>
-          verandert:
-        </p>
-        <ul>
-          <li>beëindig dit mandaat door de einddatum in te vullen;</li>
-          <li><strong>start een nieuw mandaat</strong>
-            met de gewijzigde situatie.</li>
-        </ul>
       {{/if}}
       <AuButton
-        @disabled={{this.mandaatHasEnded}}
+        @disabled={{not @mandataris.isActive}}
         {{on "click" this.changeStatus}}
       >Verander status</AuButton>
     </AuContent>

--- a/app/components/mandatarissen/mandataris-edit-prompt.js
+++ b/app/components/mandatarissen/mandataris-edit-prompt.js
@@ -22,13 +22,6 @@ export default class MandatenbeheerMandatarisEditPromptComponent extends Compone
     return this.editMode === CORRECT_MODE;
   }
 
-  get mandaatHasEnded() {
-    return (
-      this.args.mandataris.einde &&
-      this.args.mandataris.einde.getTime() < new Date().getTime()
-    );
-  }
-
   @action
   changeStatus() {
     this.editMode = CHANGE_MODE;

--- a/app/components/mandatarissen/mandataris-edit-prompt.js
+++ b/app/components/mandatarissen/mandataris-edit-prompt.js
@@ -22,6 +22,13 @@ export default class MandatenbeheerMandatarisEditPromptComponent extends Compone
     return this.editMode === CORRECT_MODE;
   }
 
+  get mandaatHasEnded() {
+    return (
+      this.args.mandataris.einde &&
+      this.args.mandataris.einde.getTime() < new Date().getTime()
+    );
+  }
+
   @action
   changeStatus() {
     this.editMode = CHANGE_MODE;

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -2,13 +2,13 @@
 <div class="au-o-box au-o-flow">
   {{#unless @noTitle}}
     <AuHeading>
-      Verander Toestand
+      Verander Status
       {{@mandataris.bekleedt.bestuursfunctie.label}}
     </AuHeading>
   {{/unless}}
   <div>
     <AuLabel>
-      Huidige Toestand
+      Huidige Status
     </AuLabel>
     <div>
       {{@mandataris.bekleedt.bestuursfunctie.label}},
@@ -23,7 +23,7 @@
   </div>
   <div>
     <AuLabel>
-      Nieuwe Toestand
+      Nieuwe Status
     </AuLabel>
     <PowerSelect
       @allowClear={{false}}

--- a/app/routes/mandatarissen/persoon.js
+++ b/app/routes/mandatarissen/persoon.js
@@ -51,6 +51,24 @@ export default class MandatarissenPersoonRoute extends Route {
     };
 
     let mandatarissen = await this.store.query('mandataris', queryParams);
-    return mandatarissen.slice();
+    return this.keepLatestMandatarisPerMandaat(mandatarissen);
+  }
+
+  keepLatestMandatarisPerMandaat(mandatarissen) {
+    const mandaatIdToMandataris = {};
+
+    mandatarissen.forEach((mandataris) => {
+      const mandaatId = mandataris.bekleedt.id;
+      if (!mandaatIdToMandataris[mandaatId]) {
+        mandaatIdToMandataris[mandaatId] = mandataris;
+      } else {
+        const existingMandataris = mandaatIdToMandataris[mandaatId];
+        if (mandataris.start > existingMandataris.start) {
+          mandaatIdToMandataris[mandaatId] = mandataris;
+        }
+      }
+    });
+
+    return Object.values(mandaatIdToMandataris);
   }
 }


### PR DESCRIPTION
combine mandaten in mandataris overview page and keep the latest one per mandaat. don't allow changing the state of a beeindigd mandaat

this shows a verhinderd mandaat that follows an effectief mandaat, but the previous version is no longer shown here
![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/1076194/14d3fa56-c95f-42e7-a5ef-32903bb16fa0)

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/1076194/cd568c94-b205-4b0b-abf2-7a5efd0fbd15)
