### PR TITLE
Add Aangewezen Burgemeester Status Code

### DIFF
--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -7,6 +7,7 @@ import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
 import { VERHINDERD_STATE_ID } from 'frontend-lmb/utils/well-known-ids';
 import moment from 'moment';
 import { getDraftStatus } from 'frontend-lmb/utils/get-publication-status';
+import { MANDATARIS_AANGEWEZEN_STATE } from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarissenUpdateState extends Component {
   @tracked newStatus = null;
@@ -19,6 +20,7 @@ export default class MandatarissenUpdateState extends Component {
   @tracked rangorde = null;
   @tracked selectedReplacement = null;
   @tracked replacementUpdated;
+  @tracked statusOptions = [];
 
   @service mandatarisStatus;
   @service currentSession;
@@ -63,10 +65,25 @@ export default class MandatarissenUpdateState extends Component {
           ),
         }
       );
+    this.statusOptions = await this.getStatusOptions();
   });
 
-  get statusOptions() {
-    return this.mandatarisStatus.statuses;
+  async getStatusOptions() {
+    const isBurgemeester = (
+      await (
+        await this.args.mandataris.bekleedt
+      ).bestuursfunctie
+    ).isBurgemeester;
+
+    // Slice to get rid of proxy
+    const statuses = this.mandatarisStatus.statuses.slice();
+
+    if (isBurgemeester) {
+      return statuses;
+    }
+    return statuses.filter(
+      (status) => status.uri !== MANDATARIS_AANGEWEZEN_STATE
+    );
   }
 
   get currentStatus() {

--- a/app/components/rdf-input-fields/mandataris-status-selector.hbs
+++ b/app/components/rdf-input-fields/mandataris-status-selector.hbs
@@ -1,0 +1,40 @@
+{{#unless @inTable}}
+  <AuLabel
+    @error={{this.hasErrors}}
+    @required={{this.isRequired}}
+    @warning={{this.hasWarnings}}
+    for={{this.inputId}}
+  >
+    {{@field.label}}
+  </AuLabel>
+{{/unless}}
+<div class={{if this.hasErrors "ember-power-select--error"}}>
+  <PowerSelect
+    @triggerId={{this.inputId}}
+    @search={{perform this.search}}
+    @searchField="label"
+    @searchEnabled={{this.searchEnabled}}
+    @selected={{this.selected}}
+    @options={{this.options}}
+    @onClose={{fn (mut this.hasBeenFocused) true}}
+    @onChange={{this.updateSelection}}
+    @allowClear={{true}}
+    @loadingMessage="Aan het laden..."
+    @noMatchesMessage="Geen resultaten gevonden"
+    @disabled={{@show}}
+    data-test-field-uri={{@field.uri.value}}
+    as |concept|
+  >
+    <span data-test-field-uri={{concept.subject.value}}>
+      {{concept.label}}
+    </span>
+  </PowerSelect>
+</div>
+
+{{#each this.errors as |error|}}
+  <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
+{{/each}}
+
+{{#each this.warnings as |warning|}}
+  <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
+{{/each}}

--- a/app/components/rdf-input-fields/mandataris-status-selector.js
+++ b/app/components/rdf-input-fields/mandataris-status-selector.js
@@ -1,0 +1,23 @@
+import { queryRecord } from 'frontend-lmb/utils/query-record';
+import ConceptSchemeSelectorComponent from './concept-selector';
+import { MANDATARIS_AANGEWEZEN_STATE } from 'frontend-lmb/utils/well-known-uris';
+
+export default class RdfInputFieldsMandatarisStatusSelectorComponent extends ConceptSchemeSelectorComponent {
+  async fetchOptions(searchData) {
+    const statuses = await super.fetchOptions(searchData);
+    const mandatarisUri = this.storeOptions.sourceNode.value;
+    const mandataris = await queryRecord(this.store, 'mandataris', {
+      'filter[:uri:]': mandatarisUri,
+    });
+    const isBurgemeester = (await (await mandataris.bekleedt).bestuursfunctie)
+      .isBurgemeester;
+
+    if (isBurgemeester) {
+      return statuses;
+    }
+
+    return statuses.filter(
+      (status) => status.subject.value !== MANDATARIS_AANGEWEZEN_STATE
+    );
+  }
+}

--- a/app/models/bestuursfunctie-code.js
+++ b/app/models/bestuursfunctie-code.js
@@ -1,5 +1,8 @@
 import Model, { attr } from '@ember-data/model';
-import { BESTUURSFUNCTIE_CODE_LEIDINGGEVEND_AMBTENAAR } from 'frontend-lmb/utils/well-known-uris';
+import {
+  BESTUURSFUNCTIE_CODE_BURGEMEESTER,
+  BESTUURSFUNCTIE_CODE_LEIDINGGEVEND_AMBTENAAR,
+} from 'frontend-lmb/utils/well-known-uris';
 
 export default class BestuursfunctieCodeModel extends Model {
   @attr uri;
@@ -9,8 +12,7 @@ export default class BestuursfunctieCodeModel extends Model {
     return this.uri === BESTUURSFUNCTIE_CODE_LEIDINGGEVEND_AMBTENAAR;
   }
 
-  rdfaBindings = {
-    class: 'http://www.w3.org/2004/02/skos/core#Concept',
-    label: 'http://www.w3.org/2004/02/skos/core#prefLabel',
-  };
+  get isBurgemeester() {
+    return this.uri === BESTUURSFUNCTIE_CODE_BURGEMEESTER;
+  }
 }

--- a/app/models/mandataris-status-code.js
+++ b/app/models/mandataris-status-code.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class MandatarisStatusCodeModel extends Model {
   @attr label;
+  @attr uri;
 }

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -16,7 +16,8 @@ export default class MandatarisModel extends Model {
   })
   modified;
 
-  @belongsTo('mandaat', { async: true, inverse: 'bekleedDoor' }) bekleedt;
+  @belongsTo('mandaat', { async: true, inverse: 'bekleedDoor' })
+  bekleedt;
 
   @belongsTo('persoon', {
     async: true,

--- a/app/utils/register-form-fields.js
+++ b/app/utils/register-form-fields.js
@@ -12,6 +12,7 @@ import RDFConceptSchemeSelectorComponent from 'frontend-lmb/components/rdf-input
 import RDFConceptSchemeMultiSelectorComponent from 'frontend-lmb/components/rdf-input-fields/concept-scheme-multi-selector';
 import RdfInputFieldsConceptSchemeSelectorWithCreateComponent from 'frontend-lmb/components/rdf-input-fields/concept-scheme-selector-with-create';
 import RdfInputFieldsConceptSchemeMultiSelectorWithCreateComponent from 'frontend-lmb/components/rdf-input-fields/concept-scheme-multi-selector-with-create';
+import RdfInputFieldsMandatarisStatusSelectorComponent from 'frontend-lmb/components/rdf-input-fields/mandataris-status-selector';
 
 export const registerCustomFormFields = () => {
   registerFormFields([
@@ -40,6 +41,11 @@ export const registerCustomFormFields = () => {
       displayType:
         'http://lblod.data.gift/display-types/mandatarisMandaatSelector',
       edit: RDFMandatarisMandaatSelectorComponent,
+    },
+    {
+      displayType:
+        'http://lblod.data.gift/display-types/mandatarisStatusCodeSelector',
+      edit: RdfInputFieldsMandatarisStatusSelectorComponent,
     },
     {
       displayType: 'http://lblod.data.gift/display-types/archivedInput',

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -2,6 +2,8 @@ export const FUNCTIONARIS_STATUS_CODE_AANGESTELD =
   'http://data.vlaanderen.be/id/concept/functionarisStatusCode/45b4b155-d22a-4eaf-be3a-97022c6b7fcd';
 export const BESTUURSFUNCTIE_CODE_LEIDINGGEVEND_AMBTENAAR =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/855489b9-b584-4f34-90b2-39aea808cd9f';
+export const BESTUURSFUNCTIE_CODE_BURGEMEESTER =
+  'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013';
 export const FRACTIETYPE_ONAFHANKELIJK =
   'http://data.vlaanderen.be/id/concept/Fractietype/Onafhankelijk';
 export const FRACTIETYPE_SAMENWERKINGSVERBAND =
@@ -14,5 +16,7 @@ export const MANDATARIS_BEKRACHTIGD_STATE =
   'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6';
 export const MANDATARIS_DRAFT_STATE =
   'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/588ce330-4abb-4448-9776-a17d9305df07';
+export const MANDATARIS_AANGEWEZEN_STATE =
+  'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/e371f89a-9e83-4a8c-a98e-cd09226fa549';
 export const BELEIDSDOMEIN_CODES_CONCEPT_SCHEME =
   'http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode';

--- a/tests/integration/components/rdf-input-fields/mandataris-status-selector-test.js
+++ b/tests/integration/components/rdf-input-fields/mandataris-status-selector-test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | rdf-input-fields/mandataris-status-selector',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.set('myAction', function(val) { ... });
+
+      await render(hbs`<RdfInputFields::MandatarisStatusSelector />`);
+
+      assert.dom(this.element).hasText('');
+
+      // Template block usage:
+      await render(hbs`
+      <RdfInputFields::MandatarisStatusSelector>
+        template block text
+      </RdfInputFields::MandatarisStatusSelector>
+    `);
+
+      assert.dom(this.element).hasText('template block text');
+    });
+  }
+);


### PR DESCRIPTION
## Description

The list of mandataris statusses is extended with a new 'aangewezen' status. Selecting this status should only be possible when selecting the status of a Burgemeester mandataris.

## How to test

- Go to the mandaat "Wijzig huidige situatie" modal. If the mandataris is a Burgemeester, "Aangewezen" should be an option in the status dropdown. Otherwise "Aangewezen" should not be in the dropdown.
- Go to the mandaat "Corrigeer fouten" modal. Here the "Aangewezen" status should also only appear when the mandataris is a Burgemeester.

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/55446974/0800c32a-42b9-4000-8817-6cfe3a876ea0)

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/124
