### PR TITLE
LMB-405: remove link to issue in description

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
 ## Description
 
-Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.
+Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context.
 
 ## How to test
 
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
 
 ## Links to other PR's
 


### PR DESCRIPTION
## Description

Removing link to issue in the description as we don't want to link or private project issues in our Github PR's.
