### PR TITLE
form history

### DIFF
--- a/app/components/form/history-row.hbs
+++ b/app/components/form/history-row.hbs
@@ -7,14 +7,20 @@
     {{this.description}}
   </td>
   <td>
-    <AuButton
-      @type="button"
-      @icon="redo"
-      @skin="link"
-      @title="Terugzetten"
-      {{on "click" (fn @onRestore @historyItem)}}
-    >
-      Terugzetten
-    </AuButton>
+    {{#if @isCurrentVersion}}
+      <div class="au-u-muted">
+        Huidige versie
+      </div>
+    {{else}}
+      <AuButton
+        @type="button"
+        @icon="redo"
+        @skin="link"
+        @title="Terugzetten"
+        {{on "click" (fn @onRestore @historyItem)}}
+      >
+        Terugzetten
+      </AuButton>
+    {{/if}}
   </td>
 </tr>

--- a/app/components/form/history-row.hbs
+++ b/app/components/form/history-row.hbs
@@ -1,0 +1,20 @@
+<tr ...attributes>
+  <td>{{moment-format @historyItem.issued "DD-MM-YYYY HH:mm"}}</td>
+  <td>
+    {{this.userName}}
+  </td>
+  <td>
+    {{this.description}}
+  </td>
+  <td>
+    <AuButton
+      @type="button"
+      @icon="redo"
+      @skin="link"
+      @title="Terugzetten"
+      {{on "click" (fn @onRestore @historyItem)}}
+    >
+      Terugzetten
+    </AuButton>
+  </td>
+</tr>

--- a/app/components/form/history-row.js
+++ b/app/components/form/history-row.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+
+export default class FormHistoryRowComponent extends Component {
+  get userName() {
+    if (!this.args.historyItem.creator) {
+      return 'Onbekend';
+    }
+    return `${this.args.historyItem.creator.voornaam} ${this.args.historyItem.creator.achternaam}`;
+  }
+
+  get description() {
+    return this.args.historyItem.description || 'Aangepast';
+  }
+}

--- a/app/components/form/history.hbs
+++ b/app/components/form/history.hbs
@@ -1,0 +1,35 @@
+{{#if this.loading}}
+  Loading...
+{{else}}
+  <AuTable @size={{this.size}}>
+    <:header>
+      <tr>
+        <th>Tijdstip</th>
+        <th>Gebruiker</th>
+        <th>Aanpassing</th>
+        <th></th>
+      </tr>
+    </:header>
+    <:body>
+      {{#each this.history as |historyItem|}}
+        <Form::HistoryRow
+          @historyItem={{historyItem}}
+          @onRestore={{perform this.restoreHistoryItem}}
+        />
+      {{else}}
+        <tr>
+          <td>Geen aanpassingen gevonden</td><td></td><td></td><td></td>
+        </tr>
+      {{/each}}
+    </:body>
+  </AuTable>
+  <Shared::TablePagination
+    @pageSize={{this.size}}
+    @page={{this.page}}
+    @totalItems={{this.totalCount}}
+    @toNextPage={{this.toNextPage}}
+    @toPreviousPage={{this.toPreviousPage}}
+  />
+
+  {{yield}}
+{{/if}}

--- a/app/components/form/history.hbs
+++ b/app/components/form/history.hbs
@@ -18,18 +18,20 @@
         />
       {{else}}
         <tr>
-          <td>Geen aanpassingen gevonden</td><td></td><td></td><td></td>
+          <td colspan="4">Geen aanpassingen gevonden</td>
         </tr>
       {{/each}}
     </:body>
   </AuTable>
-  <Shared::TablePagination
-    @pageSize={{this.size}}
-    @page={{this.page}}
-    @totalItems={{this.totalCount}}
-    @toNextPage={{this.toNextPage}}
-    @toPreviousPage={{this.toPreviousPage}}
-  />
+  {{#if (gt this.history.length 0)}}
+    <Shared::TablePagination
+      @pageSize={{this.size}}
+      @page={{this.page}}
+      @totalItems={{this.totalCount}}
+      @toNextPage={{this.toNextPage}}
+      @toPreviousPage={{this.toPreviousPage}}
+    />
+  {{/if}}
 
   {{yield}}
 {{/if}}

--- a/app/components/form/history.hbs
+++ b/app/components/form/history.hbs
@@ -15,7 +15,7 @@
         <Form::HistoryRow
           @historyItem={{historyItem}}
           @onRestore={{perform this.restoreHistoryItem}}
-          @isCurrentVersion={{eq index 0}}
+          @isCurrentVersion={{and (eq index 0) (eq this.page 0)}}
         />
       {{else}}
         <tr>

--- a/app/components/form/history.hbs
+++ b/app/components/form/history.hbs
@@ -11,10 +11,11 @@
       </tr>
     </:header>
     <:body>
-      {{#each this.history as |historyItem|}}
+      {{#each this.history as |historyItem index|}}
         <Form::HistoryRow
           @historyItem={{historyItem}}
           @onRestore={{perform this.restoreHistoryItem}}
+          @isCurrentVersion={{eq index 0}}
         />
       {{else}}
         <tr>

--- a/app/components/form/history.js
+++ b/app/components/form/history.js
@@ -1,0 +1,71 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { keepLatestTask, dropTask } from 'ember-concurrency';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+
+export default class FormHistoryComponent extends Component {
+  @tracked loading = true;
+  @tracked page = 0;
+  @tracked size = 10;
+  @tracked history = [];
+  @tracked totalCount = 0;
+
+  @service store;
+
+  constructor() {
+    super(...arguments);
+    this.fetchCurrentHistoryPage.perform();
+  }
+
+  @keepLatestTask
+  *fetchCurrentHistoryPage() {
+    this.loading = true;
+    const result = yield fetch(
+      `/form-content/${this.args.formId}/instances/${this.args.instanceId}/history?page[size]=${this.size}&page[number]=${this.page}`
+    );
+
+    const json = yield result.json();
+    const history = json.instances;
+    this.totalCount = parseInt(result.headers.get('X-Total-Count'), 10);
+
+    const userIds = new Set([...history.map((h) => h.creator)]);
+    const users = yield this.store.query('gebruiker', {
+      filter: {
+        id: Array.from(userIds).join(','),
+      },
+    });
+
+    this.history = history.map((h) => {
+      const user = users.findBy('id', h.creator);
+      return {
+        ...h,
+        creator: user,
+      };
+    });
+
+    this.loading = false;
+  }
+
+  @dropTask
+  *restoreHistoryItem(historyItem) {
+    const result = yield fetch(
+      `/form-content/history?historyUri=${historyItem.history}`
+    );
+    const json = yield result.json();
+
+    this.args.onRestore(json);
+  }
+
+  @action
+  toNextPage() {
+    this.page = this.page + 1;
+    this.fetchCurrentHistoryPage.perform();
+  }
+
+  @action
+  toPreviousPage() {
+    this.page = this.page - 1;
+    this.fetchCurrentHistoryPage.perform();
+  }
+}

--- a/app/components/form/history.js
+++ b/app/components/form/history.js
@@ -30,14 +30,19 @@ export default class FormHistoryComponent extends Component {
     this.totalCount = parseInt(result.headers.get('X-Total-Count'), 10);
 
     const userIds = new Set([...history.map((h) => h.creator)]);
-    const users = yield this.store.query('gebruiker', {
-      filter: {
-        id: Array.from(userIds).join(','),
-      },
-    });
+    let users = [];
+    if (userIds.size !== 0) {
+      users = yield this.store.query('gebruiker', {
+        filter: {
+          id: Array.from(userIds).join(','),
+        },
+      });
+    }
 
     this.history = history.map((h) => {
-      const user = users.findBy('id', h.creator);
+      const user = users.find((item) => {
+        item.id === h.creator;
+      });
       return {
         ...h,
         creator: user,

--- a/app/components/form/instance.hbs
+++ b/app/components/form/instance.hbs
@@ -34,14 +34,7 @@
       </Group>
     </AuToolbar>
 
-    <section class="au-u-margin-top-large">
-      <AuHeading
-        @level="2"
-        @skin="3"
-        class="au-u-margin-bottom"
-      >Content</AuHeading>
-      <Form::FormattedTriples @triples={{this.sourceTriples}} />
-    </section>
+    <Form::TripleContent @triples={{this.sourceTriples}} />
   {{/if}}
 
 {{else}}

--- a/app/components/form/instance.hbs
+++ b/app/components/form/instance.hbs
@@ -35,8 +35,20 @@
     </AuToolbar>
 
     <Form::TripleContent @triples={{this.sourceTriples}} />
-  {{/if}}
+    {{#if @showHistory}}
+      <section>
+        <AuHeading @level="2" @skin="4" class="au-u-margin-bottom-small">
+          History
+        </AuHeading>
 
+        <Form::History
+          @instanceId={{@instanceId}}
+          @form={{@form}}
+          @onRestore={{this.onRestore}}
+        />
+      </section>
+    {{/if}}
+  {{/if}}
 {{else}}
   <div>loading...</div>
 {{/if}}

--- a/app/components/form/instance.hbs
+++ b/app/components/form/instance.hbs
@@ -21,7 +21,7 @@
         <AuButtonGroup>
           <AuButton
             {{on "click" this.saveInstance}}
-            @disabled={{this.isSaving}}
+            @disabled={{or this.isSaving (not this.hasChanges)}}
           >
             Pas aan
           </AuButton>

--- a/app/components/form/instance.js
+++ b/app/components/form/instance.js
@@ -26,6 +26,7 @@ export default class InstanceComponent extends Component {
   @tracked sourceTriples;
   @tracked errorMessage;
   @tracked formInfo = null;
+
   formStore = null;
   savedTriples = null;
   formId = `form-${guidFor(this)}`;
@@ -111,9 +112,16 @@ export default class InstanceComponent extends Component {
     this.args.onCancel();
   }
 
-  async onInit() {
+  @action
+  async onRestore(historicalInstance) {
+    this.formInfo = null;
+    this.onInit(historicalInstance.formInstanceTtl);
+  }
+
+  async onInit(newFormTtl = null) {
     const form = this.args.form;
     const instanceId = this.args.instanceId;
+
     const { formInstanceTtl, instanceUri } = await this.retrieveFormInstance(
       form.id,
       instanceId
@@ -127,7 +135,7 @@ export default class InstanceComponent extends Component {
       sourceGraph: SOURCE_GRAPH,
     };
 
-    loadFormInto(formStore, form, formInstanceTtl, graphs);
+    loadFormInto(formStore, form, newFormTtl || formInstanceTtl, graphs);
 
     if (this.args.buildMetaTtl) {
       const metaTtl = await this.args.buildMetaTtl();

--- a/app/components/form/instance.js
+++ b/app/components/form/instance.js
@@ -26,6 +26,7 @@ export default class InstanceComponent extends Component {
   @tracked sourceTriples;
   @tracked errorMessage;
   @tracked formInfo = null;
+  @tracked hasChanges = false;
 
   formStore = null;
   savedTriples = null;
@@ -100,6 +101,7 @@ export default class InstanceComponent extends Component {
     }
 
     this.formDirtyState.markClean(this.formId);
+    this.hasChanges = false;
   }
 
   @action
@@ -194,8 +196,10 @@ export default class InstanceComponent extends Component {
 
       if (this.savedTriples === this.sourceTriples) {
         this.formDirtyState.markClean(this.formId);
+        this.hasChanges = false;
       } else {
         this.formDirtyState.markDirty(this.formId);
+        this.hasChanges = true;
       }
     };
     formStore.registerObserver(onFormUpdate);

--- a/app/components/form/new-instance.hbs
+++ b/app/components/form/new-instance.hbs
@@ -39,14 +39,7 @@
     </Group>
   </AuToolbar>
 
-  <section class="au-u-margin-top-large">
-    <AuHeading
-      @level="2"
-      @skin="3"
-      class="au-u-margin-bottom"
-    >Content</AuHeading>
-    <Form::FormattedTriples @triples={{this.sourceTriples}} />
-  </section>
+  <Form::TripleContent @triples={{this.sourceTriples}} />
 {{else}}
   <div>loading...</div>
 {{/if}}

--- a/app/components/form/triple-content.hbs
+++ b/app/components/form/triple-content.hbs
@@ -1,0 +1,17 @@
+{{#if this.showSourceTriples}}
+  <section class="au-u-margin-top-large">
+    <AuHeading
+      @level="2"
+      @skin="4"
+      class="au-u-margin-bottom-small"
+      {{on "click" this.toggleExpanded}}
+    >
+      <AuIcon @icon={{if this.expanded "dash" "plus"}} />
+      Content
+    </AuHeading>
+    {{#if this.expanded}}
+      <Form::FormattedTriples @triples={{@triples}} />
+    {{/if}}
+    {{yield}}
+  </section>
+{{/if}}

--- a/app/components/form/triple-content.js
+++ b/app/components/form/triple-content.js
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+import ENV from 'frontend-lmb/config/environment';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class FormTripleContentComponent extends Component {
+  @tracked expanded = false;
+
+  get showSourceTriples() {
+    return ENV.APP.SHOW_FORM_CONTENT;
+  }
+
+  @action
+  toggleExpanded() {
+    this.expanded = !this.expanded;
+  }
+}

--- a/app/components/rdf-input-fields/mandataris-replacement-selector.js
+++ b/app/components/rdf-input-fields/mandataris-replacement-selector.js
@@ -121,6 +121,9 @@ export default class MandatarisReplacementSelector extends InputFieldComponent {
 
   @action
   selectReplacement(mandatarises) {
+    if (this.isDestroyed || this.isDestroying) {
+      return;
+    }
     this.replacements = mandatarises;
 
     // Retrieve options in store

--- a/app/components/shared/table-pagination.hbs
+++ b/app/components/shared/table-pagination.hbs
@@ -1,0 +1,39 @@
+<div class="au-c-pagination au-u-padding-small">
+  <p>
+    <span class="au-u-hidden-visually">Rij </span><strong>{{this.startItem}}
+      -
+      {{this.endItem}}</strong>
+    van
+    {{@totalItems}}
+  </p>
+  {{yield}}
+  <ul class="au-c-pagination__list">
+    {{#if this.hasMultiplePages}}
+      {{#unless this.isFirstPage}}
+        <li class="au-c-pagination__list-item">
+          <AuButton
+            @skin="link"
+            @icon="nav-left"
+            {{on "click" @toPreviousPage}}
+          >
+            vorige
+            <span class="au-u-hidden-visually"> {{@pageSize}} rijen</span>
+          </AuButton>
+        </li>
+      {{/unless}}
+      {{#unless this.isLastPage}}
+        <li class="au-c-pagination__list-item">
+          <AuButton
+            @skin="link"
+            @icon="nav-right"
+            @iconAlignment="right"
+            {{on "click" @toNextPage}}
+          >
+            volgende
+            <span class="au-u-hidden-visually"> {{@pageSize}} rijen</span>
+          </AuButton>
+        </li>
+      {{/unless}}
+    {{/if}}
+  </ul>
+</div>

--- a/app/components/shared/table-pagination.js
+++ b/app/components/shared/table-pagination.js
@@ -1,0 +1,29 @@
+import Component from '@glimmer/component';
+
+export default class SharedTablePaginationComponent extends Component {
+  get startItem() {
+    return this.args.page * this.args.pageSize + 1;
+  }
+
+  get isFirstPage() {
+    return this.startItem === 1;
+  }
+
+  get isLastPage() {
+    return (
+      this.args.page * this.args.pageSize + this.args.pageSize >=
+      this.args.totalItems
+    );
+  }
+
+  get hasMultiplePages() {
+    return !this.isFirstPage || !this.isLastPage;
+  }
+
+  get endItem() {
+    return Math.min(
+      this.args.page * this.args.pageSize + this.args.pageSize,
+      this.args.totalItems
+    );
+  }
+}

--- a/app/models/form-definition.js
+++ b/app/models/form-definition.js
@@ -8,6 +8,7 @@ export default class FormDefinitionModel extends Model {
   metaTtl;
   @attr('string')
   prefix;
+  @attr withHistory;
 
   @hasMany('form-instance', {
     async: false,

--- a/app/routes/legacy/formbeheer/form.js
+++ b/app/routes/legacy/formbeheer/form.js
@@ -20,6 +20,7 @@ export default class FormRoute extends Route {
         formTtl: form.formTtl,
         metaTtl: form.metaTtl,
         prefix: form.prefix,
+        withHistory: form.withHistory,
       });
     }
 

--- a/app/templates/legacy/formbeheer/form/instance.hbs
+++ b/app/templates/legacy/formbeheer/form/instance.hbs
@@ -8,4 +8,7 @@
       @onCancel={{this.onCancel}}
     />
   </div>
+  {{#if this.model.form.withHistory}}
+    history here
+  {{/if}}
 </div>

--- a/app/templates/legacy/formbeheer/form/instance.hbs
+++ b/app/templates/legacy/formbeheer/form/instance.hbs
@@ -6,9 +6,7 @@
       @form={{this.model.form}}
       @onSave={{this.onSave}}
       @onCancel={{this.onCancel}}
+      @showHistory={{this.model.form.withHistory}}
     />
   </div>
-  {{#if this.model.form.withHistory}}
-    history here
-  {{/if}}
 </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -58,6 +58,7 @@ module.exports = function (environment) {
 
   if (environment === 'development') {
     ENV.APP.DISABLE_RELOAD_WARNINGS = true;
+    ENV.APP.SHOW_FORM_CONTENT = true;
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;

--- a/tests/integration/components/form/history-row-test.js
+++ b/tests/integration/components/form/history-row-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | form/history-row', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Form::HistoryRow />`);
+
+    assert.dom(this.element).hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <Form::HistoryRow>
+        template block text
+      </Form::HistoryRow>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+});

--- a/tests/integration/components/form/history-test.js
+++ b/tests/integration/components/form/history-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | form/history', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Form::History />`);
+
+    assert.dom(this.element).hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <Form::History>
+        template block text
+      </Form::History>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+});

--- a/tests/integration/components/form/triple-content-test.js
+++ b/tests/integration/components/form/triple-content-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | form/triple-content', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Form::TripleContent />`);
+
+    assert.dom(this.element).hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <Form::TripleContent>
+        template block text
+      </Form::TripleContent>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+});

--- a/tests/integration/components/shared/table-pagination-test.js
+++ b/tests/integration/components/shared/table-pagination-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | shared/table-pagination', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Shared::TablePagination />`);
+
+    assert.dom(this.element).hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <Shared::TablePagination>
+        template block text
+      </Shared::TablePagination>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+});


### PR DESCRIPTION
![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/1076194/2f5a0910-0258-480d-b51a-03f04eaa2680)

To be able to test this pr, you will need this branch in the form-content service: https://github.com/lblod/form-content-service/pull/34

note: when reverting the mandataris-edit form, an exception is thrown in the console, coming from the form library. Some hook that isn't cleaned up properly. The application keeps working as expected though, so i will just add a bug ticket to our backlog and ignore for now.