### PR TITLE
Change mandataris publication status to draft "Wijzig huidige situatie" is used

### DIFF
--- a/app/components/mandatarissen/mandataris-edit-prompt.js
+++ b/app/components/mandatarissen/mandataris-edit-prompt.js
@@ -61,7 +61,7 @@ export default class MandatenbeheerMandatarisEditPromptComponent extends Compone
   }
 
   @action
-  async onUpdateState(newMandataris) {
+  onUpdateState(newMandataris) {
     this.editMode = null;
     if (
       newMandataris != this.args.mandataris &&

--- a/app/components/mandatarissen/mandataris/publication-status-selector.hbs
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.hbs
@@ -1,17 +1,19 @@
-<PowerSelect
-  @selected={{this.publicationStatus}}
-  @options={{this.publicationStatusOptions}}
-  class="is-optional"
-  @onChange={{this.onUpdatePublicationStatus}}
-  @searchEnabled={{false}}
-  @disabled={{this.disabled}}
-  @noMatchesMessage="Geen statussen"
-  @placeholder="Bekrachtigd"
-  as |status|
->
-  {{#if status.label}}
-    {{status.label}}
-  {{else}}
-    Geen statussen
-  {{/if}}
-</PowerSelect>
+<div {{did-update this.checkPublicationStatus @mandataris.publicationStatus}}>
+  <PowerSelect
+    @selected={{this.publicationStatus}}
+    @options={{this.publicationStatusOptions}}
+    class="is-optional"
+    @onChange={{this.onUpdatePublicationStatus}}
+    @searchEnabled={{false}}
+    @disabled={{this.disabled}}
+    @noMatchesMessage="Geen statussen"
+    @placeholder="Bekrachtigd"
+    as |status|
+  >
+    {{#if status.label}}
+      {{status.label}}
+    {{else}}
+      Geen statussen
+    {{/if}}
+  </PowerSelect>
+</div>

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -21,9 +21,10 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
   }
 
   async loadPublicationStatusOptions() {
-    const publicationStatus = await this.mandataris.publicationStatus;
-    if (this.isBekrachtigd(publicationStatus)) {
-      this.disabled = true;
+    await this.checkPublicationStatus();
+
+    // If the publication status is bekrachtigd, we don't need to load the options
+    if (this.disabled) {
       return;
     }
 
@@ -31,7 +32,6 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
       'mandataris-publication-status-code'
     );
 
-    this.disabled = false;
     this.publicationStatusOptions = publicationStatuses;
   }
 
@@ -39,6 +39,12 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
     super(...arguments);
 
     this.loadPublicationStatusOptions();
+  }
+
+  @action
+  async checkPublicationStatus() {
+    const publicationStatus = await this.mandataris.publicationStatus;
+    this.disabled = this.isBekrachtigd(publicationStatus);
   }
 
   @action

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -6,6 +6,7 @@ import { inject as service } from '@ember/service';
 import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
 import { VERHINDERD_STATE_ID } from 'frontend-lmb/utils/well-known-ids';
 import moment from 'moment';
+import { getDraftStatus } from 'frontend-lmb/utils/get-publication-status';
 
 export default class MandatarissenUpdateState extends Component {
   @tracked newStatus = null;
@@ -169,7 +170,7 @@ export default class MandatarissenUpdateState extends Component {
       isBestuurlijkeAliasVan: this.args.mandataris.isBestuurlijkeAliasVan,
       beleidsdomein: this.selectedBeleidsdomeinen,
       status: this.newStatus,
-      publicationStatus: this.args.mandataris.publicationStatus,
+      publicationStatus: await getDraftStatus(this.store),
       modified: new Date(),
     };
 


### PR DESCRIPTION
## Description

When the "Wijzig huidige situatie" modal is used for a mandataris, their publication status should be set to draft, no matter what their previous publication status was. This PR is linked to the [publication status story](https://binnenland.atlassian.net/browse/LMB-246?atlOrigin=eyJpIjoiZWZlNzkzODgzNjIxNDhjYmEyNjMyMzBlYTI4NWNlODkiLCJwIjoiaiJ9) 

## How to test

Start out with an active mandate that is "Effectief" or "Bekrachtigd".
![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/55446974/52aa6752-67c4-4379-afbb-ddbcd2852dad)
Click on "Wijzig huidige situatie" and change the mandate.
Once the change is submitted, the new mandate should have a draft publication status.
![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/55446974/1ebfffb0-0fa6-4bd4-8c92-51902a31ae98)

## Links to other PR's

Add publication status to mandataris:
- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/116
- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/175
