### PR TITLE
Ben/lmb 393 edit bevoegdheden in mandataris table

### DIFF
--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -63,22 +63,20 @@
       </c.header>
 
       <c.body as |row|>
-        <td>
-          <Verkiezingen::EditOnHover
-            @text={{row.isBestuurlijkeAliasVan.gebruikteVoornaam}}
-            @editFunction={{this.openModal}}
-            @model={{row}}
-            @helpText="Pas de persoon aan"
-          />
-        </td>
-        <td>
-          <Verkiezingen::EditOnHover
-            @text={{row.isBestuurlijkeAliasVan.achternaam}}
-            @editFunction={{this.openModal}}
-            @model={{row}}
-            @helpText="Pas de persoon aan"
-          />
-        </td>
+        <Verkiezingen::EditOnHover
+          @editFunction={{this.openModal}}
+          @model={{row}}
+          @helpText="Pas de persoon aan"
+        >
+          {{row.isBestuurlijkeAliasVan.gebruikteVoornaam}}
+        </Verkiezingen::EditOnHover>
+        <Verkiezingen::EditOnHover
+          @editFunction={{this.openModal}}
+          @model={{row}}
+          @helpText="Pas de persoon aan"
+        >
+          {{row.isBestuurlijkeAliasVan.gebruikteVoornaam}}
+        </Verkiezingen::EditOnHover>
         {{#if @showFractie}}
           <td>
             {{row.heeftLidmaatschap.binnenFractie.naam}}

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -92,11 +92,10 @@
         {{/if}}
         {{#if @showBevoegdheid}}
           {{#if (eq this.editBeleidsdomeinen row.id)}}
-            <td>
+            <td {{on-click-outside this.closeEditBeleidsdomeinen}}>
               <Mandatarissen::BeleidsdomeinSelectorWithCreate
                 @beleidsdomeinen={{row.beleidsdomein}}
                 @onSelect={{this.updateBeleidsdomeinen}}
-                {{on "focusout" this.closeEditBeleidsdomeinen}}
               />
             </td>
           {{else}}

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -75,7 +75,7 @@
           @model={{row}}
           @helpText="Pas de persoon aan"
         >
-          {{row.isBestuurlijkeAliasVan.gebruikteVoornaam}}
+          {{row.isBestuurlijkeAliasVan.achternaam}}
         </Verkiezingen::EditOnHover>
         {{#if @showFractie}}
           <td>

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -91,16 +91,17 @@
           <td>{{row.rangorde}}</td>
         {{/if}}
         {{#if @showBevoegdheid}}
-          {{#if this.editBeleidsdomeinen}}
+          {{#if (eq this.editBeleidsdomeinen row.id)}}
             <td>
               <Mandatarissen::BeleidsdomeinSelectorWithCreate
-                @beleidsdomeinen={{this.selectedBeleidsdomeinen}}
+                @beleidsdomeinen={{row.beleidsdomein}}
                 @onSelect={{this.updateBeleidsdomeinen}}
               />
             </td>
           {{else}}
             <Verkiezingen::EditOnHover
               @editFunction={{this.openEditBeleidsdomeinen}}
+              @model={{row}}
               @helpText="Pas de beleidsdomeinen aan"
             >
               <Beleidsdomeinen @mandataris={{row}} />

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -91,9 +91,21 @@
           <td>{{row.rangorde}}</td>
         {{/if}}
         {{#if @showBevoegdheid}}
-          <td>
-            <Beleidsdomeinen @mandataris={{row}} />
-          </td>
+          {{#if this.editBeleidsdomeinen}}
+            <td>
+              <Mandatarissen::BeleidsdomeinSelectorWithCreate
+                @beleidsdomeinen={{this.selectedBeleidsdomeinen}}
+                @onSelect={{this.updateBeleidsdomeinen}}
+              />
+            </td>
+          {{else}}
+            <Verkiezingen::EditOnHover
+              @editFunction={{this.openEditBeleidsdomeinen}}
+              @helpText="Pas de beleidsdomeinen aan"
+            >
+              <Beleidsdomeinen @mandataris={{row}} />
+            </Verkiezingen::EditOnHover>
+          {{/if}}
         {{/if}}
         {{#if @showStartEndDate}}
           <td>

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -96,6 +96,7 @@
               <Mandatarissen::BeleidsdomeinSelectorWithCreate
                 @beleidsdomeinen={{row.beleidsdomein}}
                 @onSelect={{this.updateBeleidsdomeinen}}
+                {{on "focusout" this.closeEditBeleidsdomeinen}}
               />
             </td>
           {{else}}

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -16,6 +16,7 @@ export default class DraftMandatarisListComponent extends Component {
   @action
   closeModal() {
     this.isModalOpen = false;
+    this.mandataris = null;
   }
 
   @action
@@ -28,13 +29,13 @@ export default class DraftMandatarisListComponent extends Component {
   @action
   handleKeyDownBeleidsdomeinen(event) {
     if (event.code == 'Escape' || event.code == 'Tab') {
-      removeEventListener('keyup', this.handleKeyDownBeleidsdomeinen);
       this.closeEditBeleidsdomeinen();
     }
   }
 
   @action
   closeEditBeleidsdomeinen() {
+    removeEventListener('keyup', this.handleKeyDownBeleidsdomeinen);
     this.mandataris = null;
     this.editBeleidsdomeinen = null;
   }
@@ -49,6 +50,6 @@ export default class DraftMandatarisListComponent extends Component {
   async updatePerson(person) {
     this.mandataris.isBestuurlijkeAliasVan = person;
     await this.mandataris.save();
-    this.isModalOpen = false;
+    this.closeModal();
   }
 }

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -20,7 +20,14 @@ export default class DraftMandatarisListComponent extends Component {
 
   @action
   openEditBeleidsdomeinen(mandataris) {
+    this.mandataris = mandataris;
     this.editBeleidsdomeinen = mandataris.id;
+  }
+
+  @action
+  async updateBeleidsdomeinen(selectedBeleidsdomeinen) {
+    this.mandataris.beleidsdomein = await selectedBeleidsdomeinen;
+    await this.mandataris.save();
   }
 
   @action

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -22,6 +22,15 @@ export default class DraftMandatarisListComponent extends Component {
   openEditBeleidsdomeinen(mandataris) {
     this.mandataris = mandataris;
     this.editBeleidsdomeinen = mandataris.id;
+    addEventListener('keyup', this.handleKeyDownBeleidsdomeinen);
+  }
+
+  @action
+  handleKeyDownBeleidsdomeinen(event) {
+    if (event.code == 'Escape' || event.code == 'Tab') {
+      removeEventListener('keyup', this.handleKeyDownBeleidsdomeinen);
+      this.closeEditBeleidsdomeinen();
+    }
   }
 
   @action

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -25,8 +25,7 @@ export default class DraftMandatarisListComponent extends Component {
   }
 
   @action
-  closeEditBeleidsdomeinen(event) {
-    console.log(event);
+  closeEditBeleidsdomeinen() {
     this.mandataris = null;
     this.editBeleidsdomeinen = null;
   }

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 export default class DraftMandatarisListComponent extends Component {
   @tracked isModalOpen = false;
   @tracked mandataris;
-  @tracked editBeleidsdomeinen = false;
+  @tracked editBeleidsdomeinen;
 
   @action
   openModal(mandataris) {
@@ -19,8 +19,8 @@ export default class DraftMandatarisListComponent extends Component {
   }
 
   @action
-  openEditBeleidsdomeinen() {
-    this.editBeleidsdomeinen = true;
+  openEditBeleidsdomeinen(mandataris) {
+    this.editBeleidsdomeinen = mandataris.id;
   }
 
   @action

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 export default class DraftMandatarisListComponent extends Component {
   @tracked isModalOpen = false;
   @tracked mandataris;
+  @tracked editBeleidsdomeinen = false;
 
   @action
   openModal(mandataris) {
@@ -15,6 +16,11 @@ export default class DraftMandatarisListComponent extends Component {
   @action
   closeModal() {
     this.isModalOpen = false;
+  }
+
+  @action
+  openEditBeleidsdomeinen() {
+    this.editBeleidsdomeinen = true;
   }
 
   @action

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -25,6 +25,13 @@ export default class DraftMandatarisListComponent extends Component {
   }
 
   @action
+  closeEditBeleidsdomeinen(event) {
+    console.log(event);
+    this.mandataris = null;
+    this.editBeleidsdomeinen = null;
+  }
+
+  @action
   async updateBeleidsdomeinen(selectedBeleidsdomeinen) {
     this.mandataris.beleidsdomein = await selectedBeleidsdomeinen;
     await this.mandataris.save();

--- a/app/components/verkiezingen/edit-on-hover.hbs
+++ b/app/components/verkiezingen/edit-on-hover.hbs
@@ -1,5 +1,5 @@
-<div class="hover-container">
-  {{@text}}
+<td class="hover-container">
+  {{yield}}
   <div class="hover-element">
     <AuIcon
       @icon="pencil"
@@ -12,4 +12,4 @@
       </div>
     </div>
   </div>
-</div>
+</td>

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -198,6 +198,9 @@
   position: absolute;
   padding: 2px 5px 0px 5px;
   margin: 0px 5px;
+  z-index: 5;
+  right: 1.2rem;
+  top: 1.2rem;
 }
 
 .hover-element:hover {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "ember-cli-sri": "^2.1.1",
         "ember-cli-string-helpers": "^6.1.0",
         "ember-cli-terser": "^4.0.2",
+        "ember-click-outside": "^6.1.0",
         "ember-concurrency": "^4.0.2",
         "ember-data": "~4.12.3",
         "ember-fetch": "^8.1.2",
@@ -15434,6 +15435,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ember-click-outside": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-6.1.0.tgz",
+      "integrity": "sha512-TUsGRAPkfiLC2XtXO8i9SNsgo7lEekvOuqTp9Ab88d1FKmTps8jlYBH1F0ZwFPyI2bz+dlE1J8WqGnsleALk9g==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/addon-shim": "^1.0.0",
+        "ember-modifier": "^3.2.7 || ^4.0.0"
       }
     },
     "node_modules/ember-compatibility-helpers": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-string-helpers": "^6.1.0",
     "ember-cli-terser": "^4.0.2",
+    "ember-click-outside": "^6.1.0",
     "ember-concurrency": "^4.0.2",
     "ember-data": "~4.12.3",
     "ember-fetch": "^8.1.2",


### PR DESCRIPTION
## Description

In the mandataris table in the prepare installatievergadering it is now possible to change to beleidsdomeinen by hovering over the beleidsdomeinen and clicking the edit icon.
The edit can be closed by clicking outside or by pressing 'Escape' or 'Tab'.

![Screenshot 2024-04-29 at 10 26 57](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/43848896/1d624da0-ac0c-4a4b-92b8-2b0a683674d3)
![Screenshot 2024-04-29 at 10 27 05](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/43848896/4ed34263-1fb9-4a64-beab-39d08306a9e6)

## How to test

Go to a verkiezingen/verkiezingsuitslag/prepare route, hover over a mandataris and update the beleidsdomeinen.