### PR TITLE
LMB-398: Mirror tables in legislatuur

### DIFF
--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -46,7 +46,7 @@
             <AuDataTableThSortable
               @field="beleidsdomein"
               @currentSorting={{@sort}}
-              @label="Bevoegdheid"
+              @label="Bevoegdheden"
             />
           {{/if}}
           {{#if @showStartEndDate}}

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -27,12 +27,15 @@
     @showStartEndDate={{true}}
   />
 
-  <AuContent @skin="small">
+  <AuContent @skin="small au-u-flex au-u-flex--between ">
     <AuButton
       @skin="naked"
       @icon="add"
       {{on "click" this.createMandataris}}
     >Toevoegen</AuButton>
+    {{#if (await this.isRMW)}}
+      <AuButton @skin="naked" @icon="synchronize">Kopieer naar OCMW tabel</AuButton>
+    {{/if}}
   </AuContent>
   <AuModal
     @title={{(concat

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -35,7 +35,7 @@
       @showFunctie={{true}}
       @showRangorde={{this.showRangorde}}
       @showBevoegdheid={{this.showBeleidsDomein}}
-      @showStartEndDate={{true}}
+      @showStartEndDate={{false}}
     />
   {{/if}}
 

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -14,9 +14,8 @@
       </div>
     </Group>
   </AuToolbar>
-  {{#if this.mirrorTable.isRunning}}
+  {{#if (or this.mirrorTable.isRunning this.onCreate.isRunning)}}
     {{! Show skeleton loader }}
-    <AuLoader />
   {{else}}
     <Verkiezingen::DraftMandatarisList
       @bestuursorgaan={{@bestuursorgaan}}
@@ -36,6 +35,8 @@
     <AuButton
       @skin="naked"
       @icon="add"
+      @loading={{this.onCreate.isRunning}}
+      @loadingMessage="Aan het toevoegen"
       {{on "click" this.createMandataris}}
     >Toevoegen</AuButton>
     {{#if (or (await this.isRMW) (await this.isLidVanVB))}}
@@ -43,7 +44,7 @@
         @skin="naked"
         @icon="synchronize"
         @loading={{this.mirrorTable.isRunning}}
-        @loadingMessage="Synchroniseren"
+        @loadingMessage="Aan het synchroniseren"
         {{on "click" (perform this.mirrorTable)}}
       >Sync</AuButton>
     {{/if}}
@@ -58,7 +59,7 @@
   >
     <div class="au-o-box">
       <Form::NewInstance
-        @onCreate={{this.onCreate}}
+        @onCreate={{perform this.onCreate}}
         @form={{@form}}
         @buildSourceTtl={{this.buildSourceTtl}}
         @buildMetaTtl={{this.buildMetaTtl}}

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -33,7 +33,7 @@
       @icon="add"
       {{on "click" this.createMandataris}}
     >Toevoegen</AuButton>
-    {{#if (await this.isRMW)}}
+    {{#if (or (await this.isRMW) (await this.isLidVanVB))}}
       <AuButton @skin="naked" @icon="synchronize">Kopieer naar OCMW tabel</AuButton>
     {{/if}}
   </AuContent>

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -46,7 +46,14 @@
         @loading={{this.mirrorTable.isRunning}}
         @loadingMessage="Aan het synchroniseren"
         {{on "click" (perform this.mirrorTable)}}
-      >Sync</AuButton>
+      >
+        {{#if (await this.isRMW)}}
+          Sync met Gemeenteraad
+        {{/if}}
+        {{#if (await this.isLidVanVB)}}
+          Sync met College van Burgemeester en Schepenen
+        {{/if}}
+      </AuButton>
     {{/if}}
   </AuContent>
   <AuModal

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -1,7 +1,9 @@
 {{#if (await this.isBurgemeester)}}
   <Mandaat::BurgemeesterSelector @bestuursorgaanInTijd={{@bestuursorgaan}} />
 {{else}}
+
   <AuToolbar
+    {{did-insert (perform this.setupTable)}}
     @size="large"
     @nowrap="true"
     class="au-u-padding-bottom-none au-u-margin-bottom-none"
@@ -14,7 +16,13 @@
       </div>
     </Group>
   </AuToolbar>
-  {{#if (or this.mirrorTable.isRunning this.onCreate.isRunning)}}
+  {{#if
+    (or
+      this.mirrorTable.isRunning
+      this.onCreate.isRunning
+      this.setupTable.isRunning
+    )
+  }}
     {{! Show skeleton loader }}
   {{else}}
     <Verkiezingen::DraftMandatarisList
@@ -25,8 +33,8 @@
       @title=""
       @showFractie={{true}}
       @showFunctie={{true}}
-      @showRangorde={{true}}
-      @showBevoegdheid={{true}}
+      @showRangorde={{this.showRangorde}}
+      @showBevoegdheid={{this.showBeleidsDomein}}
       @showStartEndDate={{true}}
     />
   {{/if}}

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -34,7 +34,13 @@
       {{on "click" this.createMandataris}}
     >Toevoegen</AuButton>
     {{#if (or (await this.isRMW) (await this.isLidVanVB))}}
-      <AuButton @skin="naked" @icon="synchronize">Kopieer naar OCMW tabel</AuButton>
+      <AuButton
+        @skin="naked"
+        @icon="synchronize"
+        @loading={{this.mirrorTable.isRunning}}
+        @loadingMessage="Synchroniseren"
+        {{on "click" (perform this.mirrorTable)}}
+      >Sync</AuButton>
     {{/if}}
   </AuContent>
   <AuModal

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -14,18 +14,23 @@
       </div>
     </Group>
   </AuToolbar>
-  <Verkiezingen::DraftMandatarisList
-    @bestuursorgaan={{@bestuursorgaan}}
-    @sort={{@sort}}
-    @page={{0}}
-    @size={{9999}}
-    @title=""
-    @showFractie={{true}}
-    @showFunctie={{true}}
-    @showRangorde={{true}}
-    @showBevoegdheid={{true}}
-    @showStartEndDate={{true}}
-  />
+  {{#if this.mirrorTable.isRunning}}
+    {{! Show skeleton loader }}
+    <AuLoader />
+  {{else}}
+    <Verkiezingen::DraftMandatarisList
+      @bestuursorgaan={{@bestuursorgaan}}
+      @sort={{@sort}}
+      @page={{0}}
+      @size={{9999}}
+      @title=""
+      @showFractie={{true}}
+      @showFunctie={{true}}
+      @showRangorde={{true}}
+      @showBevoegdheid={{true}}
+      @showStartEndDate={{true}}
+    />
+  {{/if}}
 
   <AuContent @skin="small au-u-flex au-u-flex--between ">
     <AuButton

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -67,27 +67,18 @@ export default class PrepareLegislatuurSectionComponent extends Component {
       throw `Could not sync`;
     }
 
-    const mandatarissenToSyncWith =
+    const mandatarissenToSyncAdd =
       await this.getBestuursorgaanMandatarissen(bestuursorgaan);
     const currentMandatarissen = await this.getBestuursorgaanMandatarissen(
       this.args.bestuursorgaan
     );
 
-    for (const mandatarisToAdd of mandatarissenToSyncWith) {
-      const isAlreadyAdded = currentMandatarissen.find(
-        (mandataris) => mandataris.id == mandatarisToAdd.id
-      );
-
-      if (isAlreadyAdded) {
-        continue;
-      }
-
-      const mandaatOfMandatarisToAdd = await mandatarisToAdd.bekleedt;
-
-      const mandaten = await this.args.bestuursorgaan.bevat;
-      mandaten.pushObject(mandaatOfMandatarisToAdd);
-      await mandaten.save();
+    for (const mandataris of currentMandatarissen) {
+      mandataris.destroyRecord();
     }
+
+    // for (const mandatarisToAdd of mandatarissenToSyncAdd) {
+    // }
   });
 
   async getBestuursorgaanMandatarissen(bestuursorgaan) {

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -66,7 +66,48 @@ export default class PrepareLegislatuurSectionComponent extends Component {
     if (!bestuursorgaan) {
       throw `Could not sync`;
     }
+
+    const mandatarissenToSyncWith =
+      await this.getBestuursorgaanMandatarissen(bestuursorgaan);
+    const currentMandatarissen = await this.getBestuursorgaanMandatarissen(
+      this.args.bestuursorgaan
+    );
+
+    for (const possibleMandatarisToAdd of mandatarissenToSyncWith) {
+      const isAlreadyAdded = currentMandatarissen.find(
+        (mandataris) => mandataris.id == possibleMandatarisToAdd.id
+      );
+
+      if (isAlreadyAdded) {
+        continue;
+      }
+    }
   });
+
+  async getBestuursorgaanMandatarissen(bestuursorgaan) {
+    const queryParams = {
+      page: {
+        number: 0,
+        size: 9999,
+      },
+      filter: {
+        bekleedt: {
+          'bevat-in': {
+            id: bestuursorgaan.id,
+          },
+        },
+      },
+      include: [
+        'is-bestuurlijke-alias-van',
+        'bekleedt.bestuursfunctie',
+        'heeft-lidmaatschap.binnen-fractie',
+        'status',
+        'beleidsdomein',
+      ].join(','),
+    };
+
+    return await this.store.query('mandataris', queryParams);
+  }
 
   @action
   cancel() {

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -6,7 +6,10 @@ import { service } from '@ember/service';
 import { getBestuursorganenMetaTtl } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';
 import { buildNewMandatarisSourceTtl } from 'frontend-lmb/utils/build-new-mandataris-source-ttl';
 import { syncNewMandatarisMembership } from 'frontend-lmb/utils/sync-new-mandataris-membership';
-import { BURGEMEESTER_BESTUURSORGAAN_URI } from 'frontend-lmb/utils/well-known-uris';
+import {
+  BURGEMEESTER_BESTUURSORGAAN_URI,
+  RMW_BESTUURSORGAAN_URI,
+} from 'frontend-lmb/utils/well-known-uris';
 
 const CREATE_MODE = 'create';
 
@@ -29,6 +32,12 @@ export default class PrepareLegislatuurSectionComponent extends Component {
   get isBurgemeester() {
     return this.args.bestuursorgaan.hasBestuursorgaanClassificatie(
       BURGEMEESTER_BESTUURSORGAAN_URI
+    );
+  }
+
+  get isRMW() {
+    return this.args.bestuursorgaan.hasBestuursorgaanClassificatie(
+      RMW_BESTUURSORGAAN_URI
     );
   }
 

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -9,6 +9,7 @@ import { syncNewMandatarisMembership } from 'frontend-lmb/utils/sync-new-mandata
 import {
   BURGEMEESTER_BESTUURSORGAAN_URI,
   RMW_BESTUURSORGAAN_URI,
+  VB_BESTUURSORGAAN_URI,
 } from 'frontend-lmb/utils/well-known-uris';
 
 const CREATE_MODE = 'create';
@@ -38,6 +39,11 @@ export default class PrepareLegislatuurSectionComponent extends Component {
   get isRMW() {
     return this.args.bestuursorgaan.hasBestuursorgaanClassificatie(
       RMW_BESTUURSORGAAN_URI
+    );
+  }
+  get isLidVanVB() {
+    return this.args.bestuursorgaan.hasBestuursorgaanClassificatie(
+      VB_BESTUURSORGAAN_URI
     );
   }
 

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { restartableTask } from 'ember-concurrency';
+import { restartableTask, timeout } from 'ember-concurrency';
 import { service } from '@ember/service';
 import { getBestuursorganenMetaTtl } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';
 import { buildNewMandatarisSourceTtl } from 'frontend-lmb/utils/build-new-mandataris-source-ttl';
@@ -209,12 +209,11 @@ export default class PrepareLegislatuurSectionComponent extends Component {
     this.editMode = null;
   }
 
-  @action
-  async onCreate({ instanceTtl, instanceId }) {
+  onCreate = restartableTask(async ({ instanceTtl, instanceId }) => {
     this.editMode = null;
     await syncNewMandatarisMembership(this.store, instanceTtl, instanceId);
-    setTimeout(() => this.router.refresh(), 1000);
-  }
+    await timeout(1000);
+  });
 
   @action
   async buildSourceTtl(instanceUri) {

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -138,10 +138,26 @@ export default class PrepareLegislatuurSectionComponent extends Component {
         });
         await mandaat.save();
       }
+
+      const lidmaatschap = await mandatarisToAdd.heeftLidmaatschap;
+      let newLidmaatschap = null;
+      if (lidmaatschap) {
+        newLidmaatschap = this.store.createRecord('lidmaatschap', {
+          binnenFractie: await lidmaatschap.binnenFractie,
+          lidGedurende: await lidmaatschap.lidGedurende,
+        });
+      }
+
       const newMandataris = await this.createMandatarisFromMandataris(
         mandatarisToAdd,
-        mandaat
+        mandaat,
+        newLidmaatschap
       );
+
+      if (newLidmaatschap) {
+        newLidmaatschap.lid = newMandataris;
+        await newLidmaatschap.save();
+      }
 
       const mandatarissen = await mandaat.bekleedDoor;
       mandatarissen.pushObject(newMandataris);
@@ -149,7 +165,7 @@ export default class PrepareLegislatuurSectionComponent extends Component {
     }
   });
 
-  async createMandatarisFromMandataris(mandataris, mandaat) {
+  async createMandatarisFromMandataris(mandataris, mandaat, lidmaatschap) {
     return this.store.createRecord('mandataris', {
       rangorde: mandataris.rangorde,
       start: mandataris.start,
@@ -159,7 +175,7 @@ export default class PrepareLegislatuurSectionComponent extends Component {
       beleidsdomein: await mandataris.beleidsdomein,
       status: await getEffectiefStatus(this.store),
       publicationStatus: await getDraftPublicationStatus(this.store),
-      heeftLidmaatschap: await mandataris.heeftLidmaatschap,
+      heeftLidmaatschap: lidmaatschap,
     });
   }
 

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -73,14 +73,20 @@ export default class PrepareLegislatuurSectionComponent extends Component {
       this.args.bestuursorgaan
     );
 
-    for (const possibleMandatarisToAdd of mandatarissenToSyncWith) {
+    for (const mandatarisToAdd of mandatarissenToSyncWith) {
       const isAlreadyAdded = currentMandatarissen.find(
-        (mandataris) => mandataris.id == possibleMandatarisToAdd.id
+        (mandataris) => mandataris.id == mandatarisToAdd.id
       );
 
       if (isAlreadyAdded) {
         continue;
       }
+
+      const mandaatOfMandatarisToAdd = await mandatarisToAdd.bekleedt;
+
+      const mandaten = await this.args.bestuursorgaan.bevat;
+      mandaten.pushObject(mandaatOfMandatarisToAdd);
+      await mandaten.save();
     }
   });
 

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -171,17 +171,24 @@ export default class PrepareLegislatuurSectionComponent extends Component {
   });
 
   async createMandatarisFromMandataris(mandataris, mandaat, lidmaatschap) {
-    return this.store.createRecord('mandataris', {
-      rangorde: mandataris.rangorde,
+    let propertiesForMandataris = {
+      rangorde: null,
       start: mandataris.start,
       einde: mandataris.einde,
       bekleedt: mandaat,
       isBestuurlijkeAliasVan: await mandataris.isBestuurlijkeAliasVan,
-      beleidsdomein: await mandataris.beleidsdomein,
+      beleidsdomein: [],
       status: await getEffectiefStatus(this.store),
       publicationStatus: await getDraftPublicationStatus(this.store),
       heeftLidmaatschap: lidmaatschap,
-    });
+    };
+
+    if (!(await this.isLidVanVB)) {
+      propertiesForMandataris.rangorde = mandataris.rangorde;
+      propertiesForMandataris.beleidsdomein = await mandataris.beleidsdomein;
+    }
+
+    return this.store.createRecord('mandataris', propertiesForMandataris);
   }
 
   async getBestuursorgaanMandatarissen(bestuursorgaan) {

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -35,6 +35,8 @@ export default class PrepareLegislatuurSectionComponent extends Component {
   @service router;
 
   @tracked editMode = null;
+  @tracked showRangorde;
+  @tracked showBeleidsDomein;
 
   @action
   createMandataris() {
@@ -61,6 +63,18 @@ export default class PrepareLegislatuurSectionComponent extends Component {
       VAST_BUREAU_BESTUURSORGAAN_URI
     );
   }
+
+  setupTable = restartableTask(async () => {
+    const isCBS = await this.args.bestuursorgaan.hasBestuursorgaanClassificatie(
+      CBS_BESTUURSORGAAN_URI
+    );
+    const isGemeenteraad =
+      await this.args.bestuursorgaan.hasBestuursorgaanClassificatie(
+        GEMEENTERAAD_BESTUURSORGAAN_URI
+      );
+    this.showRangorde = isGemeenteraad || (await this.isRMW) || isCBS;
+    this.showBeleidsDomein = isCBS;
+  });
 
   mirrorTable = restartableTask(async () => {
     const bestuursorganen = this.args.bestuursorganen;

--- a/app/routes/verkiezingen/installatievergadering.js
+++ b/app/routes/verkiezingen/installatievergadering.js
@@ -10,7 +10,7 @@ import {
   CBS_BESTUURSORGAAN_URI,
   GEMEENTERAAD_BESTUURSORGAAN_URI,
   RMW_BESTUURSORGAAN_URI,
-  VB_BESTUURSORGAAN_URI,
+  VAST_BUREAU_BESTUURSORGAAN_URI,
 } from 'frontend-lmb/utils/well-known-uris';
 
 export default class PrepareInstallatievergaderingRoute extends Route {
@@ -88,7 +88,7 @@ export default class PrepareInstallatievergaderingRoute extends Route {
       RMW_BESTUURSORGAAN_URI,
       BURGEMEESTER_BESTUURSORGAAN_URI,
       CBS_BESTUURSORGAAN_URI,
-      VB_BESTUURSORGAAN_URI,
+      VAST_BUREAU_BESTUURSORGAAN_URI,
       BCSD_BESTUURSORGAAN_URI,
     ];
 

--- a/app/templates/verkiezingen/installatievergadering.hbs
+++ b/app/templates/verkiezingen/installatievergadering.hbs
@@ -60,6 +60,7 @@
     {{#each @model.bestuursorganenInTijd as |bestuursorgaan|}}
       <Verkiezingen::PrepareLegislatuurSection
         @bestuursorgaan={{bestuursorgaan}}
+        @bestuursorganen={{@model.bestuursorganenInTijd}}
         @sort={{this.sort}}
         @form={{@model.mandatarisNewForm}}
       />

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -35,7 +35,7 @@ export const BURGEMEESTER_BESTUURSORGAAN_URI =
   'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284';
 export const CBS_BESTUURSORGAAN_URI =
   'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000006';
-export const VB_BESTUURSORGAAN_URI =
+export const VAST_BUREAU_BESTUURSORGAAN_URI =
   'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008';
 export const BCSD_BESTUURSORGAAN_URI =
   'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009';

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -40,6 +40,18 @@ export const VAST_BUREAU_BESTUURSORGAAN_URI =
 export const BCSD_BESTUURSORGAAN_URI =
   'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009';
 
+export const MANDAAT_GEMEENTERAADSLID_CODE =
+  'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000011';
+export const MANDAAT_LID_RMW_CODE =
+  'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000015';
+export const MANDAAT_VOORZITTER_GEMEENTERAAD_CODE =
+  'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000012';
+export const VOORZITTER_RMW_CODE =
+  'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000016';
+export const LID_VAST_BUREAU_CODE =
+  'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000017';
+export const VOORZITTER_VAST_BUREAU_CODE =
+  'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000018';
 export const MANDAAT_BURGEMEESTER_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013';
 export const MANDAAT_DISTRICT_BURGEMEESTER_CODE =


### PR DESCRIPTION
## Description

On the verkiezingen pagina 6 bestuursorganen are shown. Some tables have the ability to sync with another. These syncs are `RMW` with `Gemeenteraad` and `Lid van vast bureau` with `College van Burgemeester en Schepenen`.
When pressing the button there all items in the current table are removed and the table is populated with the other table content

## How to test

Populate `Gemeenteraad tabel` and  `College van Burgemeester en Schepenen` and press sync on the other tables


![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/36266973/4dbed961-ed2b-40fb-9f16-0435a130bfbf)

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/36266973/fb92dc15-d424-4606-9e0b-b916ff449963)

