### PR TITLE
Make sure that the mandataris publication options are always loaded

### DIFF
--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -24,26 +24,18 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
     return !publicationStatus || publicationStatus.isBekrachtigd;
   }
 
-  async loadPublicationStatusOptions() {
+  async loadOptions() {
     await this.checkPublicationStatus();
 
-    // If the publication status is bekrachtigd, we don't need to load the options
-    if (this.isDisabled) {
-      return;
-    }
-
-    const statuses = await this.store.findAll(
+    this.options = await this.store.findAll(
       'mandataris-publication-status-code'
     );
-
-    this.isDisabled = false;
-    this.options = statuses;
   }
 
   constructor() {
     super(...arguments);
 
-    this.loadPublicationStatusOptions();
+    this.loadOptions();
   }
 
   @action


### PR DESCRIPTION
## Description

Due to the mandataris' publication status changing to Draft when their situation is changed, the early isBekrachtigd return broke the selector options. This PR fixes that by always loading the publication options.

## How to test

- Pick or create a mandataris that is Bekrachtigd and use the "Wijzig huidige situatie" modal.
- The mandataris publication status should now be changed to Draft and all publication status options should be available in the selector.

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/183
