### PR TITLE
Ben/lmb 392 delete mandataris

### DIFF
--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -60,6 +60,7 @@
             @label="Einde mandaat"
           />
         {{/if}}
+        <th>{{! Delete }}</th>
       </c.header>
 
       <c.body as |row|>
@@ -121,6 +122,13 @@
             {{moment-format row.einde "DD-MM-YYYY"}}
           </td>
         {{/if}}
+        <td class="au-u-text-right">
+          <AuButton
+            @icon="bin"
+            @alert={{true}}
+            {{on "click" (fn this.removeMandataris row)}}
+          >Verwijder</AuButton>
+        </td>
       </c.body>
     </t.content>
   </AuDataTable>

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -1,10 +1,14 @@
 import Component from '@glimmer/component';
 
+import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { orderMandatarissenByRangorde } from 'frontend-lmb/utils/rangorde';
+import { JSON_API_TYPE } from 'frontend-lmb/utils/constants';
 
 export default class DraftMandatarisListComponent extends Component {
+  @service toaster;
+
   @tracked isModalOpen = false;
   @tracked mandataris;
   @tracked editBeleidsdomeinen;
@@ -68,6 +72,23 @@ export default class DraftMandatarisListComponent extends Component {
 
   @action
   async removeMandataris(mandataris) {
-    await mandataris.destroyRecord();
+    const result = await fetch(
+      `/mandataris-api/mandatarissen/${mandataris.id}`,
+      {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': JSON_API_TYPE,
+        },
+      }
+    );
+
+    if (result.ok) {
+      const succesMessage = 'Mandataris succesvol verwijderd.';
+      this.toaster.success(succesMessage, 'Succes', { timeOut: 5000 });
+    } else {
+      const errorMessage =
+        'Er ging iets mis bij het verwijderen van de mandataris. Probeer het later opnieuw.';
+      this.toaster.error(errorMessage, 'Error');
+    }
   }
 }

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -1,10 +1,13 @@
 import Component from '@glimmer/component';
 
+import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { orderMandatarissenByRangorde } from 'frontend-lmb/utils/rangorde';
 
 export default class DraftMandatarisListComponent extends Component {
+  @service router;
+
   @tracked isModalOpen = false;
   @tracked mandataris;
   @tracked editBeleidsdomeinen;
@@ -64,5 +67,11 @@ export default class DraftMandatarisListComponent extends Component {
     this.mandataris.isBestuurlijkeAliasVan = person;
     await this.mandataris.save();
     this.closeModal();
+  }
+
+  @action
+  async removeMandataris(mandataris) {
+    await mandataris.destroyRecord();
+    this.router.refresh();
   }
 }

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -1,13 +1,10 @@
 import Component from '@glimmer/component';
 
-import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { orderMandatarissenByRangorde } from 'frontend-lmb/utils/rangorde';
 
 export default class DraftMandatarisListComponent extends Component {
-  @service router;
-
   @tracked isModalOpen = false;
   @tracked mandataris;
   @tracked editBeleidsdomeinen;
@@ -72,6 +69,5 @@ export default class DraftMandatarisListComponent extends Component {
   @action
   async removeMandataris(mandataris) {
     await mandataris.destroyRecord();
-    this.router.refresh();
   }
 }

--- a/app/routes/verkiezingen/verkiezingsuitslag/prepare.js
+++ b/app/routes/verkiezingen/verkiezingsuitslag/prepare.js
@@ -59,6 +59,7 @@ export default class PrepareInstallatievergaderingRoute extends Route {
         'bekleedt.bestuursfunctie',
         'heeft-lidmaatschap.binnen-fractie',
         'status',
+        'beleidsdomein',
       ].join(','),
     };
 


### PR DESCRIPTION
## Description

Add a delete button to the draft mandataris table in prepare installatievergadering. This creates a thombstone.
![Screenshot 2024-05-07 at 10 00 10](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/43848896/27ce11ad-9f1b-4bb7-99d8-fbeca916eeec)

## How to test

Go to the prepare installatievergadering route and delete a mandataris. You should go to the gemeente Aalst and select the old bestuursorgaan in tijd, otherwise, you probably won't have mandatarissen in the table and you'll first have to add some (if you have ran the latest migrations). 
If you want to check if the resources were actually deleted, you can check which resources are in the database and this should show something like this for the deleted mandataris:
![Screenshot 2024-05-07 at 09 32 06](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/43848896/ff012bea-3251-43b9-8f8f-800e9d6c0d0c)

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/132
- https://github.com/lblod/mandataris-service/pull/1