### PR TITLE
Sort mandataris publication status selector options

### DIFF
--- a/app/components/mandatarissen/mandataris/publication-status-selector.hbs
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.hbs
@@ -5,7 +5,7 @@
     class="is-optional"
     @onChange={{this.onUpdate}}
     @searchEnabled={{false}}
-    @disabled={{this.disabled}}
+    @disabled={{this.isDisabled}}
     @noMatchesMessage="Geen statussen"
     @placeholder="Bekrachtigd"
     as |status|

--- a/app/components/mandatarissen/mandataris/publication-status-selector.hbs
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.hbs
@@ -1,8 +1,8 @@
 <PowerSelect
   @selected={{this.publicationStatus}}
-  @options={{this.publicationStatusOptions}}
+  @options={{this.sortedOptions}}
   class="is-optional"
-  @onChange={{this.onUpdatePublicationStatus}}
+  @onChange={{this.onUpdate}}
   @searchEnabled={{false}}
   @disabled={{this.disabled}}
   @noMatchesMessage="Geen statussen"

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -5,7 +5,7 @@ import { service } from '@ember/service';
 
 export default class MandatarissenMandatarisPublicationStatusSelectorComponent extends Component {
   @tracked options = [];
-  @tracked disabled = false;
+  @tracked isDisabled = false;
   @service store;
 
   get mandataris() {
@@ -28,7 +28,7 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
     await this.checkPublicationStatus();
 
     // If the publication status is bekrachtigd, we don't need to load the options
-    if (this.disabled) {
+    if (this.isDisabled) {
       return;
     }
 
@@ -36,7 +36,7 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
       'mandataris-publication-status-code'
     );
 
-    this.disabled = false;
+    this.isDisabled = false;
     this.options = statuses;
   }
 
@@ -49,13 +49,13 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
   @action
   async checkPublicationStatus() {
     const publicationStatus = await this.mandataris.publicationStatus;
-    this.disabled = this.isBekrachtigd(publicationStatus);
+    this.isDisabled = this.isBekrachtigd(publicationStatus);
   }
 
   @action
   async onUpdate(publicationStatus) {
     if (publicationStatus.isBekrachtigd) {
-      this.disabled = true;
+      this.isDisabled = true;
     }
     this.mandataris.publicationStatus = publicationStatus;
     await this.mandataris.save();

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
 export default class MandatarissenMandatarisPublicationStatusSelectorComponent extends Component {
-  @tracked publicationStatusOptions = [];
+  @tracked options = [];
   @tracked disabled = false;
   @service store;
 
@@ -14,6 +14,10 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
 
   get publicationStatus() {
     return this.mandataris.publicationStatus;
+  }
+
+  get sortedOptions() {
+    return [...this.options].sort((a, b) => a.order - b.order);
   }
 
   isBekrachtigd(publicationStatus) {
@@ -27,12 +31,12 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
       return;
     }
 
-    const publicationStatuses = await this.store.findAll(
+    const statuses = await this.store.findAll(
       'mandataris-publication-status-code'
     );
 
     this.disabled = false;
-    this.publicationStatusOptions = publicationStatuses;
+    this.options = statuses;
   }
 
   constructor() {
@@ -42,7 +46,7 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
   }
 
   @action
-  async onUpdatePublicationStatus(publicationStatus) {
+  async onUpdate(publicationStatus) {
     if (publicationStatus.isBekrachtigd) {
       this.disabled = true;
     }

--- a/app/models/mandataris-publication-status-code.js
+++ b/app/models/mandataris-publication-status-code.js
@@ -4,6 +4,7 @@ import { MANDATARIS_BEKRACHTIGD_STATE } from 'frontend-lmb/utils/well-known-uris
 export default class MandatarisPublicationStatusCodeModel extends Model {
   @attr uri;
   @attr label;
+  @attr('number') order;
 
   get isBekrachtigd() {
     return this.uri === MANDATARIS_BEKRACHTIGD_STATE;
@@ -12,5 +13,6 @@ export default class MandatarisPublicationStatusCodeModel extends Model {
   rdfaBindings = {
     class: 'http://www.w3.org/2004/02/skos/core#Concept',
     label: 'http://www.w3.org/2004/02/skos/core#prefLabel',
+    order: 'http://www.w3.org/ns/shacl#order',
   };
 }

--- a/app/models/mandataris-publication-status-code.js
+++ b/app/models/mandataris-publication-status-code.js
@@ -9,10 +9,4 @@ export default class MandatarisPublicationStatusCodeModel extends Model {
   get isBekrachtigd() {
     return this.uri === MANDATARIS_BEKRACHTIGD_STATE;
   }
-
-  rdfaBindings = {
-    class: 'http://www.w3.org/2004/02/skos/core#Concept',
-    label: 'http://www.w3.org/2004/02/skos/core#prefLabel',
-    order: 'http://www.w3.org/ns/shacl#order',
-  };
 }


### PR DESCRIPTION
## Description

We want to be able to show the mandataris publication statuses in a consistent order, regardless of the order in which they were inserted into the database. This can be achieved by adding an extra sh:order triple to the concepts in the publication status migration. These triples will then be used in the frontend for manual sorting.

## How to test

- Go to any mandate that is not in the "Bekrachtigd" state.
- Click open the "Publicatie status" selector and check that the statuses are in this order:
    - Draft
    - Effectief
    - Bekrachtigd

![image](https://github.com/lblod/app-lokaal-mandatenbeheer/assets/55446974/b7d24815-a646-40f2-ae11-8ebc1a633067)

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/118
