### PR TITLE
Ben/lmb 429 mandataris extra info

### DIFF
--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -51,12 +51,6 @@
           {{/if}}
         </div>
       </div>
-      <div class="au-o-grid__item au-u-5-6">
-        <div class="au-c-description-label"><div>Beleidsdomein(en)</div></div>
-        <div class="au-c-description-value">{{await
-            this.formattedBeleidsdomein
-          }}</div>
-      </div>
       {{#if @mandataris.linkToBesluit}}
         <div class="au-o-grid__item au-u-5-6">
           <div class="au-c-description-label"><div>Link naar besluit</div></div>

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -12,14 +12,4 @@ export default class MandatarisCardComponent extends Component {
       ? this.args.mandataris.heeftLidmaatschap.get('binnenFractie').get('naam')
       : '';
   }
-
-  get formattedBeleidsdomein() {
-    const beleidsdomeinenPromise = this.args.mandataris.beleidsdomein;
-    if (!beleidsdomeinenPromise.length) {
-      return [];
-    }
-    return beleidsdomeinenPromise.then((beleidsdomeinen) => {
-      return beleidsdomeinen.map((item) => item.label).join(', ');
-    });
-  }
 }

--- a/app/components/mandatarissen/mandataris-extra-info-card.hbs
+++ b/app/components/mandatarissen/mandataris-extra-info-card.hbs
@@ -1,0 +1,9 @@
+<div class="au-o-box--small au-u-background-gray-100">
+  <div class="au-o-grid au-o-grid--tiny">
+    <div class="au-o-grid__item au-u-5-6">
+      <div class="au-c-description-label"><div>Beleidsdomein(en)</div></div>
+      <div class="au-c-description-value">{{await this.formattedBeleidsdomein}}
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/mandatarissen/mandataris-extra-info-card.hbs
+++ b/app/components/mandatarissen/mandataris-extra-info-card.hbs
@@ -10,13 +10,19 @@
   </Group>
 </AuToolbar>
 
-<div class="au-o-box--small au-u-background-gray-100">
-  <div class="au-o-grid au-o-grid--tiny">
-    <div class="au-o-grid__item au-u-5-6">
-      <div class="au-c-description-label"><div>Beleidsdomein(en)</div></div>
-      <div class="au-c-description-value">{{await this.formattedBeleidsdomein}}
+<div class="au-o-box au-u-background-gray-100">
+  <div class="au-o-grid au-o-grid--small">
+    {{#if this.hasBeleidsdomeinen}}
+      <div class="au-o-grid__item au-u-5-6">
+        <div class="au-c-description-label"><div>Beleidsdomein(en)</div></div>
+        <div class="au-c-description-value">{{await
+            this.formattedBeleidsdomein
+          }}
+        </div>
       </div>
-    </div>
+    {{else}}
+      Deze mandataris heeft geen velden met bijkomende info.
+    {{/if}}
   </div>
 </div>
 

--- a/app/components/mandatarissen/mandataris-extra-info-card.hbs
+++ b/app/components/mandatarissen/mandataris-extra-info-card.hbs
@@ -6,7 +6,10 @@
     </AuHeading>
   </Group>
   <Group>
-    <AuButton {{on "click" this.toggleModal}}>Bewerk</AuButton>
+    <AuButton
+      {{on "click" this.toggleModal}}
+      @disabled={{not this.hasBeleidsdomeinen}}
+    >Bewerk</AuButton>
   </Group>
 </AuToolbar>
 

--- a/app/components/mandatarissen/mandataris-extra-info-card.hbs
+++ b/app/components/mandatarissen/mandataris-extra-info-card.hbs
@@ -1,3 +1,15 @@
+<AuToolbar @size="large" class="au-u-padding-none au-u-bottom-none" as |Group|>
+
+  <Group>
+    <AuHeading @skin="4">
+      Bijkomende informatie
+    </AuHeading>
+  </Group>
+  <Group>
+    <AuButton {{on "click" this.toggleModal}}>Bewerk</AuButton>
+  </Group>
+</AuToolbar>
+
 <div class="au-o-box--small au-u-background-gray-100">
   <div class="au-o-grid au-o-grid--tiny">
     <div class="au-o-grid__item au-u-5-6">
@@ -7,3 +19,19 @@
     </div>
   </div>
 </div>
+
+<AuModal
+  @title="Bewerk bijkomende info mandataris"
+  @modalOpen={{this.isModalActive}}
+  @closable={{true}}
+  @closeModal={{this.toggleModal}}
+>
+  <div class="au-o-box">
+    <Form::Instance
+      @instanceId={{@mandataris.id}}
+      @form={{@form}}
+      @onCancel={{this.toggleModal}}
+      @onSave={{this.onSave}}
+    />
+  </div>
+</AuModal>

--- a/app/components/mandatarissen/mandataris-extra-info-card.js
+++ b/app/components/mandatarissen/mandataris-extra-info-card.js
@@ -18,6 +18,17 @@ export default class MandatarisExtraInfoCardComponent extends Component {
     });
   }
 
+  get hasBeleidsdomeinen() {
+    if (
+      this.args.mandataris.get('bekleedt').get('isBurgemeester') ||
+      this.args.mandataris.get('bekleedt').get('isSchepen')
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   @action
   toggleModal() {
     this.isModalActive = !this.isModalActive;

--- a/app/components/mandatarissen/mandataris-extra-info-card.js
+++ b/app/components/mandatarissen/mandataris-extra-info-card.js
@@ -1,0 +1,13 @@
+import Component from '@glimmer/component';
+
+export default class MandatarisExtraInfoCardComponent extends Component {
+  get formattedBeleidsdomein() {
+    const beleidsdomeinenPromise = this.args.mandataris.beleidsdomein;
+    if (!beleidsdomeinenPromise.length) {
+      return [];
+    }
+    return beleidsdomeinenPromise.then((beleidsdomeinen) => {
+      return beleidsdomeinen.map((item) => item.label).join(', ');
+    });
+  }
+}

--- a/app/components/mandatarissen/mandataris-extra-info-card.js
+++ b/app/components/mandatarissen/mandataris-extra-info-card.js
@@ -1,6 +1,13 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
 
 export default class MandatarisExtraInfoCardComponent extends Component {
+  @service router;
+
+  @tracked isModalActive = false;
+
   get formattedBeleidsdomein() {
     const beleidsdomeinenPromise = this.args.mandataris.beleidsdomein;
     if (!beleidsdomeinenPromise.length) {
@@ -9,5 +16,16 @@ export default class MandatarisExtraInfoCardComponent extends Component {
     return beleidsdomeinenPromise.then((beleidsdomeinen) => {
       return beleidsdomeinen.map((item) => item.label).join(', ');
     });
+  }
+
+  @action
+  toggleModal() {
+    this.isModalActive = !this.isModalActive;
+  }
+
+  @action
+  onSave() {
+    this.isModalActive = !this.isModalActive;
+    setTimeout(() => this.router.refresh(), 1000);
   }
 }

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -71,20 +71,6 @@
         />
       </div>
     {{/if}}
-    {{#if
-      (or @mandataris.bekleedt.isBurgemeester @mandataris.bekleedt.isSchepen)
-    }}
-      <div>
-        <AuLabel>
-          Beleidsdomeinen
-        </AuLabel>
-        <Mandatarissen::BeleidsdomeinSelectorWithCreate
-          @beleidsdomeinen={{this.selectedBeleidsdomeinen}}
-          @onSelect={{this.updateBeleidsdomeinen}}
-        />
-        <AuHelpText>Enkel voor burgemeester en schepenen</AuHelpText>
-      </div>
-    {{/if}}
     <div>
       <AuLabel>
         Fractie

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -11,7 +11,6 @@ import { burgemeesterOnlyStates } from 'frontend-lmb/utils/well-known-uris';
 export default class MandatarissenUpdateState extends Component {
   @tracked newStatus = null;
   @tracked date = null;
-  @tracked selectedBeleidsdomeinen = [];
   @tracked selectedFractie = null;
   @tracked bestuurseenheid = null;
   @tracked bestuursorganenOfMandaat = [];
@@ -40,7 +39,6 @@ export default class MandatarissenUpdateState extends Component {
   load = task({ drop: true }, async () => {
     this.newStatus = this.args.mandataris.status;
     this.date = new Date();
-    this.selectedBeleidsdomeinen = this.args.mandataris.beleidsdomein.slice();
     this.rangorde = this.args.mandataris.rangorde;
     this.selectedFractie = await (
       await this.args.mandataris.heeftLidmaatschap
@@ -105,35 +103,11 @@ export default class MandatarissenUpdateState extends Component {
     return this.date.getTime() >= this.args.mandataris.start.getTime();
   }
 
-  get hasChangesInBeleidsdomeinen() {
-    if (
-      this.selectedBeleidsdomeinen.length !==
-      this.args.mandataris.beleidsdomein.length
-    ) {
-      return true;
-    }
-
-    // if the length is the same, a difference requires a new item to have been added
-
-    const oldIds = new Set();
-
-    this.args.mandataris.beleidsdomein.forEach((beleidsdomein) => {
-      oldIds.add(beleidsdomein.id);
-    });
-    for (let i = 0; i < this.selectedBeleidsdomeinen.length; i++) {
-      if (!oldIds.has(this.selectedBeleidsdomeinen[i].id)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   get hasChanges() {
     return (
       this.newStatus?.id !== this.args.mandataris.status?.id ||
       this.selectedFractie?.id !==
         this.args.mandataris.get('heeftLidmaatschap.binnenFractie.id') ||
-      this.hasChangesInBeleidsdomeinen ||
       this.rangorde !== this.args.mandataris.rangorde ||
       this.replacementUpdated
     );
@@ -167,7 +141,7 @@ export default class MandatarissenUpdateState extends Component {
       einde: endDate,
       bekleedt: this.args.mandataris.bekleedt,
       isBestuurlijkeAliasVan: this.args.mandataris.isBestuurlijkeAliasVan,
-      beleidsdomein: this.selectedBeleidsdomeinen,
+      beleidsdomein: this.args.mandataris.beleidsdomein,
       status: this.newStatus,
       publicationStatus: await getDraftPublicationStatus(this.store),
       modified: new Date(),
@@ -282,10 +256,6 @@ export default class MandatarissenUpdateState extends Component {
       event.preventDefault();
     }
     this.rangorde = event.target.value;
-  }
-
-  @action updateBeleidsdomeinen(selectedBeleidsdomeinen) {
-    this.selectedBeleidsdomeinen = selectedBeleidsdomeinen;
   }
 
   @action updateFractie(newFractie) {

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { getUniqueVervangers } from 'frontend-lmb/models/mandataris';
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import {

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -2,7 +2,10 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { getUniqueVervangers } from 'frontend-lmb/models/mandataris';
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
-import { MANDATARIS_EDIT_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
+import {
+  MANDATARIS_EDIT_FORM_ID,
+  MANDATARIS_EXTRA_INFO_FORM_ID,
+} from 'frontend-lmb/utils/well-known-ids';
 import RSVP from 'rsvp';
 
 export default class MandatarissenPersoonMandatarisRoute extends Route {
@@ -18,6 +21,10 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
     const mandatarissen = await this.getMandatarissen(persoon, mandaat);
 
     const mandatarisEditForm = getFormFrom(this.store, MANDATARIS_EDIT_FORM_ID);
+    const mandatarisExtraInfoForm = getFormFrom(
+      this.store,
+      MANDATARIS_EXTRA_INFO_FORM_ID
+    );
 
     const bestuursorganen = await (await mandataris.bekleedt).get('bevatIn');
 
@@ -26,6 +33,7 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
       vervangers,
       mandatarissen,
       mandatarisEditForm,
+      mandatarisExtraInfoForm,
       bestuursorganen,
     });
   }

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -27,7 +27,10 @@
   </div>
 
   <div class="au-o-box">
-    <Mandatarissen::MandatarisExtraInfoCard @mandataris={{@model.mandataris}} />
+    <Mandatarissen::MandatarisExtraInfoCard
+      @mandataris={{@model.mandataris}}
+      @form={{@model.mandatarisExtraInfoForm}}
+    />
   </div>
 
   <div class="au-o-box">

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -27,6 +27,10 @@
   </div>
 
   <div class="au-o-box">
+    <Mandatarissen::MandatarisExtraInfoCard @mandataris={{@model.mandataris}} />
+  </div>
+
+  <div class="au-o-box">
     <Mandatarissen::MandatarisEditPrompt
       class="au-c-collapsible au-u-margin-top-small"
       @mandataris={{@model.mandataris}}

--- a/app/utils/well-known-ids.js
+++ b/app/utils/well-known-ids.js
@@ -4,6 +4,7 @@ export const FEMALE_ID = '5ab0e9b8a3b2ca7c5e000029';
 export const FRACTIE_FORM_ID = 'fractie';
 export const MANDAAT_FORM_ID = 'mandaat';
 export const MANDATARIS_EDIT_FORM_ID = 'mandataris-edit';
+export const MANDATARIS_EXTRA_INFO_FORM_ID = 'mandataris-extra-info';
 export const MANDATARIS_NEW_FORM_ID = 'mandataris-new';
 export const CONTACTINFO_FORM_ID = 'contactinfo';
 export const FUNCTIONARIS_CREATE_FORM_ID = 'functionaris-new';


### PR DESCRIPTION
## Description

Add extra component which shows extra info of mandataris (for now only beleidsdomeinen) and has a modal to update this.

![Screenshot 2024-05-17 at 16 00 02](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/43848896/54fc7c31-5b7c-4b2e-b9d6-d28339687af5)
![Screenshot 2024-05-17 at 16 00 08](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/43848896/7a9a75ad-d849-4c56-a06f-8b5553d43c33)
![Screenshot 2024-05-17 at 16 09 29](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/43848896/c9b87f0c-3696-4fd6-b4f1-e3a3392e9a32)

## How to test

Go to a mandataris page and see if the extra info is there and if the form works. Be aware, only burgemeesters and schepenen have beleidsdomeinen.

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/147
