### PR TITLE
when changing the status of the installatievergadering, move fake ocmw members over to the right graph

### DIFF
--- a/app/controllers/verkiezingen/installatievergadering.js
+++ b/app/controllers/verkiezingen/installatievergadering.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
+import { INSTALLATIVERGADERING_BEHANDELD_STATUS } from 'frontend-lmb/utils/well-known-uris';
 
 export default class VerkiezingenInstallatievergaderingController extends Controller {
   queryParams = ['bestuursperiode'];
@@ -15,6 +16,16 @@ export default class VerkiezingenInstallatievergaderingController extends Contro
     const installatievergadering = this.model.installatievergadering;
     installatievergadering.status = status;
     await installatievergadering.save();
+
+    if (
+      installatievergadering.get('status.uri') ===
+      INSTALLATIVERGADERING_BEHANDELD_STATUS
+    ) {
+      await fetch(
+        `/installatievergadering-api/${installatievergadering.id}/move-ocmw-organs`,
+        { method: 'POST' }
+      );
+    }
   }
 
   @action

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -52,3 +52,6 @@ export const burgemeesterOnlyStates = [
   MANDATARIS_AANGEWEZEN_STATE,
   MANDATARIS_TITELVOEREND_STATE,
 ];
+
+export const INSTALLATIVERGADERING_BEHANDELD_STATUS =
+  'http://data.lblod.info/id/concept/InstallatievergaderingStatus/c9fc3292-1576-4a82-8dcd-60795e22131f';


### PR DESCRIPTION
## Description

when changing the status of the installatievergadering, move fake ocmw members over to the right graph
## How to test

See the linked PR

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/4
