### PR TITLE
LMB-391: Change rangorde up and down of mandataris in orgaan

### DIFF
--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -90,7 +90,10 @@
         {{#if @showRangorde}}
           {{#if (eq this.editRangorde row.id)}}
             <td {{on-click-outside this.closeEditRangorde}}>
-              <Verkiezingen::RangordeInput @rangorde={{row.rangorde}} />
+              <Verkiezingen::RangordeInput
+                @rangorde={{row.rangorde}}
+                @updatedRangorde={{this.updateRangorde}}
+              />
             </td>
           {{else}}
             <Verkiezingen::EditOnHover

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -85,7 +85,10 @@
         {{/if}}
         {{#if @showRangorde}}
           <td>
-            <Verkiezingen::RangordeInput @mandataris={{row}} />
+            <Verkiezingen::RangordeInput
+              @mandataris={{row}}
+              @mandatarissen={{@mandatarissen}}
+            />
           </td>
         {{/if}}
         {{#if @showBevoegdheid}}

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -84,22 +84,9 @@
           </td>
         {{/if}}
         {{#if @showRangorde}}
-          {{#if (eq this.editRangorde row.id)}}
-            <td {{on-click-outside this.closeEditRangorde}}>
-              <Verkiezingen::RangordeInput
-                @rangorde={{row.rangorde}}
-                @updatedRangorde={{this.updateRangorde}}
-              />
-            </td>
-          {{else}}
-            <Verkiezingen::EditOnHover
-              @editFunction={{this.openEditRangorde}}
-              @model={{row}}
-              @helpText="Pas de rangorde aan"
-            >
-              {{row.rangorde}}
-            </Verkiezingen::EditOnHover>
-          {{/if}}
+          <td>
+            <Verkiezingen::RangordeInput @mandataris={{row}} />
+          </td>
         {{/if}}
         {{#if @showBevoegdheid}}
           {{#if (eq this.editBeleidsdomeinen row.id)}}

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -35,11 +35,7 @@
           />
         {{/if}}
         {{#if @showRangorde}}
-          <AuDataTableThSortable
-            @field="rangorde"
-            @currentSorting={{@sort}}
-            @label="Rangorde"
-          />
+          <th>Rangorde</th>
         {{/if}}
         {{#if @showBevoegdheid}}
           <AuDataTableThSortable

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -92,6 +92,7 @@
             <td {{on-click-outside this.closeEditRangorde}}>
               <AuInput
                 value={{this.editRangordeValue}}
+                placeholder="bv. eerste, 1 of 1ste"
                 {{on "keyup" (perform this.validateRangorde)}}
               />
             </td>

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -90,7 +90,10 @@
         {{#if @showRangorde}}
           {{#if (eq this.editRangorde row.id)}}
             <td {{on-click-outside this.closeEditRangorde}}>
-              <AuInput value={{row.rangorde}} />
+              <AuInput
+                value={{this.editRangordeValue}}
+                {{on "keyup" (perform this.validateRangorde)}}
+              />
             </td>
           {{else}}
             <Verkiezingen::EditOnHover

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -1,7 +1,7 @@
 <div class="au-c-body-container">
   <h1 class="au-u-h2 au-u-margin-bottom-small">{{@title}}</h1>
   <AuDataTable
-    @content={{@mandatarissen}}
+    @content={{this.resortedMandatarissen}}
     @noDataMessage="Geen mandatarissen gevonden"
     @sort={{@sort}}
     @page={{@page}}
@@ -35,7 +35,11 @@
           />
         {{/if}}
         {{#if @showRangorde}}
-          <th>Rangorde</th>
+          <AuDataTableThSortable
+            @field="rangorde"
+            @currentSorting={{@sort}}
+            @label="Rangorde"
+          />
         {{/if}}
         {{#if @showBevoegdheid}}
           <AuDataTableThSortable

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -88,7 +88,19 @@
           </td>
         {{/if}}
         {{#if @showRangorde}}
-          <td>{{row.rangorde}}</td>
+          {{#if (eq this.editRangorde row.id)}}
+            <td {{on-click-outside this.closeEditRangorde}}>
+              <AuInput value={{row.rangorde}} />
+            </td>
+          {{else}}
+            <Verkiezingen::EditOnHover
+              @editFunction={{this.openEditRangorde}}
+              @model={{row}}
+              @helpText="Pas de rangorde aan"
+            >
+              {{row.rangorde}}
+            </Verkiezingen::EditOnHover>
+          {{/if}}
         {{/if}}
         {{#if @showBevoegdheid}}
           {{#if (eq this.editBeleidsdomeinen row.id)}}

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -90,11 +90,7 @@
         {{#if @showRangorde}}
           {{#if (eq this.editRangorde row.id)}}
             <td {{on-click-outside this.closeEditRangorde}}>
-              <AuInput
-                value={{this.editRangordeValue}}
-                placeholder="bv. eerste, 1 of 1ste"
-                {{on "keyup" (perform this.validateRangorde)}}
-              />
+              <Verkiezingen::RangordeInput @rangorde={{row.rangorde}} />
             </td>
           {{else}}
             <Verkiezingen::EditOnHover

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -41,13 +41,35 @@ export default class DraftMandatarisListComponent extends Component {
       return;
     }
 
-    if (this.rangordeAsStringMapping.includes(firstWord.input?.toLowerCase())) {
+    if (
+      Object.keys(this.rangordeAsStringMapping).includes(
+        firstWord.input?.toLowerCase()
+      )
+    ) {
       console.log(`first word is a number`, firstWord.input);
+      console.log(`number is`, this.rangordeAsStringMapping[firstWord.input]);
+    } else {
+      const intValue = parseInt(firstWord);
+      if (!intValue) {
+        // show warning
+        return;
+      }
+      console.log({ intValue });
     }
   });
 
   get rangordeAsStringMapping() {
-    return ['eerste', 'tweede'];
+    return {
+      eerste: 1,
+      tweede: 2,
+      derde: 3,
+      vierde: 4,
+      vijfde: 5,
+      zesde: 6,
+      zevende: 7,
+      achtste: 8,
+      negende: 9,
+    };
   }
 
   findFirstWordOfString(string) {

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -6,6 +6,7 @@ export default class DraftMandatarisListComponent extends Component {
   @tracked isModalOpen = false;
   @tracked mandataris;
   @tracked editBeleidsdomeinen;
+  @tracked editRangorde;
 
   @action
   openModal(mandataris) {
@@ -17,6 +18,18 @@ export default class DraftMandatarisListComponent extends Component {
   closeModal() {
     this.isModalOpen = false;
     this.mandataris = null;
+  }
+
+  @action
+  openEditRangorde(mandataris) {
+    this.mandataris = mandataris;
+    this.editRangorde = mandataris.id;
+  }
+
+  @action
+  closeEditRangorde() {
+    this.mandataris = null;
+    this.editRangorde = null;
   }
 
   @action

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -7,7 +7,6 @@ export default class DraftMandatarisListComponent extends Component {
   @tracked isModalOpen = false;
   @tracked mandataris;
   @tracked editBeleidsdomeinen;
-  @tracked editRangorde;
 
   @action
   openModal(mandataris) {
@@ -19,25 +18,6 @@ export default class DraftMandatarisListComponent extends Component {
   closeModal() {
     this.isModalOpen = false;
     this.mandataris = null;
-  }
-
-  @action
-  openEditRangorde(mandataris) {
-    this.mandataris = mandataris;
-    this.editRangorde = mandataris.id;
-    this.editRangordeValue = mandataris.rangorde;
-  }
-
-  @action
-  updateRangorde(rangorde) {
-    this.mandataris.rangorde = rangorde;
-    this.mandataris.save();
-  }
-
-  @action
-  closeEditRangorde() {
-    this.mandataris = null;
-    this.editRangorde = null;
   }
 
   @action

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -29,6 +29,12 @@ export default class DraftMandatarisListComponent extends Component {
   }
 
   @action
+  updateRangorde(rangorde) {
+    this.mandataris.rangorde = rangorde;
+    this.mandataris.save();
+  }
+
+  @action
   closeEditRangorde() {
     this.mandataris = null;
     this.editRangorde = null;

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -1,12 +1,14 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { restartableTask, timeout } from 'ember-concurrency';
 
 export default class DraftMandatarisListComponent extends Component {
   @tracked isModalOpen = false;
   @tracked mandataris;
   @tracked editBeleidsdomeinen;
   @tracked editRangorde;
+  @tracked editRangordeValue;
 
   @action
   openModal(mandataris) {
@@ -24,7 +26,19 @@ export default class DraftMandatarisListComponent extends Component {
   openEditRangorde(mandataris) {
     this.mandataris = mandataris;
     this.editRangorde = mandataris.id;
+    this.editRangordeValue = mandataris.rangorde;
   }
+
+  validateRangorde = restartableTask(async (event) => {
+    await timeout(200);
+
+    if (!event.target.value) {
+      this.editRangordeValue = null;
+      return;
+    }
+
+    this.editRangordeValue = event.target.value;
+  });
 
   @action
   closeEditRangorde() {

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -8,7 +8,6 @@ export default class DraftMandatarisListComponent extends Component {
   @tracked mandataris;
   @tracked editBeleidsdomeinen;
   @tracked editRangorde;
-  @tracked editRangordeValue;
 
   @action
   openModal(mandataris) {
@@ -32,13 +31,33 @@ export default class DraftMandatarisListComponent extends Component {
   validateRangorde = restartableTask(async (event) => {
     await timeout(200);
 
-    if (!event.target.value) {
-      this.editRangordeValue = null;
+    const inputValue = event.target?.value;
+
+    if (!inputValue) {
+      return;
+    }
+    const firstWord = this.findFirstWordOfString(inputValue);
+    if (!firstWord) {
       return;
     }
 
-    this.editRangordeValue = event.target.value;
+    if (this.rangordeAsStringMapping.includes(firstWord.input?.toLowerCase())) {
+      console.log(`first word is a number`, firstWord.input);
+    }
   });
+
+  get rangordeAsStringMapping() {
+    return ['eerste', 'tweede'];
+  }
+
+  findFirstWordOfString(string) {
+    // eslint-disable-next-line no-useless-escape
+    const regex = new RegExp(/^([\w\-]+)/);
+    if (regex.test(string)) {
+      return string.match(regex);
+    }
+    return null;
+  }
 
   @action
   closeEditRangorde() {

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -2,11 +2,23 @@ import Component from '@glimmer/component';
 
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { orderMandatarissenByRangorde } from 'frontend-lmb/utils/rangorde';
 
 export default class DraftMandatarisListComponent extends Component {
   @tracked isModalOpen = false;
   @tracked mandataris;
   @tracked editBeleidsdomeinen;
+
+  get resortedMandatarissen() {
+    if (!this.args.sort || this.args.sort.indexOf('rangorde') < 0) {
+      return this.args.mandatarissen;
+    }
+    const sorted = orderMandatarissenByRangorde([...this.args.mandatarissen]);
+    if (this.args.sort.startsWith('-')) {
+      return sorted.reverse();
+    }
+    return sorted;
+  }
 
   @action
   openModal(mandataris) {

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
+
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { restartableTask, timeout } from 'ember-concurrency';
 
 export default class DraftMandatarisListComponent extends Component {
   @tracked isModalOpen = false;
@@ -27,19 +27,6 @@ export default class DraftMandatarisListComponent extends Component {
     this.editRangorde = mandataris.id;
     this.editRangordeValue = mandataris.rangorde;
   }
-
-  validateRangorde = restartableTask(async (event) => {
-    await timeout(200);
-
-    let possibleOrder = this.findOrderInString(event.target?.value);
-
-    if (!possibleOrder) {
-      console.warn(`Geen getal gevonden in input veld`);
-      return;
-    }
-
-    console.log({ possibleOrder });
-  });
 
   @action
   closeEditRangorde() {
@@ -79,46 +66,5 @@ export default class DraftMandatarisListComponent extends Component {
     this.mandataris.isBestuurlijkeAliasVan = person;
     await this.mandataris.save();
     this.closeModal();
-  }
-
-  findOrderInString(possibleString) {
-    if (!possibleString) {
-      return null;
-    }
-
-    const firstWord = this.findFirstWordOfString(possibleString);
-    if (!firstWord) {
-      return null;
-    }
-
-    const lowercaseWord = firstWord.input?.toLowerCase();
-    if (Object.keys(this.rangordeAsStringMapping).includes(lowercaseWord)) {
-      return this.rangordeAsStringMapping[lowercaseWord];
-    } else {
-      return parseInt(lowercaseWord);
-    }
-  }
-
-  findFirstWordOfString(string) {
-    // eslint-disable-next-line no-useless-escape
-    const regex = new RegExp(/^([\w\-]+)/);
-    if (regex.test(string)) {
-      return string.match(regex);
-    }
-    return null;
-  }
-
-  get rangordeAsStringMapping() {
-    return {
-      eerste: 1,
-      tweede: 2,
-      derde: 3,
-      vierde: 4,
-      vijfde: 5,
-      zesde: 6,
-      zevende: 7,
-      achtste: 8,
-      negende: 9,
-    };
   }
 }

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -31,55 +31,15 @@ export default class DraftMandatarisListComponent extends Component {
   validateRangorde = restartableTask(async (event) => {
     await timeout(200);
 
-    const inputValue = event.target?.value;
+    let possibleOrder = this.findOrderInString(event.target?.value);
 
-    if (!inputValue) {
-      return;
-    }
-    const firstWord = this.findFirstWordOfString(inputValue);
-    if (!firstWord) {
+    if (!possibleOrder) {
+      console.warn(`Geen getal gevonden in input veld`);
       return;
     }
 
-    if (
-      Object.keys(this.rangordeAsStringMapping).includes(
-        firstWord.input?.toLowerCase()
-      )
-    ) {
-      console.log(`first word is a number`, firstWord.input);
-      console.log(`number is`, this.rangordeAsStringMapping[firstWord.input]);
-    } else {
-      const intValue = parseInt(firstWord);
-      if (!intValue) {
-        // show warning
-        return;
-      }
-      console.log({ intValue });
-    }
+    console.log({ possibleOrder });
   });
-
-  get rangordeAsStringMapping() {
-    return {
-      eerste: 1,
-      tweede: 2,
-      derde: 3,
-      vierde: 4,
-      vijfde: 5,
-      zesde: 6,
-      zevende: 7,
-      achtste: 8,
-      negende: 9,
-    };
-  }
-
-  findFirstWordOfString(string) {
-    // eslint-disable-next-line no-useless-escape
-    const regex = new RegExp(/^([\w\-]+)/);
-    if (regex.test(string)) {
-      return string.match(regex);
-    }
-    return null;
-  }
 
   @action
   closeEditRangorde() {
@@ -119,5 +79,46 @@ export default class DraftMandatarisListComponent extends Component {
     this.mandataris.isBestuurlijkeAliasVan = person;
     await this.mandataris.save();
     this.closeModal();
+  }
+
+  findOrderInString(possibleString) {
+    if (!possibleString) {
+      return null;
+    }
+
+    const firstWord = this.findFirstWordOfString(possibleString);
+    if (!firstWord) {
+      return null;
+    }
+
+    const lowercaseWord = firstWord.input?.toLowerCase();
+    if (Object.keys(this.rangordeAsStringMapping).includes(lowercaseWord)) {
+      return this.rangordeAsStringMapping[lowercaseWord];
+    } else {
+      return parseInt(lowercaseWord);
+    }
+  }
+
+  findFirstWordOfString(string) {
+    // eslint-disable-next-line no-useless-escape
+    const regex = new RegExp(/^([\w\-]+)/);
+    if (regex.test(string)) {
+      return string.match(regex);
+    }
+    return null;
+  }
+
+  get rangordeAsStringMapping() {
+    return {
+      eerste: 1,
+      tweede: 2,
+      derde: 3,
+      vierde: 4,
+      vijfde: 5,
+      zesde: 6,
+      zevende: 7,
+      achtste: 8,
+      negende: 9,
+    };
   }
 }

--- a/app/components/verkiezingen/rangorde-input.hbs
+++ b/app/components/verkiezingen/rangorde-input.hbs
@@ -12,7 +12,8 @@
       value={{this.rangorde}}
       placeholder="bv. Eerste schepen"
       @warning={{this.inputWarningMessage}}
-      {{on "input" this.onUpdateRangorde}}
+      {{on "blur" this.onUpdateRangorde}}
+      {{on "keyup" this.onEnterInRangorde}}
     />
     <AuButton
       hideText={{true}}

--- a/app/components/verkiezingen/rangorde-input.hbs
+++ b/app/components/verkiezingen/rangorde-input.hbs
@@ -17,7 +17,7 @@
     @skin="secondary"
     @icon="plus"
     class="order-input-as-string--plus"
-    @disabled={{this.isplusDisabled}}
+    @disabled={{this.isPlusDisabled}}
   />
 </div>
 <AuHelpText @warning={{this.inputWarningMessage}}>

--- a/app/components/verkiezingen/rangorde-input.hbs
+++ b/app/components/verkiezingen/rangorde-input.hbs
@@ -10,9 +10,9 @@
     />
     <AuInput
       value={{this.rangordeInput}}
-      placeholder="bv. eerste, 1 of 1ste"
+      placeholder="bv. Eerste schepen"
       @warning={{this.inputWarningMessage}}
-      {{on "keyup" (perform this.transformRangorde)}}
+      {{on "input" this.setRangorde}}
     />
     <AuButton
       hideText={{true}}

--- a/app/components/verkiezingen/rangorde-input.hbs
+++ b/app/components/verkiezingen/rangorde-input.hbs
@@ -1,0 +1,19 @@
+<div class="order-input-as-string">
+  <AuButton
+    hideText={{true}}
+    @icon="dash"
+    @skin="secondary"
+    class="order-input-as-string--minus"
+  />
+  <AuInput
+    value={{@rangorde}}
+    placeholder="bv. eerste, 1 of 1ste"
+    {{on "keyup" (perform this.transformRangorde)}}
+  />
+  <AuButton
+    hideText={{true}}
+    @skin="secondary"
+    @icon="plus"
+    class="order-input-as-string--plus"
+  />
+</div>

--- a/app/components/verkiezingen/rangorde-input.hbs
+++ b/app/components/verkiezingen/rangorde-input.hbs
@@ -1,27 +1,29 @@
-<div class="order-input-as-string">
-  <AuButton
-    hideText={{true}}
-    @icon="dash"
-    @skin="secondary"
-    class="order-input-as-string--minus"
-    @disabled={{this.isMinusDisabled}}
-    {{on "click" this.rangordeDown}}
-  />
-  <AuInput
-    value={{this.rangordeInput}}
-    placeholder="bv. eerste, 1 of 1ste"
-    @warning={{this.inputWarningMessage}}
-    {{on "keyup" (perform this.transformRangorde)}}
-  />
-  <AuButton
-    hideText={{true}}
-    @skin="secondary"
-    @icon="plus"
-    class="order-input-as-string--plus"
-    @disabled={{this.isPlusDisabled}}
-    {{on "click" this.rangordeUp}}
-  />
+<div>
+  <div class="order-input-as-string">
+    <AuButton
+      hideText={{true}}
+      @icon="dash"
+      @skin="secondary"
+      class="order-input-as-string--minus"
+      @disabled={{this.isMinusDisabled}}
+      {{on "click" this.rangordeDown}}
+    />
+    <AuInput
+      value={{this.rangordeInput}}
+      placeholder="bv. eerste, 1 of 1ste"
+      @warning={{this.inputWarningMessage}}
+      {{on "keyup" (perform this.transformRangorde)}}
+    />
+    <AuButton
+      hideText={{true}}
+      @skin="secondary"
+      @icon="plus"
+      class="order-input-as-string--plus"
+      @disabled={{this.isPlusDisabled}}
+      {{on "click" this.rangordeUp}}
+    />
+  </div>
+  <AuHelpText @warning={{this.inputWarningMessage}}>
+    {{this.inputWarningMessage}}
+  </AuHelpText>
 </div>
-<AuHelpText @warning={{this.inputWarningMessage}}>
-  {{this.inputWarningMessage}}
-</AuHelpText>

--- a/app/components/verkiezingen/rangorde-input.hbs
+++ b/app/components/verkiezingen/rangorde-input.hbs
@@ -5,6 +5,7 @@
     @skin="secondary"
     class="order-input-as-string--minus"
     @disabled={{this.isMinusDisabled}}
+    {{on "click" this.rangordeDown}}
   />
   <AuInput
     value={{@rangorde}}
@@ -18,6 +19,7 @@
     @icon="plus"
     class="order-input-as-string--plus"
     @disabled={{this.isPlusDisabled}}
+    {{on "click" this.rangordeUp}}
   />
 </div>
 <AuHelpText @warning={{this.inputWarningMessage}}>

--- a/app/components/verkiezingen/rangorde-input.hbs
+++ b/app/components/verkiezingen/rangorde-input.hbs
@@ -9,10 +9,10 @@
       {{on "click" this.rangordeDown}}
     />
     <AuInput
-      value={{this.rangordeInput}}
+      value={{this.rangorde}}
       placeholder="bv. Eerste schepen"
       @warning={{this.inputWarningMessage}}
-      {{on "input" this.setRangorde}}
+      {{on "input" this.onUpdateRangorde}}
     />
     <AuButton
       hideText={{true}}

--- a/app/components/verkiezingen/rangorde-input.hbs
+++ b/app/components/verkiezingen/rangorde-input.hbs
@@ -8,7 +8,7 @@
     {{on "click" this.rangordeDown}}
   />
   <AuInput
-    value={{@rangorde}}
+    value={{this.rangordeInput}}
     placeholder="bv. eerste, 1 of 1ste"
     @warning={{this.inputWarningMessage}}
     {{on "keyup" (perform this.transformRangorde)}}

--- a/app/components/verkiezingen/rangorde-input.hbs
+++ b/app/components/verkiezingen/rangorde-input.hbs
@@ -4,10 +4,12 @@
     @icon="dash"
     @skin="secondary"
     class="order-input-as-string--minus"
+    @disabled={{this.isMinusDisabled}}
   />
   <AuInput
     value={{@rangorde}}
     placeholder="bv. eerste, 1 of 1ste"
+    @warning={{this.inputWarningMessage}}
     {{on "keyup" (perform this.transformRangorde)}}
   />
   <AuButton
@@ -15,5 +17,9 @@
     @skin="secondary"
     @icon="plus"
     class="order-input-as-string--plus"
+    @disabled={{this.isplusDisabled}}
   />
 </div>
+<AuHelpText @warning={{this.inputWarningMessage}}>
+  {{this.inputWarningMessage}}
+</AuHelpText>

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -100,7 +100,7 @@ export default class VerkiezingenRangordeInputComponent extends Component {
   }
 
   get isPlusDisabled() {
-    return !this.rangordeInteger;
+    return !this.rangordeInteger || this.rangordeInteger >= 20;
   }
 
   get rangordeAsStringMapping() {

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -50,6 +50,8 @@ export default class VerkiezingenRangordeInputComponent extends Component {
     } else {
       this.rangordeInput = this.rangordeInteger;
     }
+
+    this.args.updatedRangorde(this.rangordeInput);
   }
 
   @action

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -59,13 +59,12 @@ export default class VerkiezingenRangordeInputComponent extends Component {
     if (!possibleString) {
       return null;
     }
-    let foundNumber = null;
     Object.keys(rangordeStringMapping).forEach((key) => {
       if (possibleString.startsWith(key)) {
-        foundNumber = rangordeStringMapping[key];
+        return rangordeStringMapping[key];
       }
     });
-    return foundNumber;
+    return null;
   }
 
   findFirstWordOfString(string) {

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -19,7 +19,7 @@ export default class VerkiezingenRangordeInputComponent extends Component {
   }
 
   transformRangorde = restartableTask(async (event) => {
-    await timeout(200);
+    await timeout(250);
 
     this.rangordeInput = event.target?.value;
     this.rangordeInteger = this.findOrderInString(this.rangordeInput);
@@ -29,6 +29,7 @@ export default class VerkiezingenRangordeInputComponent extends Component {
     } else {
       this.inputWarningMessage = null;
     }
+    this.setRangorde();
   });
 
   setRangorde() {

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -69,7 +69,7 @@ export default class VerkiezingenRangordeInputComponent extends Component {
   }
 
   get isMinusDisabled() {
-    return !this.rangordeInteger || this.rangordeInteger == 0;
+    return !this.rangordeInteger || this.rangordeInteger <= 1;
   }
 
   get isPlusDisabled() {

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -94,6 +94,14 @@ export default class VerkiezingenRangordeInputComponent extends Component {
     return null;
   }
 
+  get isMinusDisabled() {
+    return !this.rangordeInteger || this.rangordeInteger <= 1;
+  }
+
+  get isPlusDisabled() {
+    return !this.rangordeInteger;
+  }
+
   get rangordeAsStringMapping() {
     return {
       eerste: 1,
@@ -105,14 +113,17 @@ export default class VerkiezingenRangordeInputComponent extends Component {
       zevende: 7,
       achtste: 8,
       negende: 9,
+      tiende: 10,
+      elfde: 11,
+      twaalfde: 12,
+      dertiende: 13,
+      veertiende: 14,
+      vijftiende: 15,
+      zestiende: 16,
+      zeventiende: 17,
+      achtiende: 18,
+      negentiende: 19,
+      twintigste: 20,
     };
-  }
-
-  get isMinusDisabled() {
-    return !this.rangordeInteger || this.rangordeInteger <= 1;
-  }
-
-  get isPlusDisabled() {
-    return !this.rangordeInteger;
   }
 }

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -1,0 +1,59 @@
+import Component from '@glimmer/component';
+
+import { restartableTask, timeout } from 'ember-concurrency';
+
+export default class VerkiezingenRangordeInputComponent extends Component {
+  transformRangorde = restartableTask(async (event) => {
+    await timeout(200);
+
+    let possibleOrder = this.findOrderInString(event.target?.value);
+
+    if (!possibleOrder) {
+      console.warn(`Geen getal gevonden in input veld`);
+      return;
+    }
+
+    console.log({ possibleOrder });
+  });
+
+  findOrderInString(possibleString) {
+    if (!possibleString) {
+      return null;
+    }
+
+    const firstWord = this.findFirstWordOfString(possibleString);
+    if (!firstWord) {
+      return null;
+    }
+
+    const lowercaseWord = firstWord.input?.toLowerCase();
+    if (Object.keys(this.rangordeAsStringMapping).includes(lowercaseWord)) {
+      return this.rangordeAsStringMapping[lowercaseWord];
+    } else {
+      return parseInt(lowercaseWord);
+    }
+  }
+
+  findFirstWordOfString(string) {
+    // eslint-disable-next-line no-useless-escape
+    const regex = new RegExp(/^([\w\-]+)/);
+    if (regex.test(string)) {
+      return string.match(regex);
+    }
+    return null;
+  }
+
+  get rangordeAsStringMapping() {
+    return {
+      eerste: 1,
+      tweede: 2,
+      derde: 3,
+      vierde: 4,
+      vijfde: 5,
+      zesde: 6,
+      zevende: 7,
+      achtste: 8,
+      negende: 9,
+    };
+  }
+}

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 
+import { action } from '@ember/object';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 
@@ -26,6 +27,15 @@ export default class VerkiezingenRangordeInputComponent extends Component {
     }
     console.log(`Rangorde in transform:`, this.rangordeInteger);
   });
+
+  @action
+  rangordeUp() {
+    this.rangordeInteger += 1;
+  }
+  @action
+  rangordeDown() {
+    this.rangordeInteger -= 1;
+  }
 
   findOrderInString(possibleString) {
     if (!possibleString) {

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -1,19 +1,30 @@
 import Component from '@glimmer/component';
 
 import { restartableTask, timeout } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
 
 export default class VerkiezingenRangordeInputComponent extends Component {
+  @tracked rangordeInteger;
+  @tracked inputWarningMessage;
+
+  constructor() {
+    super(...arguments);
+
+    this.rangordeInteger = this.findOrderInString(this.args.rangorde ?? null);
+  }
+
   transformRangorde = restartableTask(async (event) => {
     await timeout(200);
 
-    let possibleOrder = this.findOrderInString(event.target?.value);
+    const inputValue = event.target?.value;
+    this.rangordeInteger = this.findOrderInString(inputValue);
 
-    if (!possibleOrder) {
-      console.warn(`Geen getal gevonden in input veld`);
-      return;
+    if (inputValue && !this.rangordeInteger) {
+      this.inputWarningMessage = `We kunnen geen rangorde vinden`;
+    } else {
+      this.inputWarningMessage = null;
     }
-
-    console.log({ possibleOrder });
+    console.log(`Rangorde in transform:`, this.rangordeInteger);
   });
 
   findOrderInString(possibleString) {
@@ -55,5 +66,13 @@ export default class VerkiezingenRangordeInputComponent extends Component {
       achtste: 8,
       negende: 9,
     };
+  }
+
+  get isMinusDisabled() {
+    return !this.rangordeInteger || this.rangordeInteger == 0;
+  }
+
+  get isPlusDisabled() {
+    return !this.rangordeInteger;
   }
 }

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -137,4 +137,11 @@ export default class VerkiezingenRangordeInputComponent extends Component {
       this.setRangorde(this.rangorde.replace(currentOrder, newOrder));
     }
   }
+
+  @action
+  onEnterInRangorde(event) {
+    if (event.key === 'Enter') {
+      this.setRangorde(event.currentTarget.value);
+    }
+  }
 }

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -90,7 +90,7 @@ export default class VerkiezingenRangordeInputComponent extends Component {
     // eslint-disable-next-line no-useless-escape
     const regex = new RegExp(/^([\w\-]+)/);
     if (regex.test(string)) {
-      return string.match(regex);
+      return `${string}`.match(regex);
     }
     return null;
   }

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -260,10 +260,10 @@
 }
 
 .hover-help-text {
-  display:none;
-  position:absolute;
+  display: none;
+  position: absolute;
   background-color: #687483;
-  color:white;
+  color: white;
   border-radius: 5px;
   bottom: -3.3rem;
   left: 50%;
@@ -275,5 +275,24 @@
 }
 
 .hover-element:hover .hover-help-text {
-  display:block;
+  display: block;
+}
+
+.order-input-as-string {
+  display: flex;
+  flex-direction: row;
+  gap: 0px;
+
+  input {
+    border-radius: 0px;
+  }
+}
+
+.order-input-as-string--minus {
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+.order-input-as-string--plus {
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
 }

--- a/app/utils/rangorde.js
+++ b/app/utils/rangorde.js
@@ -1,0 +1,28 @@
+export const rangordeStringMapping = {
+  Eerste: 1,
+  Tweede: 2,
+  Derde: 3,
+  Vierde: 4,
+  Vijfde: 5,
+  Zesde: 6,
+  Zevende: 7,
+  Achtste: 8,
+  Negende: 9,
+  Tiende: 10,
+  Elfde: 11,
+  Twaalfde: 12,
+  Dertiende: 13,
+  Veertiende: 14,
+  Vijftiende: 15,
+  Zestiende: 16,
+  Zeventiende: 17,
+  Achtiende: 18,
+  Negentiende: 19,
+  Twintigste: 20,
+};
+
+export const rangordeNumberMapping = {};
+
+Object.keys(rangordeStringMapping).forEach((key) => {
+  rangordeNumberMapping[rangordeStringMapping[key]] = key;
+});

--- a/app/utils/rangorde.js
+++ b/app/utils/rangorde.js
@@ -26,3 +26,25 @@ export const rangordeNumberMapping = {};
 Object.keys(rangordeStringMapping).forEach((key) => {
   rangordeNumberMapping[rangordeStringMapping[key]] = key;
 });
+
+export const rangordeStringToNumber = (rangordeString) => {
+  if (!rangordeString) {
+    return null;
+  }
+  const firstWord = rangordeString.split(' ')[0];
+  return rangordeStringMapping[firstWord];
+};
+
+export const orderMandatarissenByRangorde = (mandatarissen) => {
+  return mandatarissen.sort((a, b) => {
+    const aNumber = rangordeStringToNumber(a.rangorde);
+    const bNumber = rangordeStringToNumber(b.rangorde);
+    if (aNumber == null) {
+      return -1;
+    }
+    if (bNumber == null) {
+      return 1;
+    }
+    return aNumber - bNumber;
+  });
+};


### PR DESCRIPTION
## Description

We want to change the rangorde of a mandataris in orgaan to be moved up or down in the table. The input field is a free text input but we are setting some limitations on it warning users of potential issues.

* We support changing the rangorde using buttons from 1 to 20 inclusive
* Gibberish text is allowed but shows a warning
* A rangorde is automatically generated based on the mandate of the mandataris when clicking plus or mandataris
* Sorting works based on the numeric value of the rangorde and is unchanged for other columns
* when changing the rangorde using the buttons, the mandataris switches rangorde with the mandataris that previously had that rangorde
* changing rangorde also takes into account the sorting

## How to test

Check the rangorde of the mandaten

## Attachments

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/1076194/6414f13f-78a4-4ea1-aff3-47577ec94e20)

