### PR TITLE
LMB-236: Navigate to persoon from mandataris

### DIFF
--- a/app/controllers/mandatarissen/mandataris.js
+++ b/app/controllers/mandatarissen/mandataris.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MandatarissenMandatarisController extends Controller {
   @service router;
@@ -18,5 +18,10 @@ export default class MandatarissenMandatarisController extends Controller {
 
   get persoon() {
     return this.model.mandataris.isBestuurlijkeAliasVan;
+  }
+
+  @action
+  routeToPersoon() {
+    this.router.transitionTo('mandatarissen.persoon', this.persoon.id);
   }
 }

--- a/app/controllers/mandatarissen/mandataris.js
+++ b/app/controllers/mandatarissen/mandataris.js
@@ -15,4 +15,8 @@ export default class MandatarissenMandatarisController extends Controller {
   onMandatarisChanged(newMandataris) {
     this.router.transitionTo('mandatarissen.mandataris', newMandataris.id);
   }
+
+  get persoon() {
+    return this.model.mandataris.isBestuurlijkeAliasVan;
+  }
 }

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -192,3 +192,9 @@
 .ember-power-select-dropdown.ember-basic-dropdown-content--in-place {
   z-index: 10;
 }
+
+.mimmick-au-link-button-style {
+  color: var(--au-blue-700);
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/app/templates/mandatarissen/mandataris.hbs
+++ b/app/templates/mandatarissen/mandataris.hbs
@@ -1,7 +1,7 @@
 <AuToolbar @border="bottom" @size="large" as |Group|>
   <Group>
     <AuHeading @skin="2">Mandaat
-      <AuLink @route="mandatarissen.persoon" @model={{this.persoon}}>
+      <AuLink {{on "click" this.routeToPersoon}}>
         {{this.persoon.gebruikteVoornaam}}
         {{this.persoon.achternaam}}
       </AuLink>

--- a/app/templates/mandatarissen/mandataris.hbs
+++ b/app/templates/mandatarissen/mandataris.hbs
@@ -1,8 +1,10 @@
 <AuToolbar @border="bottom" @size="large" as |Group|>
   <Group>
     <AuHeading @skin="2">Mandaat
-      {{@model.mandataris.isBestuurlijkeAliasVan.gebruikteVoornaam}}
-      {{@model.mandataris.isBestuurlijkeAliasVan.achternaam}}
+      <AuLink @route="mandatarissen.persoon" @model={{this.persoon}}>
+        {{this.persoon.gebruikteVoornaam}}
+        {{this.persoon.achternaam}}
+      </AuLink>
       <br />
       {{this.bestuursorganenTitle}}
     </AuHeading>

--- a/app/templates/mandatarissen/mandataris.hbs
+++ b/app/templates/mandatarissen/mandataris.hbs
@@ -1,10 +1,14 @@
 <AuToolbar @border="bottom" @size="large" as |Group|>
   <Group>
     <AuHeading @skin="2">Mandaat
-      <AuLink {{on "click" this.routeToPersoon}}>
+      {{! template-lint-disable no-invalid-interactive }}
+      <span
+        {{on "click" this.routeToPersoon}}
+        class="mimmick-au-link-button-style"
+      >
         {{this.persoon.gebruikteVoornaam}}
         {{this.persoon.achternaam}}
-      </AuLink>
+      </span>
       <br />
       {{this.bestuursorganenTitle}}
     </AuHeading>


### PR DESCRIPTION
LMB-236

## Description

The user was not able to go back to the mandates of the person itself. Now they can click the name at the top of the detailed mandataris to go back to the persons mandatarissen overview.

## Test
1. Go to a persons mandatarissen
2. Open the detail of a mandaat of the person
3. Now you will see that the name of the person is a link and that you can go back to the persons overview by clicking it

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/36266973/86f384cf-a0e3-429a-8931-58c5d65ff3d8)
