### PR TITLE
extract fold mandatarissen to util, generalize folded fracties component, rework person mandaten page

### DIFF
--- a/app/components/mandaat/folded-fracties.js
+++ b/app/components/mandaat/folded-fracties.js
@@ -17,6 +17,10 @@ export default class MandaatFoldedFractiesComponent extends Component {
     return this.args.bestuursperiode;
   }
 
+  get mandaat() {
+    return this.args.mandaat;
+  }
+
   constructor(...args) {
     super(...args);
     this.load();
@@ -32,21 +36,31 @@ export default class MandaatFoldedFractiesComponent extends Component {
   }
 
   async getMandatarissen(persoon) {
-    return await this.store.query('mandataris', {
+    const options = {
       filter: {
         'is-bestuurlijke-alias-van': {
           ':id:': persoon.id,
         },
-        bekleedt: {
-          'bevat-in': {
-            'heeft-bestuursperiode': {
-              ':id:': this.bestuursperiode.id,
-            },
-          },
-        },
       },
       include: 'heeft-lidmaatschap.binnen-fractie',
-    });
+    };
+
+    if (this.bestuursperiode) {
+      options.filter.bekleedt = {
+        'bevat-in': {
+          'heeft-bestuursperiode': {
+            ':id:': this.bestuursperiode.id,
+          },
+        },
+      };
+    }
+    // mandaat takes precedence over bestuursperiode since it's more specific
+    if (this.mandaat) {
+      options.filter.bekleedt = {
+        ':id:': this.mandaat.id,
+      };
+    }
+    return await this.store.query('mandataris', options);
   }
 
   // Using EmberData get returns undefined even if the relation is loaded

--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -35,7 +35,7 @@
         <div class="au-c-description-label">Fractie</div>
         <div class="au-c-description-value"><Mandaat::FoldedFracties
             @persoon={{this.persoon}}
-            @bestuursperiode={{@bestuursperiode}}
+            @mandaat={{@mandataris.mandaat}}
           /></div>
       </div>
       <div class="au-o-grid__item au-u-1-2 au-u-1-3@medium">

--- a/app/components/organen/mandataris-table.hbs
+++ b/app/components/organen/mandataris-table.hbs
@@ -59,6 +59,7 @@
         <Mandaat::FoldedFracties
           @persoon={{row.mandataris.isBestuurlijkeAliasVan}}
           @bestuursperiode={{@bestuursperiode}}
+          @mandaat={{row.mandataris.bekleedt}}
         />
       </td>
       <td><LinkTo

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -6,8 +6,12 @@ import { inject as service } from '@ember/service';
 export default class MandatarissenPersoonMandatenController extends Controller {
   @service router;
 
+  queryParams = ['activeOnly'];
+
   @tracked isModalOpen = false;
   @tracked selectedBestuursorgaan = null;
+  @tracked activeOnly = true;
+  sort = 'is-bestuurlijke-alias-van.achternaam';
 
   @action
   toggleModal() {
@@ -28,5 +32,10 @@ export default class MandatarissenPersoonMandatenController extends Controller {
       this.selectedBestuursorgaan.id,
       { queryParams: { person: this.model.persoon.id } }
     );
+  }
+
+  @action
+  toggleActiveOnly() {
+    this.activeOnly = !this.activeOnly;
   }
 }

--- a/app/routes/organen/orgaan/mandatarissen.js
+++ b/app/routes/organen/orgaan/mandatarissen.js
@@ -1,8 +1,8 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import moment from 'moment';
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import { MANDATARIS_NEW_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
+import { foldMandatarisses } from 'frontend-lmb/utils/fold-mandatarisses';
 
 export default class OrganenMandatarissenRoute extends Route {
   @service store;
@@ -24,149 +24,18 @@ export default class OrganenMandatarissenRoute extends Route {
 
       mandatarissen = await this.store.query('mandataris', options);
     }
-    const unsorted = await this.foldMandatarissen(mandatarissen);
+    const folded = await foldMandatarisses(params, mandatarissen);
     const mandatarisNewForm = await getFormFrom(
       this.store,
       MANDATARIS_NEW_FORM_ID
     );
 
     return {
-      mandatarissen: this.reSortMandatarissen(params, unsorted),
+      mandatarissen: folded,
       bestuursorgaan: parentModel.bestuursorgaan,
       selectedBestuursperiode: parentModel.selectedBestuursperiode,
       mandatarisNewForm: mandatarisNewForm,
       currentBestuursorgaan: currentBestuursorgaan,
-    };
-  }
-
-  reSortMandatarissen(params, mandatarissen) {
-    const needsResort = ![
-      'start',
-      'einde',
-      'heeft-lidmaatschap.binnen-fractie.naam',
-    ].find((resortKey) => {
-      params.sort.includes(resortKey);
-    });
-    if (!needsResort) {
-      // can trust api to have sorted properly since we haven't recombined these fields in a possibly destructive way
-      return mandatarissen;
-    }
-
-    const getValue = (folded, key) => {
-      if (key.indexOf('heeft-lidmaatschap.binnen-fractie.naam') >= 0) {
-        return folded.mandataris.get('heeftLidmaatschap.binnenFractie.naam');
-      }
-      if (key.indexOf('start') >= 0) {
-        return (
-          folded.foldedStart && moment(folded.foldedStart).format('YYYY-MM-DD')
-        );
-      }
-      if (key.indexOf('einde') >= 0) {
-        return (
-          folded.foldedEnd && moment(folded.foldedEnd).format('YYYY-MM-DD')
-        );
-      }
-      return null;
-    };
-
-    return mandatarissen.sort((a, b) => {
-      const aVal = getValue(a, params.sort);
-      const bVal = getValue(b, params.sort);
-      if (aVal === bVal) {
-        return 0;
-      }
-      let result = 0;
-      if (aVal === null) {
-        result = 1;
-      }
-      if (bVal === null) {
-        result = -1;
-      }
-      if (aVal > bVal) {
-        result = 1;
-      } else {
-        result = -1;
-      }
-
-      if (params.sort.indexOf('-') === 0) {
-        return result * -1;
-      }
-      return result;
-    });
-  }
-
-  async foldMandatarissen(mandatarissen) {
-    // 'persoonId-mandaatId' to foldedMandataris
-    const persoonMandaatData = {};
-    await Promise.all(
-      mandatarissen.map(async (mandataris) => {
-        const personId = (await mandataris.isBestuurlijkeAliasVan).id;
-        const mandaatId = (await mandataris.bekleedt).id;
-        const key = `${personId}-${mandaatId}`;
-        const existing = persoonMandaatData[key];
-
-        if (existing) {
-          this.updateFoldedMandataris(mandataris, existing);
-          return;
-        }
-        persoonMandaatData[key] = this.buildFoldedMandataris(mandataris);
-      })
-    );
-    return Object.values(persoonMandaatData).map(
-      ({ foldedStart, foldedEnd, mandataris }) => {
-        return {
-          foldedStart,
-          foldedEnd,
-          mandataris,
-        };
-      }
-    );
-  }
-
-  updateFoldedMandataris(mandataris, foldedMandataris) {
-    this.updateFoldedStart(mandataris, foldedMandataris);
-    this.updateFoldedEnd(mandataris, foldedMandataris);
-    this.updateMandataris(mandataris, foldedMandataris);
-  }
-
-  updateFoldedStart(mandataris, foldedMandataris) {
-    if (!mandataris.start || !foldedMandataris.foldedStart) {
-      foldedMandataris.foldedStart = null;
-    } else {
-      foldedMandataris.foldedStart = moment.min(
-        moment(foldedMandataris.foldedStart),
-        moment(mandataris.start)
-      );
-    }
-  }
-
-  updateFoldedEnd(mandataris, foldedMandataris) {
-    if (!mandataris.einde || !foldedMandataris.foldedEnd) {
-      foldedMandataris.foldedEnd = null;
-    } else {
-      foldedMandataris.foldedEnd = moment.max(
-        moment(foldedMandataris.foldedEnd),
-        moment(mandataris.einde)
-      );
-    }
-  }
-
-  updateMandataris(mandataris, foldedMandataris) {
-    // Keep the one with the latest end date. If the end date is null,
-    // we assume this is the latest one.
-    if (
-      moment(mandataris.einde).isSame(foldedMandataris.foldedEnd) ||
-      !mandataris.einde
-    ) {
-      foldedMandataris.mandataris = mandataris;
-    }
-  }
-
-  buildFoldedMandataris(mandataris) {
-    return {
-      foldedStart: mandataris.start,
-      foldedEnd: mandataris.einde,
-      mandataris,
     };
   }
 

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -16,51 +16,118 @@
   </Group>
 </AuToolbar>
 <AuHeading @skin="3" class="au-u-regular au-u-padding-left">
-  {{this.model.persoon.naam}}
+  {{@model.persoon.naam}}
 </AuHeading>
 
 <div class="au-c-body-container au-c-body-container--scroll">
-  <div class="au-o-box">
-    <AuHeading @level="3" @skin="4">
-      Huidige mandaten
-    </AuHeading>
-
-    <AuHr />
-
-    <ul class="au-c-list-vertical">
-      {{#each @model.actieveMandatarissen as |mandataris|}}
-        <Mandatarissen::MandatarisSummary @mandataris={{mandataris}} />
-        <AuHr />
-      {{else}}
-        <AuPill @icon="info-circle" class="au-u-margin-bottom">
-          Geen huidige mandaten beschikbaar
-        </AuPill>
-      {{/each}}
-    </ul>
-
-    <AuHeading @level="3" @skin="4">
-      Beëindigde mandaten
-    </AuHeading>
-
-    <AuHr />
-
-    <ul class="au-c-list-vertical">
-      {{#each @model.inactieveMandatarissen as |mandataris|}}
-        <Mandatarissen::MandatarisSummary @mandataris={{mandataris}} />
-        <AuHr />
-      {{else}}
-        <AuPill @icon="info-circle">
-          Geen beëindigde mandaten beschikbaar
-        </AuPill>
-      {{/each}}
-    </ul>
+  <div class="au-u-regular au-u-padding">
+    <AuToggleSwitch
+      @checked={{this.activeOnly}}
+      @onChange={{this.toggleActiveOnly}}
+    >Verberg niet actieve posities</AuToggleSwitch>
 
   </div>
 
-  <div class="au-o-box">
-    <div class="au-u-padding-top-small">
-    </div>
-  </div>
+  <AuDataTable
+    @content={{@model.mandatarissen}}
+    @noDataMessage="Geen mandaten gevonden"
+    @sort={{this.sort}}
+    @page={{this.page}}
+    @size={{this.size}}
+    as |t|
+  >
+    <t.content as |c|>
+      <c.header>
+        <AuDataTableThSortable
+          @field="bekleedt.bevatIn.isTijdsspecialisatieVan.naam"
+          @currentSorting={{this.sort}}
+          @label="Bestuursorgaan"
+        />
+        <AuDataTableThSortable
+          @field="bekleedt.bestuursfunctie.label"
+          @currentSorting={{this.sort}}
+          @label="Mandaat"
+        />
+        <AuDataTableThSortable
+          @field="heeftLidmaatschap.binnenFractie.naam"
+          @currentSorting={{this.sort}}
+          @label="Fractie"
+        />
+        <AuDataTableThSortable
+          @field="start"
+          @currentSorting={{this.sort}}
+          @label="Start mandaat"
+        />
+        <AuDataTableThSortable
+          @field="einde"
+          @currentSorting={{this.sort}}
+          @label="Einde mandaat"
+        />
+        <th>
+          Publicatie Status
+        </th>
+      </c.header>
+
+      <c.body as |row|>
+        <td>
+          {{#each row.mandataris.bekleedt.bevatIn as |orgaan index|}}
+            <LinkTo
+              @route="organen.orgaan"
+              @model={{orgaan.isTijdsspecialisatieVan.id}}
+              class="au-c-link"
+            >
+              {{orgaan.isTijdsspecialisatieVan.naam}}{{if
+                (lt index (sub row.mandataris.bekleedt.bevatIn.length 1))
+                ", "
+                ""
+              }}
+            </LinkTo>
+          {{/each}}
+        </td>
+        <td><LinkTo
+            @route="mandatarissen.persoon.mandataris"
+            @models={{array
+              row.mandataris.isBestuurlijkeAliasVan.id
+              row.mandataris.id
+            }}
+            class="au-c-link"
+          >
+            {{row.mandataris.bekleedt.bestuursfunctie.label}}
+          </LinkTo>
+        </td>
+        <td>
+          <Mandaat::FoldedFracties
+            @persoon={{row.mandataris.isBestuurlijkeAliasVan}}
+            @mandaat={{row.mandataris.bekleedt}}
+          />
+        </td>
+        <td>
+          {{moment-format row.foldedStart "DD-MM-YYYY"}}
+        </td>
+        <td>
+          {{moment-format row.foldedEnd "DD-MM-YYYY"}}
+        </td>
+        <td>
+          <AuPill
+            @skin={{if
+              (or
+                (not row.mandataris.publicationStatus.label)
+                (eq row.mandataris.publicationStatus.label "Bekrachtigd")
+              )
+              "success"
+              "default"
+            }}
+            @draft={{false}}
+            @size="regular"
+            @iconAlignment="left"
+            @hideText={{false}}
+          >
+            {{or row.mandataris.publicationStatus.label "Bekrachtigd"}}
+          </AuPill>
+        </td>
+      </c.body>
+    </t.content>
+  </AuDataTable>
 </div>
 
 <AuModal

--- a/app/utils/fold-mandatarisses.js
+++ b/app/utils/fold-mandatarisses.js
@@ -1,0 +1,134 @@
+import moment from 'moment';
+
+export const foldMandatarisses = async (params, mandatarisses) => {
+  return sort(params, await fold(mandatarisses));
+};
+
+async function fold(mandatarissen) {
+  // 'persoonId-mandaatId' to foldedMandataris
+  const persoonMandaatData = {};
+  await Promise.all(
+    mandatarissen.map(async (mandataris) => {
+      const personId = (await mandataris.isBestuurlijkeAliasVan).id;
+      const mandaatId = (await mandataris.bekleedt).id;
+      const key = `${personId}-${mandaatId}`;
+      const existing = persoonMandaatData[key];
+
+      if (existing) {
+        updateFoldedMandataris(mandataris, existing);
+        return;
+      }
+      persoonMandaatData[key] = buildFoldedMandataris(mandataris);
+    })
+  );
+  return Object.values(persoonMandaatData).map(
+    ({ foldedStart, foldedEnd, mandataris }) => {
+      return {
+        foldedStart,
+        foldedEnd,
+        mandataris,
+      };
+    }
+  );
+}
+
+function sort(params, mandatarissen) {
+  const needsResort = [
+    'start',
+    'einde',
+    'heeft-lidmaatschap.binnen-fractie.naam',
+  ].find((resortKey) => {
+    return params?.sort?.includes(resortKey);
+  });
+  if (!params?.sort || !needsResort) {
+    // can trust api to have sorted properly since we haven't recombined these fields in a possibly destructive way
+    return mandatarissen;
+  }
+
+  const getValue = (folded, key) => {
+    if (key.indexOf('heeft-lidmaatschap.binnen-fractie.naam') >= 0) {
+      return folded.mandataris.get('heeftLidmaatschap.binnenFractie.naam');
+    }
+    if (key.indexOf('start') >= 0) {
+      return (
+        folded.foldedStart && moment(folded.foldedStart).format('YYYY-MM-DD')
+      );
+    }
+    if (key.indexOf('einde') >= 0) {
+      return folded.foldedEnd && moment(folded.foldedEnd).format('YYYY-MM-DD');
+    }
+    return null;
+  };
+
+  return mandatarissen.sort((a, b) => {
+    const aVal = getValue(a, params.sort);
+    const bVal = getValue(b, params.sort);
+    if (aVal === bVal) {
+      return 0;
+    }
+    let result = 0;
+    if (aVal === null) {
+      result = 1;
+    }
+    if (bVal === null) {
+      result = -1;
+    }
+    if (aVal > bVal) {
+      result = 1;
+    } else {
+      result = -1;
+    }
+
+    if (params.sort.indexOf('-') === 0) {
+      return result * -1;
+    }
+    return result;
+  });
+}
+
+function updateFoldedMandataris(mandataris, foldedMandataris) {
+  updateFoldedStart(mandataris, foldedMandataris);
+  updateFoldedEnd(mandataris, foldedMandataris);
+  updateMandataris(mandataris, foldedMandataris);
+}
+
+function buildFoldedMandataris(mandataris) {
+  return {
+    foldedStart: mandataris.start,
+    foldedEnd: mandataris.einde,
+    mandataris,
+  };
+}
+
+function updateFoldedStart(mandataris, foldedMandataris) {
+  if (!mandataris.start || !foldedMandataris.foldedStart) {
+    foldedMandataris.foldedStart = null;
+  } else {
+    foldedMandataris.foldedStart = moment.min(
+      moment(foldedMandataris.foldedStart),
+      moment(mandataris.start)
+    );
+  }
+}
+
+function updateFoldedEnd(mandataris, foldedMandataris) {
+  if (!mandataris.einde || !foldedMandataris.foldedEnd) {
+    foldedMandataris.foldedEnd = null;
+  } else {
+    foldedMandataris.foldedEnd = moment.max(
+      moment(foldedMandataris.foldedEnd),
+      moment(mandataris.einde)
+    );
+  }
+}
+
+function updateMandataris(mandataris, foldedMandataris) {
+  // Keep the one with the latest end date. If the end date is null,
+  // we assume this is the latest one.
+  if (
+    moment(mandataris.einde).isSame(foldedMandataris.foldedEnd) ||
+    !mandataris.einde
+  ) {
+    foldedMandataris.mandataris = mandataris;
+  }
+}


### PR DESCRIPTION


## Description

extract fold mandatarissen to util, generalize folded fracties component, rework person mandaten page

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/1076194/fbb7de4c-e237-4da7-a34e-3b64ce70c5f8)


## How to test

Open the mandates of http://localhost:4200/mandatarissen/ac7c0cec477cc285a64e2ab49dbf472d72552c43caf849a827ac7766b9894282/persoon (chosen because he has many)

sort them by the different fields and toggle showing inactive mandates on and off