### PR TITLE
LMB 400 - fix vervangers

### DIFF
--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -72,11 +72,11 @@
       </div>
     {{/if}}
 
-    {{#if @vervangers}}
+    {{#if (await this.vervangenen)}}
       <div class="au-o-grid__item au-u-5-6">
         <div class="au-c-description-label"><div>Vervanger van:</div></div>
         <div class="au-c-description-value au-u-margin-top-tiny">
-          {{#each @vervangers as |replaced index|}}
+          {{#each (await this.vervangenen) as |replaced index|}}
             <AuLink
               @route="mandatarissen.mandataris"
               @model={{replaced.id}}
@@ -84,7 +84,7 @@
             >
               {{replaced.isBestuurlijkeAliasVan.gebruikteVoornaam}}
               {{replaced.isBestuurlijkeAliasVan.achternaam}}{{if
-                (lt index (sub @vervangers.length 1))
+                (lt index (sub this.vervangenen.length 1))
                 ","
               }}
             </AuLink>
@@ -92,11 +92,11 @@
         </div>
       </div>
     {{/if}}
-    {{#if @mandataris.tijdelijkeVervangingen}}
+    {{#if (await this.vervangers)}}
       <div class="au-o-grid__item au-u-5-6">
         <div class="au-c-description-label"><div>Vervangen door:</div></div>
         <div class="au-c-description-value">
-          {{#each @mandataris.tijdelijkeVervangingen as |replacement index|}}
+          {{#each (await this.vervangers) as |replacement index|}}
             <AuLink
               @route="mandatarissen.mandataris"
               @model={{replacement.id}}
@@ -104,7 +104,7 @@
             >
               {{replacement.isBestuurlijkeAliasVan.gebruikteVoornaam}}
               {{replacement.isBestuurlijkeAliasVan.achternaam}}{{if
-                (lt index (sub @mandataris.tijdelijkeVervangingen.length 1))
+                (lt index (sub this.vervangers.length 1))
                 ","
               }}
             </AuLink>

--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -72,11 +72,11 @@
       </div>
     {{/if}}
 
-    {{#if (await this.vervangenen)}}
+    {{#if (await this.vervangersVan)}}
       <div class="au-o-grid__item au-u-5-6">
         <div class="au-c-description-label"><div>Vervanger van:</div></div>
         <div class="au-c-description-value au-u-margin-top-tiny">
-          {{#each (await this.vervangenen) as |replaced index|}}
+          {{#each (await this.vervangersVan) as |replaced index|}}
             <AuLink
               @route="mandatarissen.mandataris"
               @model={{replaced.id}}
@@ -84,7 +84,7 @@
             >
               {{replaced.isBestuurlijkeAliasVan.gebruikteVoornaam}}
               {{replaced.isBestuurlijkeAliasVan.achternaam}}{{if
-                (lt index (sub this.vervangenen.length 1))
+                (lt index (sub this.vervangersVan.length 1))
                 ","
               }}
             </AuLink>
@@ -92,11 +92,11 @@
         </div>
       </div>
     {{/if}}
-    {{#if (await this.vervangers)}}
+    {{#if (await this.vervangersDoor)}}
       <div class="au-o-grid__item au-u-5-6">
         <div class="au-c-description-label"><div>Vervangen door:</div></div>
         <div class="au-c-description-value">
-          {{#each (await this.vervangers) as |replacement index|}}
+          {{#each (await this.vervangersDoor) as |replacement index|}}
             <AuLink
               @route="mandatarissen.mandataris"
               @model={{replacement.id}}
@@ -104,7 +104,7 @@
             >
               {{replacement.isBestuurlijkeAliasVan.gebruikteVoornaam}}
               {{replacement.isBestuurlijkeAliasVan.achternaam}}{{if
-                (lt index (sub this.vervangers.length 1))
+                (lt index (sub this.vervangersDoor.length 1))
                 ","
               }}
             </AuLink>

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -14,12 +14,12 @@ export default class MandatarisCardComponent extends Component {
     return this.args.mandataris.isBestuurlijkeAliasVan;
   }
 
-  get vervangers() {
-    return this.args.mandataris.uniqueVervangers;
+  get vervangersDoor() {
+    return this.args.mandataris.uniqueVervangersDoor;
   }
 
-  get vervangenen() {
-    return this.args.mandataris.uniqueVervangenen;
+  get vervangersVan() {
+    return this.args.mandataris.uniqueVervangersVan;
   }
 
   get skinForStatusPill() {

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -14,6 +14,14 @@ export default class MandatarisCardComponent extends Component {
     return this.args.mandataris.isBestuurlijkeAliasVan;
   }
 
+  get vervangers() {
+    return this.args.mandataris.uniqueVervangers;
+  }
+
+  get vervangenen() {
+    return this.args.mandataris.uniqueVervangenen;
+  }
+
   get skinForStatusPill() {
     if (this.status && this.status == 'Effectief') {
       return 'success';

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -163,9 +163,11 @@ export default class MandatarissenUpdateState extends Component {
           this.selectedFractie
         );
       newMandataris.tijdelijkeVervangingen = [replacementMandataris];
-    } else if (this.newStatus.id === VERHINDERD_STATE_ID) {
+    } else {
       newMandataris.tijdelijkeVervangingen =
         (await this.args.mandataris.tijdelijkeVervangingen) || [];
+      newMandataris.vervangerVan =
+        (await this.args.mandataris.vervangerVan) || [];
     }
 
     this.args.mandataris.einde = this.date;

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -92,11 +92,11 @@ export default class MandatarisModel extends Model {
     return false;
   }
 
-  get uniqueVervangers() {
+  get uniqueVervangersDoor() {
     return this.getUnique(this.tijdelijkeVervangingen);
   }
 
-  get uniqueVervangenen() {
+  get uniqueVervangersVan() {
     return this.getUnique(this.vervangerVan);
   }
 

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -92,6 +92,35 @@ export default class MandatarisModel extends Model {
     return false;
   }
 
+  get uniqueVervangers() {
+    return this.getUnique(this.tijdelijkeVervangingen);
+  }
+
+  get uniqueVervangenen() {
+    return this.getUnique(this.vervangerVan);
+  }
+
+  async getUnique(people) {
+    const vervangers = new Map();
+
+    for (let vervanger of people.slice()) {
+      const persoon = await vervanger.isBestuurlijkeAliasVan;
+      if (!vervangers.has(persoon.id)) {
+        vervangers.set(persoon.id, vervanger);
+      } else {
+        const existingVervanger = vervangers.get(persoon.id);
+        const existingEinde = existingVervanger.einde;
+        const newEinde = vervanger.einde;
+
+        // Keep the most recent
+        if (!newEinde || (existingEinde && newEinde > existingEinde)) {
+          vervangers.set(persoon.id, vervanger);
+        }
+      }
+    }
+    return Array.from(vervangers.values());
+  }
+
   async save() {
     const creating = !this.id;
     const result = await super.save(...arguments);
@@ -127,25 +156,3 @@ export async function getUniqueBestuursorganen(mandataris) {
 
   return Array.from(bestuursorganen);
 }
-
-export const getUniqueVervangers = async (mandataris) => {
-  const duplicateVervangers = await mandataris.vervangerVan;
-  const vervangers = new Map();
-
-  for (let vervanger of duplicateVervangers) {
-    const persoon = await vervanger.isBestuurlijkeAliasVan;
-    if (!vervangers.has(persoon.id)) {
-      vervangers.set(persoon.id, vervanger);
-    } else {
-      const existingVervanger = vervangers.get(persoon.id);
-      const existingEinde = existingVervanger.einde;
-      const newEinde = vervanger.einde;
-
-      // Keep the most recent vervanger
-      if (!newEinde || (existingEinde && newEinde > existingEinde)) {
-        vervangers.set(persoon.id, vervanger);
-      }
-    }
-  }
-  return Array.from(vervangers.values());
-};

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import { getUniqueVervangers } from 'frontend-lmb/models/mandataris';
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import {
   MANDATARIS_EDIT_FORM_ID,
@@ -17,7 +16,6 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
 
     const mandataris = await this.getMandataris(params.mandataris_id);
     const mandaat = await mandataris.bekleedt;
-    const vervangers = await getUniqueVervangers(mandataris);
     const mandatarissen = await this.getMandatarissen(persoon, mandaat);
 
     const mandatarisEditForm = getFormFrom(this.store, MANDATARIS_EDIT_FORM_ID);
@@ -32,7 +30,6 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
 
     return RSVP.hash({
       mandataris,
-      vervangers,
       mandatarissen,
       mandatarisEditForm,
       mandatarisExtraInfoForm,

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -47,7 +47,6 @@
   <div class="au-o-box">
     <Mandatarissen::MandatarisCard
       @mandataris={{@model.mandataris}}
-      @vervangers={{@model.vervangers}}
       @bestuursperiode={{@model.selectedBestuursperiode}}
     />
   </div>


### PR DESCRIPTION
## Description

Fix some issues with vervangers and vervangingen, now every mandataris that replaces another mandataris should link to that replacement, and also link to the new mandataris if the replacement is updated. In the mandataris route, it should always show only one replacement, more specifically the latest. Same should be true for the replaced mandataris.

## How to test

Go to the route of a mandataris, make it verhinderd, and then do an update (not corrigeer fouten, update the fractie or something like that) to both the replaced mandataris as the replacement and see they both are only linked to the latest corresponding mandataris. 
