### PR TITLE
Fold Fracties

### DIFF
--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -9,6 +9,7 @@ import {
   getEffectiefStatus,
 } from 'frontend-lmb/utils/get-mandataris-status';
 import { queryRecord } from 'frontend-lmb/utils/query-record';
+import { toUserReadableListing } from 'frontend-lmb/utils/to-user-readable-listing';
 
 export default class MandaatBurgemeesterSelectorComponent extends Component {
   @service store;
@@ -66,20 +67,13 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
     });
   }
 
-  toUserReadableListing(array, itemToString) {
-    return `${array
-      .slice(0, -1)
-      .map((p) => itemToString(p))
-      .join(', ')} en ${itemToString(array.at(-1))}`;
-  }
-
   async setMultipleBurgemeestersError(burgemeesters) {
     const personen = await Promise.all(
       burgemeesters.map((b) => b.isBestuurlijkeAliasVan)
     );
 
     this.errorMessage = `Er zijn meerdere burgemeesters gevonden:
-      ${this.toUserReadableListing(personen, (p) => `${p.gebruikteVoornaam} ${p.achternaam}`)}.`;
+      ${toUserReadableListing(personen, (p) => `${p.gebruikteVoornaam} ${p.achternaam}`)}.`;
   }
 
   async createMandataris(burgemeesterMandaat) {

--- a/app/components/mandaat/folded-fracties.hbs
+++ b/app/components/mandaat/folded-fracties.hbs
@@ -1,0 +1,1 @@
+<div>{{this.fractiesText}}</div>

--- a/app/components/mandaat/folded-fracties.js
+++ b/app/components/mandaat/folded-fracties.js
@@ -1,0 +1,75 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { toUserReadableListing } from 'frontend-lmb/utils/to-user-readable-listing';
+import moment from 'moment';
+
+export default class MandaatFoldedFractiesComponent extends Component {
+  @service store;
+
+  @tracked fractiesText = '';
+
+  get persoon() {
+    return this.args.persoon;
+  }
+
+  constructor(...args) {
+    super(...args);
+    this.load();
+  }
+
+  async load() {
+    const mandatarissen = await this.getMandatarissen(this.persoon);
+
+    const { currentFractie, allFracties } =
+      await this.getFoldedFracties(mandatarissen);
+
+    this.fractiesText = this.fractiesToString(currentFractie, allFracties);
+  }
+
+  async getMandatarissen(persoon) {
+    return await this.store.query('mandataris', {
+      filter: {
+        'is-bestuurlijke-alias-van': {
+          ':id:': persoon.id,
+        },
+      },
+      include: 'heeft-lidmaatschap.binnen-fractie',
+    });
+  }
+
+  async getFoldedFracties(mandatarissen) {
+    let latestMandataris = null;
+    const allFracties = new Set();
+
+    await Promise.all(
+      mandatarissen.map(async (mandataris) => {
+        const fractie = mandataris.get('heeftLidmaatschap.binnenFractie.naam');
+        allFracties.add(fractie);
+
+        if (
+          !latestMandataris ||
+          moment(mandataris.einde).isAfter(latestMandataris.einde) ||
+          !mandataris.einde
+        ) {
+          latestMandataris = mandataris;
+        }
+      })
+    );
+
+    const currentFractie = latestMandataris.get(
+      'heeftLidmaatschap.binnenFractie.naam'
+    );
+
+    return { currentFractie, allFracties: Array.from(allFracties) };
+  }
+
+  fractiesToString(currentFractie, allFracties) {
+    const otherFracties = allFracties
+      .filter((f) => f != currentFractie && f) // TODO the "!=" and "&& f" are confusing
+      .toSorted((a, b) => a.localeCompare(b));
+    return otherFracties.length
+      ? `${currentFractie} (${toUserReadableListing(otherFracties)})`
+      : currentFractie;
+  }
+}

--- a/app/components/organen/mandataris-table.hbs
+++ b/app/components/organen/mandataris-table.hbs
@@ -56,7 +56,9 @@
           {{row.mandataris.isBestuurlijkeAliasVan.achternaam}}
         </LinkTo></td>
       <td>
-        {{row.foldedFracties}}
+        <Mandaat::FoldedFracties
+          @persoon={{row.mandataris.isBestuurlijkeAliasVan}}
+        />
       </td>
       <td><LinkTo
           @route={{@mandaatRoute}}

--- a/app/routes/organen/orgaan/mandatarissen.js
+++ b/app/routes/organen/orgaan/mandatarissen.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { toUserReadableListing } from 'frontend-lmb/utils/to-user-readable-listing';
 import moment from 'moment';
 
 export default class OrganenMandatarissenRoute extends Route {
@@ -185,8 +186,8 @@ export default class OrganenMandatarissenRoute extends Route {
       .filter((f) => f != currentFractie && f) // TODO the "&& f" is confusing
       .toSorted((a, b) => a.localeCompare(b));
     return sortedFracties.length
-      ? `${currentFractie} (${sortedFracties.join(', ')})`
-      : currentFractie; // TODO Join with prefix and postfix
+      ? `${currentFractie} (${toUserReadableListing(sortedFracties)})`
+      : currentFractie;
   }
 
   getOptions(params, bestuursOrgaan) {

--- a/app/routes/organen/orgaan/mandatarissen.js
+++ b/app/routes/organen/orgaan/mandatarissen.js
@@ -100,13 +100,10 @@ export default class OrganenMandatarissenRoute extends Route {
 
         if (existing) {
           this.updateFoldedMandataris(mandataris, fractie, existing);
-        } else {
-          const firstOccurrence = this.buildFoldedMandataris(
-            mandataris,
-            fractie
-          );
-          persoonMandaatData[key] = firstOccurrence;
+          return;
         }
+        const firstOccurrence = this.buildFoldedMandataris(mandataris, fractie);
+        persoonMandaatData[key] = firstOccurrence;
       })
     );
     return Object.values(persoonMandaatData).map(

--- a/app/utils/to-user-readable-listing.js
+++ b/app/utils/to-user-readable-listing.js
@@ -1,0 +1,29 @@
+export const toUserReadableListing = (
+  array,
+  itemToString = (item) => item,
+  prefix = '',
+  postfix = ''
+) => {
+  if (array.length === 0) {
+    return '';
+  }
+
+  const safeItemToString = (item) => {
+    const stringified = itemToString(item);
+
+    if (stringified == null) {
+      throw new Error('itemToString should not return null or undefined');
+    }
+    return stringified;
+  };
+
+  const content =
+    array.length === 1
+      ? safeItemToString(array[0])
+      : `${array
+          .slice(0, -1)
+          .map((p) => safeItemToString(p))
+          .join(', ')} en ${safeItemToString(array.at(-1))}`;
+
+  return `${prefix}${content}${postfix}`;
+};


### PR DESCRIPTION
## Description

A mandataris can have changed fractions. If so, whenever we show a combined view of a mandataris, we should show all fractions like this: `Current (onafhankelijk)`. It was already available in the organen mandatarissen table, but it should be applied more broadly across the whole app.

## How to test

Go to a organen mandatarissen table and have a look at the fracties if they have the proper format. (Will also be applied to the mandatarissen search page in the future)

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/55446974/323e8cb7-b3c9-4078-b270-6aecd27a2afc)

