### PR TITLE
Ben/lmb 352 extend form instance tables

### DIFF
--- a/app/components/form/instance-table.hbs
+++ b/app/components/form/instance-table.hbs
@@ -5,6 +5,16 @@
         {{this.formInfo.formDefinition.id}}
         Form Instances</AuHeading>
     </Group>
+    <Group class="au-u-1-3@medium">
+      <AuInput
+        value={{@filter}}
+        @icon="search"
+        @iconAlignment="left"
+        @width="block"
+        placeholder="Zoek {{this.formInfo.formDefinition.id}}"
+        {{on "input" (perform @search value="target.value")}}
+      />
+    </Group>
     <Group>
       <AuButton {{on "click" @onCreate}}>Voeg form instance toe</AuButton>
     </Group>

--- a/app/components/form/instance-table.hbs
+++ b/app/components/form/instance-table.hbs
@@ -12,6 +12,7 @@
 
   <AuDataTable
     @content={{this.formInfo.instances}}
+    @sort={{@sort}}
     @page={{@page}}
     @size={{@size}}
     @isLoading={{not this.initialized}}
@@ -21,7 +22,11 @@
     <t.content as |c|>
       <c.header>
         {{#each this.formInfo.headers as |header|}}
-          <th>{{header}}</th>
+          <AuDataTableThSortable
+            @field={{header}}
+            @currentSorting={{@sort}}
+            @label={{header}}
+          />
         {{/each}}
         <th>{{! Bewerk }}</th>
         <th>{{! Delete }}</th>

--- a/app/components/form/instance-table.js
+++ b/app/components/form/instance-table.js
@@ -46,7 +46,7 @@ export default class InstanceTableComponent extends Component {
     const form = this.args.formDefinition;
     const id = form.id;
     const response = await fetch(
-      `/form-content/${id}/instances?page[size]=${this.args.size}&page[number]=${this.args.page}&sort=${this.args.sort}`
+      `/form-content/${id}/instances?page[size]=${this.args.size}&page[number]=${this.args.page}&sort=${this.args.sort}&filter=${this.args.filter}`
     );
     if (!response.ok) {
       let error = new Error(response.statusText);

--- a/app/components/form/instance-table.js
+++ b/app/components/form/instance-table.js
@@ -46,7 +46,7 @@ export default class InstanceTableComponent extends Component {
     const form = this.args.formDefinition;
     const id = form.id;
     const response = await fetch(
-      `/form-content/${id}/instances?page[size]=${this.args.size}&page[number]=${this.args.page}`
+      `/form-content/${id}/instances?page[size]=${this.args.size}&page[number]=${this.args.page}&sort=${this.args.sort}`
     );
     if (!response.ok) {
       let error = new Error(response.statusText);

--- a/app/controllers/formbeheer/form/instances.js
+++ b/app/controllers/formbeheer/form/instances.js
@@ -4,10 +4,11 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class FormInstancesController extends Controller {
-  queryParams = ['page', 'size'];
+  queryParams = ['page', 'size', 'sort'];
 
   @service router;
   @tracked page = 0;
+  @tracked sort = 'uri';
   size = 10;
 
   @action

--- a/app/controllers/formbeheer/form/instances.js
+++ b/app/controllers/formbeheer/form/instances.js
@@ -4,11 +4,12 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class FormInstancesController extends Controller {
-  queryParams = ['page', 'size', 'sort'];
+  queryParams = ['page', 'size', 'sort', 'filter'];
 
   @service router;
   @tracked page = 0;
   @tracked sort = 'uri';
+  @tracked filter = '';
   size = 10;
 
   @action

--- a/app/controllers/formbeheer/form/instances.js
+++ b/app/controllers/formbeheer/form/instances.js
@@ -2,6 +2,8 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { task, timeout } from 'ember-concurrency';
+import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
 
 export default class FormInstancesController extends Controller {
   queryParams = ['page', 'size', 'sort', 'filter'];
@@ -24,4 +26,10 @@ export default class FormInstancesController extends Controller {
   async onRemoveInstance() {
     this.router.refresh();
   }
+
+  search = task({ restartable: true }, async (searchData) => {
+    await timeout(SEARCH_TIMEOUT);
+    this.page = 0;
+    this.filter = searchData;
+  });
 }

--- a/app/routes/formbeheer/form/instances.js
+++ b/app/routes/formbeheer/form/instances.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 
 export default class FormInstancesRoute extends Route {
   queryParams = {
+    filter: { refreshModel: true },
     page: { refreshModel: false },
     size: { refreshModel: false },
     sort: { refreshModel: true },

--- a/app/routes/formbeheer/form/instances.js
+++ b/app/routes/formbeheer/form/instances.js
@@ -4,6 +4,7 @@ export default class FormInstancesRoute extends Route {
   queryParams = {
     page: { refreshModel: false },
     size: { refreshModel: false },
+    sort: { refreshModel: true },
   };
 
   async model() {

--- a/app/templates/formbeheer/form/instances.hbs
+++ b/app/templates/formbeheer/form/instances.hbs
@@ -6,6 +6,7 @@
     @page={{this.page}}
     @size={{this.size}}
     @filter={{this.filter}}
+    @search={{this.search}}
     @formDefinition={{this.model.formDefinition}}
     @onRemoveInstance={{this.onRemoveInstance}}
     @editRoute="formbeheer.form.instance"

--- a/app/templates/formbeheer/form/instances.hbs
+++ b/app/templates/formbeheer/form/instances.hbs
@@ -2,6 +2,7 @@
 <div class="au-c-body-container au-c-body-container--scroll">
   <Form::InstanceTable
     @onCreate={{this.onCreate}}
+    @sort={{this.sort}}
     @page={{this.page}}
     @size={{this.size}}
     @formDefinition={{this.model.formDefinition}}

--- a/app/templates/formbeheer/form/instances.hbs
+++ b/app/templates/formbeheer/form/instances.hbs
@@ -5,6 +5,7 @@
     @sort={{this.sort}}
     @page={{this.page}}
     @size={{this.size}}
+    @filter={{this.filter}}
     @formDefinition={{this.model.formDefinition}}
     @onRemoveInstance={{this.onRemoveInstance}}
     @editRoute="formbeheer.form.instance"


### PR DESCRIPTION
## Description

Add sorting and search to instance table.

![Screenshot 2024-04-19 at 07 45 37](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/43848896/a9e79ad7-92f2-454d-b6a9-d56e036b5abe)

## Testing

Be sure to check out the corresponding form-content branch: https://github.com/lblod/form-content-service/pull/45
Play around with it a bit in a form page, the person instances are useful, since these have good and multiple labels.