### PR TITLE
LMB-294: Forbid mandatees from changing fraction

### DIFF
--- a/app/components/mandatarissen/fractie-selector.js
+++ b/app/components/mandatarissen/fractie-selector.js
@@ -39,7 +39,7 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
       fracties = [...fracties, onafhankelijke];
     }
 
-    if (this.isChangingFraction && this.mandataris) {
+    if (this.isChangingFraction && this.mandataris && this._fractie) {
       if (await this.isFractionIndependent(this._fractie)) {
         const mandataries = await this.store.query('mandataris', {
           include: 'heeft-lidmaatschap,heeft-lidmaatschap.binnen-fractie',
@@ -54,7 +54,14 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
         const fractionsForMandataries = [];
         for (const mandate of mandataries) {
           const lidmaatschap = await mandate.heeftLidmaatschap;
+          if (!lidmaatschap) {
+            continue;
+          }
           const fraction = await lidmaatschap.binnenFractie;
+          if (!fraction) {
+            continue;
+          }
+
           if (
             !fractionsForMandataries.find(
               (fractionModel) => fractionModel.id == fraction.id

--- a/app/components/mandatarissen/fractie-selector.js
+++ b/app/components/mandatarissen/fractie-selector.js
@@ -39,8 +39,8 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
       fracties = [...fracties, onafhankelijke];
     }
 
-    if (this.isChangingFraction && this.mandataris && this._fractie) {
-      if (await this.isFractionIndependent(this._fractie)) {
+    if (this.isUpdatingFractie && this.mandataris && this._fractie) {
+      if (await this.isFractieIndependent(this._fractie)) {
         const mandataries = await this.store.query('mandataris', {
           include: 'heeft-lidmaatschap,heeft-lidmaatschap.binnen-fractie',
           filter: {
@@ -51,36 +51,36 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
           },
         });
 
-        const fractionsForMandataries = [];
+        const fractiesForMandataries = [];
         for (const mandate of mandataries) {
           const lidmaatschap = await mandate.heeftLidmaatschap;
           if (!lidmaatschap) {
             continue;
           }
-          const fraction = await lidmaatschap.binnenFractie;
-          if (!fraction) {
+          const fractie = await lidmaatschap.binnenFractie;
+          if (!fractie) {
             continue;
           }
 
           if (
-            !fractionsForMandataries.find(
-              (fractionModel) => fractionModel.id == fraction.id
+            !fractiesForMandataries.find(
+              (fractieModel) => fractieModel.id == fractie.id
             )
           ) {
-            fractionsForMandataries.push(fraction);
+            fractiesForMandataries.push(fractie);
           }
         }
-        this.fractieOptions = fractionsForMandataries;
+        this.fractieOptions = fractiesForMandataries;
       } else {
-        const independentFraction = await this.getIndependentFraction(fracties);
-        if (independentFraction) {
-          this.fractieOptions = [this._fractie, independentFraction];
+        const independentFractie = await this.getIndependentFractie(fracties);
+        if (independentFractie) {
+          this.fractieOptions = [this._fractie, independentFractie];
         } else {
-          console.warning(`Creating a new independent fraction`);
-          // should we create a new independent fraction here?
-          const newIndependentFraction =
+          console.warning(`Creating a new independent fractie`);
+          // should we create a new independent fractie here?
+          const newIndependentFractie =
             await this.createOnafhankelijkeFractie();
-          this.fractieOptions = [newIndependentFraction];
+          this.fractieOptions = [newIndependentFractie];
         }
       }
     } else {
@@ -141,17 +141,17 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
     return searchResults;
   });
 
-  async isFractionIndependent(fraction) {
-    return await fraction.get('fractietype.isOnafhankelijk');
+  async isFractieIndependent(fractie) {
+    return await fractie.get('fractietype.isOnafhankelijk');
   }
 
-  // This is always one yes?
-  async getIndependentFraction(fractions) {
-    for (const fraction of fractions) {
-      const isIndependent = await this.isFractionIndependent(fraction);
+  // REMOVE: This is always one yes?
+  async getIndependentFractie(fracties) {
+    for (const fractie of fracties) {
+      const isIndependent = await this.isFractieIndependent(fractie);
 
       if (isIndependent) {
-        return fraction;
+        return fractie;
       }
     }
     return null;
@@ -161,10 +161,10 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
     return this.args.mandataris;
   }
 
-  get isChangingFraction() {
-    const state = this.args.isChangingFraction;
+  get isUpdatingFractie() {
+    const state = this.args.isUpdatingFractie;
     if (state && typeof state == 'boolean') {
-      return this.args.isChangingFraction;
+      return this.args.isUpdatingFractie;
     }
 
     return false;

--- a/app/components/mandatarissen/fractie-selector.js
+++ b/app/components/mandatarissen/fractie-selector.js
@@ -49,7 +49,7 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
   }
 
   async getFractiesWhenUpdateState() {
-    const mandataries = await this.store.query('mandataris', {
+    const mandatarissen = await this.store.query('mandataris', {
       include: 'heeft-lidmaatschap,heeft-lidmaatschap.binnen-fractie',
       filter: {
         bekleedt: { id: this.mandataris.bekleedt.id },
@@ -58,14 +58,14 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
         },
       },
     });
-    const fracties = await this.fractionsOfMandataries(mandataries);
+    const fracties = await this.fractiesVanMandatarissen(mandatarissen);
 
     return fracties;
   }
 
-  async fractionsOfMandataries(mandataries) {
-    const fractiesForMandataries = [];
-    for (const mandate of mandataries) {
+  async fractiesVanMandatarissen(mandatarissen) {
+    const fracties = [];
+    for (const mandate of mandatarissen) {
       const lidmaatschap = await mandate.heeftLidmaatschap;
       if (!lidmaatschap) {
         continue;
@@ -75,16 +75,12 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
         continue;
       }
 
-      if (
-        !fractiesForMandataries.find(
-          (fractieModel) => fractieModel.id == fractie.id
-        )
-      ) {
-        fractiesForMandataries.push(fractie);
+      if (!fracties.find((fractieModel) => fractieModel.id == fractie.id)) {
+        fracties.push(fractie);
       }
     }
 
-    return fractiesForMandataries;
+    return fracties;
   }
 
   async fetchFracties(searchData) {

--- a/app/components/mandatarissen/fractie-selector.js
+++ b/app/components/mandatarissen/fractie-selector.js
@@ -37,7 +37,9 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
       fracties = await this.fetchFracties();
     }
 
-    let onafhankelijke = await this.getIndependentFractie(fracties);
+    let onafhankelijke = fracties.find((f) =>
+      f.get('fractietype.isOnafhankelijk')
+    );
 
     if (!onafhankelijke) {
       onafhankelijke = await this.createOnafhankelijkeFractie();
@@ -144,17 +146,6 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
     }
 
     return type.isOnafhankelijk;
-  }
-
-  async getIndependentFractie(fracties) {
-    for (const fractie of fracties) {
-      const isIndependent = await this.isFractieIndependent(fractie);
-
-      if (isIndependent) {
-        return fractie;
-      }
-    }
-    return null;
   }
 
   get mandataris() {

--- a/app/components/mandatarissen/fractie-selector.js
+++ b/app/components/mandatarissen/fractie-selector.js
@@ -54,9 +54,9 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
     const mandatarissen = await this.store.query('mandataris', {
       include: 'heeft-lidmaatschap,heeft-lidmaatschap.binnen-fractie',
       filter: {
-        bekleedt: { id: this.mandataris.bekleedt.id },
+        bekleedt: { id: this.args.mandataris.bekleedt.id },
         'is-bestuurlijke-alias-van': {
-          id: this.mandataris.isBestuurlijkeAliasVan.id,
+          id: this.args.mandataris.isBestuurlijkeAliasVan.id,
         },
       },
     });
@@ -146,10 +146,6 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
     }
 
     return type.isOnafhankelijk;
-  }
-
-  get mandataris() {
-    return this.args.mandataris;
   }
 
   get isUpdatingFractie() {

--- a/app/components/mandatarissen/fractie-selector.js
+++ b/app/components/mandatarissen/fractie-selector.js
@@ -31,7 +31,7 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
   async loadFracties() {
     let fracties = [];
 
-    if (this.isUpdatingFractie && this._fractie) {
+    if (this.args.isUpdatingFractie && this._fractie) {
       fracties = await this.getFractiesWhenUpdateState();
     } else {
       fracties = await this.fetchFracties();
@@ -146,14 +146,5 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
     }
 
     return type.isOnafhankelijk;
-  }
-
-  get isUpdatingFractie() {
-    const state = this.args.isUpdatingFractie;
-    if (state && typeof state == 'boolean') {
-      return this.args.isUpdatingFractie;
-    }
-
-    return false;
   }
 }

--- a/app/components/mandatarissen/fractie-selector.js
+++ b/app/components/mandatarissen/fractie-selector.js
@@ -38,7 +38,25 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
       onafhankelijke = await this.createOnafhankelijkeFractie();
       fracties = [...fracties, onafhankelijke];
     }
-    this.fractieOptions = fracties;
+
+    if (this.isChangingFraction) {
+      if (await this.isFractionIndependent(this._fractie)) {
+        const previousFraction = null;
+        console.log(`set previous fraction`, previousFraction);
+      } else {
+        const independentFraction = await this.getIndependentFraction(fracties);
+        if (independentFraction) {
+          this.fractieOptions = [this._fractie, independentFraction];
+        } else {
+          console.warning(`Creating a new independent fraction`);
+          const newIndependentFraction =
+            await this.createOnafhankelijkeFractie();
+          this.fractieOptions = [newIndependentFraction];
+        }
+      }
+    } else {
+      this.fractieOptions = fracties;
+    }
   }
 
   async fetchFracties(searchData) {
@@ -93,4 +111,29 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
     let searchResults = await this.fetchFracties(searchData);
     return searchResults;
   });
+
+  async isFractionIndependent(fraction) {
+    return await fraction.get('fractietype.isOnafhankelijk');
+  }
+
+  // This is always one yes?
+  async getIndependentFraction(fractions) {
+    for (const fraction of fractions) {
+      const isIndependent = await this.isFractionIndependent(fraction);
+
+      if (isIndependent) {
+        return fraction;
+      }
+    }
+    return null;
+  }
+
+  get isChangingFraction() {
+    const state = this.args.isChangingFraction;
+    if (state && typeof state == 'boolean') {
+      return this.args.isChangingFraction;
+    }
+
+    return false;
+  }
 }

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -94,6 +94,7 @@
           @allowClear={{true}}
           @bestuurseenheid={{this.bestuurseenheid}}
           @bestuursorganen={{this.bestuursorganenForFractie}}
+          @isChangingFraction={{true}}
         />
       {{/if}}
     </div>

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -94,6 +94,7 @@
           @allowClear={{true}}
           @bestuurseenheid={{this.bestuurseenheid}}
           @bestuursorganen={{this.bestuursorganenForFractie}}
+          @mandataris={{@mandataris}}
           @isChangingFraction={{true}}
         />
       {{/if}}

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -95,7 +95,7 @@
           @bestuurseenheid={{this.bestuurseenheid}}
           @bestuursorganen={{this.bestuursorganenForFractie}}
           @mandataris={{@mandataris}}
-          @isChangingFraction={{true}}
+          @isUpdatingFractie={{true}}
         />
       {{/if}}
     </div>


### PR DESCRIPTION
## Description 
When a fraction is added to a mandataris the user can only change the fraction to one it had before or to independent. This limitation can only be in the update mandataris and NOT in the correct mandataris.


## Test

1. Go to a mandataris or create a new one without a fraction
2. Select a fraction (all options should be in the list)
3. Update it again. The fraction list should contain the previous option and independent