### PR TITLE
LMB-236: use the AuLink instead of the router and the action method

### DIFF
--- a/app/controllers/mandatarissen/mandataris.js
+++ b/app/controllers/mandatarissen/mandataris.js
@@ -19,9 +19,4 @@ export default class MandatarissenMandatarisController extends Controller {
   get persoon() {
     return this.model.mandataris.isBestuurlijkeAliasVan;
   }
-
-  @action
-  routeToPersoon() {
-    this.router.transitionTo('mandatarissen.persoon', this.persoon.id);
-  }
 }

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -192,9 +192,3 @@
 .ember-power-select-dropdown.ember-basic-dropdown-content--in-place {
   z-index: 10;
 }
-
-.mimmick-au-link-button-style {
-  color: var(--au-blue-700);
-  text-decoration: underline;
-  cursor: pointer;
-}

--- a/app/templates/mandatarissen/mandataris.hbs
+++ b/app/templates/mandatarissen/mandataris.hbs
@@ -1,14 +1,11 @@
 <AuToolbar @border="bottom" @size="large" as |Group|>
   <Group>
     <AuHeading @skin="2">Mandaat
-      {{! template-lint-disable no-invalid-interactive }}
-      <span
-        {{on "click" this.routeToPersoon}}
-        class="mimmick-au-link-button-style"
-      >
-        {{this.persoon.gebruikteVoornaam}}
-        {{this.persoon.achternaam}}
-      </span>
+      <AuLink
+        @route="mandatarissen.persoon"
+        @model={{this.persoon.id}}
+      >{{this.persoon.gebruikteVoornaam}}
+        {{this.persoon.achternaam}}</AuLink>
       <br />
       {{this.bestuursorganenTitle}}
     </AuHeading>


### PR DESCRIPTION
Previous implementation was this https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/170

Using AuLink for this now 
```hbs
      <AuLink
        @route="mandatarissen.persoon"
        @model={{this.persoon.id}}
      >{{this.persoon.gebruikteVoornaam}}
        {{this.persoon.achternaam}}</AuLink>
```