### PR TITLE
fix replacements being confusing when changing state of a verhinderd mandataris

### DIFF
--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -57,7 +57,11 @@ export default class MandatarissenUpdateState extends Component {
   }
 
   get showReplacement() {
-    return this.newStatus?.id === VERHINDERD_STATE_ID;
+    return (
+      this.newStatus?.id === VERHINDERD_STATE_ID &&
+      // if we are already verhinderd it does not make sense to change the replacements here, keep them  the same and don't show the selector
+      this.args.mandataris.status?.id !== VERHINDERD_STATE_ID
+    );
   }
 
   get isTerminatingMandate() {
@@ -162,6 +166,9 @@ export default class MandatarissenUpdateState extends Component {
           this.selectedFractie
         );
       newMandataris.tijdelijkeVervangingen = [replacementMandataris];
+    } else if (this.newStatus.id === VERHINDERD_STATE_ID) {
+      newMandataris.tijdelijkeVervangingen =
+        (await this.args.mandataris.tijdelijkeVervangingen) || [];
     }
 
     this.args.mandataris.einde = this.date;


### PR DESCRIPTION
When changing the state of a mandataris that is verhinderd, you should not update their replacements. That should not trigger creating a new mandataris versioned entity, so let's just not make it editable when they already are verhinderd and simply keep the previously selected mandatarisses.

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/1076194/d7294ed7-0cf5-4fbb-8a81-fc8b323a65f0)
