### PR TITLE
hide inappropriate fields in forms too, deal with titelvoerend in the same way as aangewezen

### DIFF
--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -6,7 +6,7 @@ import { inject as service } from '@ember/service';
 import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
 import { VERHINDERD_STATE_ID } from 'frontend-lmb/utils/well-known-ids';
 import { getDraftPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
-import { MANDATARIS_AANGEWEZEN_STATE } from 'frontend-lmb/utils/well-known-uris';
+import { burgemeesterOnlyStates } from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarissenUpdateState extends Component {
   @tracked newStatus = null;
@@ -69,7 +69,7 @@ export default class MandatarissenUpdateState extends Component {
       return statuses;
     }
     return statuses.filter(
-      (status) => status.uri !== MANDATARIS_AANGEWEZEN_STATE
+      (status) => !burgemeesterOnlyStates.includes(status.uri)
     );
   }
 

--- a/app/components/rdf-input-fields/beleidsdomein-code-selector.hbs
+++ b/app/components/rdf-input-fields/beleidsdomein-code-selector.hbs
@@ -1,0 +1,38 @@
+{{#if this.shouldRender}}
+  {{#unless @inTable}}
+    <AuLabel
+      @error={{this.hasErrors}}
+      @required={{this.isRequired}}
+      @warning={{this.hasWarnings}}
+      for={{this.inputId}}
+    >
+      {{@field.label}}
+    </AuLabel>
+  {{/unless}}
+  <div class={{if this.hasErrors "ember-power-select--error"}}>
+    <Mandatarissen::ConceptSelectorWithCreate
+      @multiple={{true}}
+      @type={{@field.options.type}}
+      @conceptScheme={{this.conceptScheme}}
+      @search={{this.search}}
+      @searchEnabled={{this.searchEnabled}}
+      @selected={{this.selected}}
+      @options={{this.options}}
+      @onClose={{fn (mut this.hasBeenFocused) true}}
+      @onChange={{this.updateSelection}}
+      @onCreate={{this.add}}
+      @disabled={{@show}}
+      as |concept|
+    >
+      {{concept.label}}
+    </Mandatarissen::ConceptSelectorWithCreate>
+  </div>
+
+  {{#each this.errors as |error|}}
+    <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
+  {{/each}}
+
+  {{#each this.warnings as |warning|}}
+    <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
+  {{/each}}
+{{/if}}

--- a/app/components/rdf-input-fields/beleidsdomein-code-selector.js
+++ b/app/components/rdf-input-fields/beleidsdomein-code-selector.js
@@ -1,0 +1,62 @@
+import RdfInputFieldsConceptSchemeMultiSelectorWithCreateComponent from './concept-scheme-multi-selector-with-create';
+import {
+  triplesForPath,
+  updateSimpleFormValue,
+} from '@lblod/submission-form-helpers';
+import { ORG } from 'frontend-lmb/rdf/namespaces';
+import { inject as service } from '@ember/service';
+import { getByUri } from 'frontend-lmb/utils/get-by-uri';
+import { tracked } from '@glimmer/tracking';
+
+export default class RdfBeleidsdomeinCodeSelector extends RdfInputFieldsConceptSchemeMultiSelectorWithCreateComponent {
+  @service store;
+  @tracked shouldRender;
+
+  constructor() {
+    super(...arguments);
+    this.registerObserver();
+  }
+
+  registerObserver() {
+    const onFormUpdate = () => {
+      if (this.isDestroyed) {
+        return;
+      }
+
+      this.checkIfShouldRender();
+    };
+    this.storeOptions.store.registerObserver(onFormUpdate);
+    onFormUpdate();
+  }
+
+  async checkIfShouldRender() {
+    const mandaatUri = this.storeOptions.store.match(
+      this.storeOptions.sourceNode,
+      ORG('holds'),
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    const mandaat = await getByUri(
+      this.store,
+      'mandaat',
+      mandaatUri[0]?.object?.value,
+      { include: 'bestuursfunctie' }
+    );
+    this.shouldRender = mandaat?.isBurgemeester || mandaat?.isSchepen;
+
+    if (!this.shouldRender && this.selected?.length > 0) {
+      // without timeout, the form ttl doesn't update immediately
+      setTimeout(() => {
+        this.selected = [];
+        // clear selection
+        const matches = triplesForPath(this.storeOptions, true).values;
+
+        // Cleanup old value(s) in the store
+        matches.forEach((m) =>
+          updateSimpleFormValue(this.storeOptions, undefined, m)
+        );
+      }, 100);
+    }
+  }
+}

--- a/app/components/rdf-input-fields/mandataris-rangorde.hbs
+++ b/app/components/rdf-input-fields/mandataris-rangorde.hbs
@@ -1,0 +1,27 @@
+{{#if this.shouldRender}}
+  <AuLabel
+    for={{this.inputId}}
+    @error={{this.hasErrors}}
+    @warning={{this.hasWarnings}}
+    @required={{this.isRequired}}
+  >
+    {{@field.label}}
+  </AuLabel>
+  <AuInput
+    @error={{this.hasErrors}}
+    @warning={{this.hasWarnings}}
+    @width="block"
+    id={{this.inputId}}
+    value={{this.rangorde}}
+    placeholder="Eerste schepen"
+    {{on "blur" this.updateValue}}
+  />
+
+  {{#each this.errors as |error|}}
+    <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
+  {{/each}}
+
+  {{#each this.warnings as |warning|}}
+    <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
+  {{/each}}
+{{/if}}

--- a/app/components/rdf-input-fields/mandataris-rangorde.js
+++ b/app/components/rdf-input-fields/mandataris-rangorde.js
@@ -1,0 +1,92 @@
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import { guidFor } from '@ember/object/internals';
+import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
+import { ORG } from 'frontend-lmb/rdf/namespaces';
+import { getByUri } from 'frontend-lmb/utils/get-by-uri';
+import {
+  triplesForPath,
+  updateSimpleFormValue,
+} from '@lblod/submission-form-helpers';
+
+export default class RdfMandatarisRangorde extends InputFieldComponent {
+  inputId = 'rangorde-' + guidFor(this);
+
+  @service store;
+  @tracked rangorde;
+  @tracked shouldRender;
+
+  constructor() {
+    super(...arguments);
+    this.loadProvidedValue();
+    this.registerObserver();
+  }
+
+  async loadProvidedValue() {
+    const matches = triplesForPath(this.storeOptions);
+
+    if (matches.values.length > 0) {
+      this.rangorde = matches.values[0].value;
+    }
+  }
+
+  registerObserver() {
+    const onFormUpdate = () => {
+      if (this.isDestroyed) {
+        return;
+      }
+
+      this.checkIfShouldRender();
+    };
+    this.storeOptions.store.registerObserver(onFormUpdate);
+    onFormUpdate();
+  }
+
+  async checkIfShouldRender() {
+    const mandaatUri = this.storeOptions.store.match(
+      this.storeOptions.sourceNode,
+      ORG('holds'),
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    const mandaat = await getByUri(
+      this.store,
+      'mandaat',
+      mandaatUri[0]?.object?.value,
+      { include: 'bestuursfunctie' }
+    );
+    this.shouldRender = mandaat?.isSchepen;
+
+    if (!this.shouldRender && this.rangorde != null) {
+      // without timeout, the form ttl doesn't update immediately
+      setTimeout(() => {
+        this.rangorde = null;
+        // clear selection
+        const matches = triplesForPath(this.storeOptions, true).values;
+
+        // Cleanup old value(s) in the store
+        matches.forEach((m) =>
+          updateSimpleFormValue(this.storeOptions, undefined, m)
+        );
+      }, 100);
+    }
+  }
+
+  @action
+  async updateValue(event) {
+    if (event && typeof event.preventDefault === 'function') {
+      event.preventDefault();
+    }
+    const rangorde = event.target.value.trim();
+    this.rangorde = rangorde;
+
+    replaceSingleFormValue(this.storeOptions, rangorde ? rangorde : null);
+
+    this.updateValidations();
+
+    this.hasBeenFocused = true;
+  }
+}

--- a/app/components/rdf-input-fields/mandataris-replacement-selector.js
+++ b/app/components/rdf-input-fields/mandataris-replacement-selector.js
@@ -57,7 +57,7 @@ export default class MandatarisReplacementSelector extends InputFieldComponent {
       new NamedNode(MANDATARIS_VERHINDERD_STATE),
       this.storeOptions.sourceGraph
     );
-    if (!this.shouldRender) {
+    if (!this.shouldRender && this.replacements?.length > 0) {
       // without timeout, the form ttl doesn't update immediately
       setTimeout(() => this.selectReplacement([]), 100);
     }

--- a/app/components/rdf-input-fields/mandataris-status-selector.js
+++ b/app/components/rdf-input-fields/mandataris-status-selector.js
@@ -1,5 +1,5 @@
 import { queryRecord } from 'frontend-lmb/utils/query-record';
-import { MANDATARIS_AANGEWEZEN_STATE } from 'frontend-lmb/utils/well-known-uris';
+import { burgemeesterOnlyStates } from 'frontend-lmb/utils/well-known-uris';
 import { tracked } from '@glimmer/tracking';
 import { ORG } from 'frontend-lmb/rdf/namespaces';
 import { service } from '@ember/service';
@@ -58,7 +58,7 @@ export default class RdfInputFieldsMandatarisStatusSelectorComponent extends Rdf
     }
 
     return statuses.filter(
-      (status) => status.subject.value !== MANDATARIS_AANGEWEZEN_STATE
+      (status) => !burgemeesterOnlyStates.includes(status.subject.value)
     );
   }
 }

--- a/app/utils/form-validations/mandataris-rangorde.js
+++ b/app/utils/form-validations/mandataris-rangorde.js
@@ -1,0 +1,5 @@
+import { rangordeStringToNumber } from '../rangorde';
+
+export const isValidRangorde = (rangorde) => {
+  return rangordeStringToNumber(rangorde?.value) != null;
+};

--- a/app/utils/form-validations/register.js
+++ b/app/utils/form-validations/register.js
@@ -1,9 +1,14 @@
 import { registerCustomValidation } from '@lblod/submission-form-helpers';
 import { rijksregisternummerValidation } from './rijksregisternummer';
+import { isValidRangorde } from './mandataris-rangorde';
 
 export const registerCustomValidations = () => {
   registerCustomValidation(
     'http://mu.semte.ch/vocabularies/ext/ValidRijksregisternummer',
     rijksregisternummerValidation
+  );
+  registerCustomValidation(
+    'http://mu.semte.ch/vocabularies/ext/ValidRangorde',
+    isValidRangorde
   );
 };

--- a/app/utils/get-by-uri.js
+++ b/app/utils/get-by-uri.js
@@ -1,0 +1,13 @@
+export const getByUri = async (store, type, uri, options = {}) => {
+  if (!uri) {
+    return null;
+  }
+  const queryOptions = {
+    filter: {
+      ':uri:': uri,
+    },
+    ...options,
+  };
+  const results = await store.query(type, queryOptions);
+  return results.length > 0 ? results[0] : null;
+};

--- a/app/utils/register-form-fields.js
+++ b/app/utils/register-form-fields.js
@@ -13,6 +13,8 @@ import RDFConceptSchemeMultiSelectorComponent from 'frontend-lmb/components/rdf-
 import RdfInputFieldsConceptSchemeSelectorWithCreateComponent from 'frontend-lmb/components/rdf-input-fields/concept-scheme-selector-with-create';
 import RdfInputFieldsConceptSchemeMultiSelectorWithCreateComponent from 'frontend-lmb/components/rdf-input-fields/concept-scheme-multi-selector-with-create';
 import RdfInputFieldsMandatarisStatusSelectorComponent from 'frontend-lmb/components/rdf-input-fields/mandataris-status-selector';
+import RdfBeleidsdomeinCodeSelector from 'frontend-lmb/components/rdf-input-fields/beleidsdomein-code-selector';
+import RdfMandatarisRangorde from 'frontend-lmb/components/rdf-input-fields/mandataris-rangorde';
 
 export const registerCustomFormFields = () => {
   registerFormFields([
@@ -82,6 +84,15 @@ export const registerCustomFormFields = () => {
       displayType:
         'http://lblod.data.gift/display-types/conceptSchemeMultiSelectorWithCreate',
       edit: RdfInputFieldsConceptSchemeMultiSelectorWithCreateComponent,
+    },
+    {
+      displayType:
+        'http://lblod.data.gift/display-types/mandatarisBeleidsdomein',
+      edit: RdfBeleidsdomeinCodeSelector,
+    },
+    {
+      displayType: 'http://lblod.data.gift/display-types/mandatarisRangorde',
+      edit: RdfMandatarisRangorde,
     },
   ]);
 };

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -14,6 +14,8 @@ export const MANDATARIS_VERHINDERD_STATE =
   'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/c301248f-0199-45ca-b3e5-4c596731d5fe';
 export const MANDATARIS_AANGEWEZEN_STATE =
   'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/e371f89a-9e83-4a8c-a98e-cd09226fa549';
+export const MANDATARIS_TITELVOEREND_STATE =
+  'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/aacb3fed-b51d-4e0b-a411-f3fa641da1b3';
 export const MANDATARIS_EFFECTIEF_STATE =
   'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75';
 export const MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE =
@@ -32,3 +34,7 @@ export const MANDAAT_SCHEPEN_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000014';
 export const MANDAAT_DISTRICT_SCHEPEN_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001e';
+export const burgemeesterOnlyStates = [
+  MANDATARIS_AANGEWEZEN_STATE,
+  MANDATARIS_TITELVOEREND_STATE,
+];


### PR DESCRIPTION
## Description

hide inappropriate fields in forms too, deal with titelvoerend in the same way as aangewezen

## How to test

open a gemeenteraadslid, it should not show rangorde or beleidsdomeinen and the status values don't include the burgemeester special cases.

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/1076194/1e3f91a8-a561-4aac-a886-e04f9d012bc8)

open a schepen, it should show rangorde and beleidsdomeinen but the status should not include the burgemeester specific info. Rangorde shows a warning when incorrect values are entered.

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/1076194/eae74986-7486-4cc5-9b73-9b38c545fb00)

open a mayor, it should not show rangorde but should show beleidsdomeinen. The status should contain all values

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/1076194/92e35483-e1b1-4a1f-9361-6aa0ef0448a2)

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/180
