### PR TITLE
LMB- 296: Mandataris has a link to besluit

### DIFF
--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -57,6 +57,13 @@
             this.formattedBeleidsdomein
           }}</div>
       </div>
+      {{#if @mandataris.linkToBesluit}}
+        <div class="au-o-grid__item au-u-5-6">
+          <div class="au-c-description-label"><div>Link naar besluit</div></div>
+          <div class="au-c-description-value"><AuLink
+            >{{@mandataris.linkToBesluit}}</AuLink></div>
+        </div>
+      {{/if}}
 
       {{#if @vervangers}}
         <div class="au-o-grid__item au-u-5-6">

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -9,6 +9,7 @@ export default class MandatarisModel extends Model {
   @attr('datetime') einde;
   @attr duplicationReason;
   @attr uri;
+  @attr('string') linkToBesluit;
   @attr('datetime', {
     defaultValue() {
       return new Date();


### PR DESCRIPTION
## Description

When the besluit is not added as linked data we want the user to set a url to the besluit

## How to test

1. Go to a person and click the detail of a mandataris
2. Correct the mandataris and add the link to the besluit
3. The link  to besluit will now be visible in the information card

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/140

## Attachments

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/36266973/c084b754-fe68-4d9b-af39-c461a862e95f)

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/36266973/df06a949-ae31-4c73-bf7a-ab34ef258db7)
