### PR TITLE
add temporary mandataris upload route to test uploads

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -44,6 +44,7 @@ Router.map(function () {
       this.route('mandaten');
       this.route('mandataris', { path: '/:mandataris_id/mandataris' });
     });
+    this.route('upload');
   });
 
   this.route('verkiezingen', function () {

--- a/app/routes/mandatarissen/upload.js
+++ b/app/routes/mandatarissen/upload.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class MandatarissenUploadRoute extends Route {}

--- a/app/templates/mandatarissen/upload.hbs
+++ b/app/templates/mandatarissen/upload.hbs
@@ -1,0 +1,4 @@
+{{page-title "Upload"}}
+
+<AuFileUpload @endPoint="/mandataris-api/mandatarissen/upload-csv" />
+{{outlet}}

--- a/tests/unit/routes/mandatarissen/upload-test.js
+++ b/tests/unit/routes/mandatarissen/upload-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-lmb/tests/helpers';
+
+module('Unit | Route | mandatarissen/upload', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:mandatarissen/upload');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
## Description
add temporary mandataris upload route to test uploads
## How to test
manually go to http://localhost:4200/mandatarissen/upload and verify that you can use the endpoint in the linked PR to create person instances