### PR TITLE
LMB-415: modied store.save is overwritting the form changes of form-content-service

### DIFF
--- a/app/components/mandatarissen/mandataris-edit-prompt.js
+++ b/app/components/mandatarissen/mandataris-edit-prompt.js
@@ -54,9 +54,6 @@ export default class MandatenbeheerMandatarisEditPromptComponent extends Compone
       sourceGraph: SOURCE_GRAPH,
     });
 
-    this.args.mandataris.modified = new Date();
-    await this.args.mandataris.save();
-
     setTimeout(() => this.router.refresh(), 1000);
   }
 


### PR DESCRIPTION
## Description

When correcting a mandataris the changes are saved but than overwritten by the save of ember. This because the dct:modified was saved in the ember code.

## How to test

Modified should be correct when:
1. create new mandaat
2. wijzig een istuatie
3. Corrigeer situatie
