### PR TITLE
only show beleidsdomein if burgemeester or shepen in update state, refactor check for show rangorde

### DIFF
--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -71,16 +71,20 @@
         />
       </div>
     {{/if}}
-    <div>
-      <AuLabel>
-        Beleidsdomeinen
-      </AuLabel>
-      <Mandatarissen::BeleidsdomeinSelectorWithCreate
-        @beleidsdomeinen={{this.selectedBeleidsdomeinen}}
-        @onSelect={{this.updateBeleidsdomeinen}}
-      />
-      <AuHelpText>Enkel voor burgemeester en schepenen</AuHelpText>
-    </div>
+    {{#if
+      (or @mandataris.bekleedt.isBurgemeester @mandataris.bekleedt.isSchepen)
+    }}
+      <div>
+        <AuLabel>
+          Beleidsdomeinen
+        </AuLabel>
+        <Mandatarissen::BeleidsdomeinSelectorWithCreate
+          @beleidsdomeinen={{this.selectedBeleidsdomeinen}}
+          @onSelect={{this.updateBeleidsdomeinen}}
+        />
+        <AuHelpText>Enkel voor burgemeester en schepenen</AuHelpText>
+      </div>
+    {{/if}}
     <div>
       <AuLabel>
         Fractie
@@ -99,7 +103,7 @@
         />
       {{/if}}
     </div>
-    {{#if this.showRangorde}}
+    {{#if @mandataris.bekleedt.isSchepen}}
       <div>
         <AuLabel>
           Rangorde

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -149,11 +149,6 @@ export default class MandatarissenUpdateState extends Component {
     );
   }
 
-  get showRangorde() {
-    const roleName = this.args.mandataris.get('bekleedt.bestuursfunctie.label');
-    return roleName && roleName.toLowerCase().indexOf('schepen') >= 0;
-  }
-
   get rangordePlaceholder() {
     const mandaatName = (
       this.args.mandataris.get('bekleedt.bestuursfunctie.label') || 'schepen'

--- a/app/models/mandaat.js
+++ b/app/models/mandaat.js
@@ -1,4 +1,10 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import {
+  MANDAAT_BURGEMEESTER_CODE,
+  MANDAAT_DISTRICT_BURGEMEESTER_CODE,
+  MANDAAT_DISTRICT_SCHEPEN_CODE,
+  MANDAAT_SCHEPEN_CODE,
+} from 'frontend-lmb/utils/well-known-uris';
 
 const identity = Boolean;
 
@@ -36,5 +42,18 @@ export default class MandaatModel extends Model {
   // If any of the bestuursorganen is decretaal, then the mandaat is decretaal.
   get isDecretaal() {
     return this.isDecretaalHelper();
+  }
+
+  get isBurgemeester() {
+    return [
+      MANDAAT_BURGEMEESTER_CODE,
+      MANDAAT_DISTRICT_BURGEMEESTER_CODE,
+    ].includes(this.bestuursfunctie.get('uri'));
+  }
+
+  get isSchepen() {
+    return [MANDAAT_SCHEPEN_CODE, MANDAAT_DISTRICT_SCHEPEN_CODE].includes(
+      this.bestuursfunctie.get('uri')
+    );
   }
 }

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -24,3 +24,11 @@ export const BELEIDSDOMEIN_CODES_CONCEPT_SCHEME =
   'http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode';
 export const BESTUURSORGAAN_CLASSIFICATIE_CODE_BURGEMEESTER =
   'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284';
+export const MANDAAT_BURGEMEESTER_CODE =
+  'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013';
+export const MANDAAT_DISTRICT_BURGEMEESTER_CODE =
+  'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001d';
+export const MANDAAT_SCHEPEN_CODE =
+  'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000014';
+export const MANDAAT_DISTRICT_SCHEPEN_CODE =
+  'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001e';


### PR DESCRIPTION
## Description

only show beleidsdomein if burgemeester or shepen in update state, refactor check for show rangorde

## How to test

Open a burgemeester, see that the rangorde is gone but the beleidsdomeinen are present in update state
Open a schepen, see that rangorde and beleidsdomeinen are present in update state
Open a gemeenteraadslid, see that neither are present in update state

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/1076194/5dc1a6a7-56e6-4b39-83b1-401cc14016c9)
![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/1076194/948ab5d8-7699-49c9-b5b3-8707d2089202)
![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/1076194/a43cb12a-188c-40a3-b029-a58dac484bca)

