### PR TITLE
LMB-499 recognize toegevoegde schepen as schepen

### DIFF
--- a/app/models/mandaat.js
+++ b/app/models/mandaat.js
@@ -4,6 +4,7 @@ import {
   MANDAAT_DISTRICT_BURGEMEESTER_CODE,
   MANDAAT_DISTRICT_SCHEPEN_CODE,
   MANDAAT_SCHEPEN_CODE,
+  MANDAAT_TOEGEVOEGDE_SCHEPEN_CODE,
 } from 'frontend-lmb/utils/well-known-uris';
 
 const identity = Boolean;
@@ -52,8 +53,10 @@ export default class MandaatModel extends Model {
   }
 
   get isSchepen() {
-    return [MANDAAT_SCHEPEN_CODE, MANDAAT_DISTRICT_SCHEPEN_CODE].includes(
-      this.bestuursfunctie.get('uri')
-    );
+    return [
+      MANDAAT_SCHEPEN_CODE,
+      MANDAAT_DISTRICT_SCHEPEN_CODE,
+      MANDAAT_TOEGEVOEGDE_SCHEPEN_CODE,
+    ].includes(this.bestuursfunctie.get('uri'));
   }
 }

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -58,6 +58,8 @@ export const MANDAAT_DISTRICT_BURGEMEESTER_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001d';
 export const MANDAAT_SCHEPEN_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000014';
+export const MANDAAT_TOEGEVOEGDE_SCHEPEN_CODE =
+  'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/59a90e03-4f22-4bb9-8c91-132618db4b38';
 export const MANDAAT_DISTRICT_SCHEPEN_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001e';
 export const burgemeesterOnlyStates = [


### PR DESCRIPTION
## Description

The mandaat toegevoegde schepen was not recognized as a schepen. 

## How to test

In de bestuurseenheid gemeente Aalst, this route http://localhost:4200/mandatarissen/757d15975fdbbb28147146e84778554682d2446682428233b7a13c900364b81b/persoon/5C3DC0C857753A00090001F3/mandataris should show bevoegdheden en this form should be editable. Which before was not the case.