### PR TITLE
LMB-455: replace all inject as service with service + group imports

### DIFF
--- a/app/components/address/adressenregister-selector.js
+++ b/app/components/address/adressenregister-selector.js
@@ -1,8 +1,10 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
-import { task, timeout } from 'ember-concurrency';
+
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+
+import { task, timeout } from 'ember-concurrency';
 import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
 
 export default class AdressenregisterSelectorComponent extends Component {

--- a/app/components/bestuursperiode-new-button.js
+++ b/app/components/bestuursperiode-new-button.js
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
+
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
+
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import { BESTUURSPERIODE_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 

--- a/app/components/form/cancel-with-confirm.js
+++ b/app/components/form/cancel-with-confirm.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 

--- a/app/components/form/history.js
+++ b/app/components/form/history.js
@@ -1,8 +1,10 @@
 import Component from '@glimmer/component';
+
 import { tracked } from '@glimmer/tracking';
-import { task } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
+
+import { task } from 'ember-concurrency';
 
 export default class FormHistoryComponent extends Component {
   @tracked loading = true;

--- a/app/components/form/instance-table.js
+++ b/app/components/form/instance-table.js
@@ -1,8 +1,9 @@
-import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 
-import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+
 import { JSON_API_TYPE } from 'frontend-lmb/utils/constants';
 
 export default class InstanceTableComponent extends Component {

--- a/app/components/form/instance.js
+++ b/app/components/form/instance.js
@@ -1,6 +1,9 @@
 import Component from '@glimmer/component';
+
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+import { guidFor } from '@ember/object/internals';
 
 import { RDF, FORM } from '../../rdf/namespaces';
 import { NamedNode } from 'rdflib';
@@ -15,11 +18,9 @@ import {
   SOURCE_GRAPH,
   RESOURCE_CACHE_TIMEOUT,
 } from '../../utils/constants';
-import { inject as service } from '@ember/service';
 import { task, timeout } from 'ember-concurrency';
 import { notifyFormSavedSuccessfully } from 'frontend-lmb/utils/toasts';
 import { loadFormInto } from 'frontend-lmb/utils/loadFormInto';
-import { guidFor } from '@ember/object/internals';
 
 export default class InstanceComponent extends Component {
   @service store;

--- a/app/components/form/new-instance.js
+++ b/app/components/form/new-instance.js
@@ -1,6 +1,9 @@
 import Component from '@glimmer/component';
+
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+import { guidFor } from '@ember/object/internals';
 
 import { v4 as uuid } from 'uuid';
 import { RDF, FORM } from '../../rdf/namespaces';
@@ -16,11 +19,9 @@ import {
   SOURCE_GRAPH,
   RESOURCE_CACHE_TIMEOUT,
 } from '../../utils/constants';
-import { inject as service } from '@ember/service';
 import { task, timeout } from 'ember-concurrency';
 import { notifyFormSavedSuccessfully } from 'frontend-lmb/utils/toasts';
 import { loadFormInto } from 'frontend-lmb/utils/loadFormInto';
-import { guidFor } from '@ember/object/internals';
 
 export default class NewInstanceComponent extends Component {
   @service store;

--- a/app/components/form/triple-content.js
+++ b/app/components/form/triple-content.js
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
-import ENV from 'frontend-lmb/config/environment';
+
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+
+import ENV from 'frontend-lmb/config/environment';
 
 export default class FormTripleContentComponent extends Component {
   @tracked expanded = false;

--- a/app/components/global-system-notification.js
+++ b/app/components/global-system-notification.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+
 import config from 'frontend-lmb/config/environment';
 
 export default class GlobalSystemNotification extends Component {

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
+
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+
 import moment from 'moment';
 import {
   getDraftPublicationStatus,

--- a/app/components/mandaat/folded-fracties.js
+++ b/app/components/mandaat/folded-fracties.js
@@ -1,6 +1,8 @@
 import Component from '@glimmer/component';
+
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+
 import { toUserReadableListing } from 'frontend-lmb/utils/to-user-readable-listing';
 import moment from 'moment';
 

--- a/app/components/mandatarissen/beleidsdomein-selector-with-create.js
+++ b/app/components/mandatarissen/beleidsdomein-selector-with-create.js
@@ -1,8 +1,10 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
-import { task, timeout } from 'ember-concurrency';
+
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+
+import { task, timeout } from 'ember-concurrency';
 import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
 import { BELEIDSDOMEIN_CODES_CONCEPT_SCHEME } from 'frontend-lmb/utils/well-known-uris';
 

--- a/app/components/mandatarissen/concept-selector-with-create.js
+++ b/app/components/mandatarissen/concept-selector-with-create.js
@@ -1,7 +1,8 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
-import { guidFor } from '@ember/object/internals';
+
+import { service } from '@ember/service';
 import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
 
 export default class ConceptSelectorWithCreateComponent extends Component {
   inputId = 'select-' + guidFor(this);

--- a/app/components/mandatarissen/fractie-selector.js
+++ b/app/components/mandatarissen/fractie-selector.js
@@ -1,8 +1,10 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
-import { task, timeout } from 'ember-concurrency';
+
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+
+import { task, timeout } from 'ember-concurrency';
 import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
 import { FRACTIETYPE_ONAFHANKELIJK } from 'frontend-lmb/utils/well-known-uris';
 

--- a/app/components/mandatarissen/history.js
+++ b/app/components/mandatarissen/history.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
+
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class MandatarisHistoryComponent extends Component {

--- a/app/components/mandatarissen/mandataris-extra-info-card.js
+++ b/app/components/mandatarissen/mandataris-extra-info-card.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';

--- a/app/components/mandatarissen/mandataris-summary.js
+++ b/app/components/mandatarissen/mandataris-summary.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+
 import { restartableTask } from 'ember-concurrency';
 
 export default class MandatenbeheerMandatarisSummaryComponent extends Component {

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -1,5 +1,6 @@
-import { action } from '@ember/object';
 import Component from '@glimmer/component';
+
+import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 

--- a/app/components/mandatarissen/mandaten-as-links.js
+++ b/app/components/mandatarissen/mandaten-as-links.js
@@ -1,8 +1,9 @@
 import Component from '@glimmer/component';
 
 import { A } from '@ember/array';
-import { restartableTask } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
+
+import { restartableTask } from 'ember-concurrency';
 import { foldMandatarisses } from 'frontend-lmb/utils/fold-mandatarisses';
 
 export default class MandatarissenMandatenAsLinks extends Component {

--- a/app/components/mandatarissen/replacement-select.js
+++ b/app/components/mandatarissen/replacement-select.js
@@ -1,8 +1,10 @@
 import Component from '@glimmer/component';
+
 import { action } from '@ember/object';
-import { task } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+
+import { task } from 'ember-concurrency';
 
 export default class MandatarissenReplacementComponent extends Component {
   @service mandataris;

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -1,8 +1,10 @@
 import Component from '@glimmer/component';
+
 import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
 import { VERHINDERD_STATE_ID } from 'frontend-lmb/utils/well-known-ids';
 import { getDraftPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';

--- a/app/components/mandatenbeheer/bestuursorgaan-mandaten.js
+++ b/app/components/mandatenbeheer/bestuursorgaan-mandaten.js
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+
 import { task } from 'ember-concurrency';
 
 export default class MandatenbeheerBestuursorgaanMandatenComponent extends Component {

--- a/app/components/mandatenbeheer/mandaat-bestuursorganen-selector.js
+++ b/app/components/mandatenbeheer/mandaat-bestuursorganen-selector.js
@@ -1,7 +1,8 @@
 import Component from '@glimmer/component';
+
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MandaatBestuursorganenSelector extends Component {
   @service store;

--- a/app/components/person/search-form-pagination.js
+++ b/app/components/person/search-form-pagination.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+
 import { action } from '@ember/object';
 
 export default class PersoonSearchFormPagination extends Component {

--- a/app/components/person/search-form.js
+++ b/app/components/person/search-form.js
@@ -1,9 +1,11 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
-import { task, timeout } from 'ember-concurrency';
+
+import { service } from '@ember/service';
 import { A } from '@ember/array';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+
+import { task, timeout } from 'ember-concurrency';
 
 export default class SharedPersoonPersoonSearchFormComponent extends Component {
   @service store;

--- a/app/components/person/search-result.js
+++ b/app/components/person/search-result.js
@@ -1,7 +1,8 @@
 import Component from '@glimmer/component';
+
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SharedPersoonPersoonSearchResultComponent extends Component {
   @service currentSession;

--- a/app/components/person/selector.js
+++ b/app/components/person/selector.js
@@ -1,10 +1,12 @@
+import Component from '@glimmer/component';
+
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
+
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import { CREATE_PERSON_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
-import Component from '@glimmer/component';
 
 export default class PersonSelectorComponent extends Component {
   inputId = 'input-' + guidFor(this);

--- a/app/components/rdf-input-fields/address-selector.js
+++ b/app/components/rdf-input-fields/address-selector.js
@@ -1,9 +1,11 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
-import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
-import { triplesForPath } from '@lblod/submission-form-helpers';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
+
+import { triplesForPath } from '@lblod/submission-form-helpers';
 import { NamedNode } from 'rdflib';
 import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
 

--- a/app/components/rdf-input-fields/archived-input.js
+++ b/app/components/rdf-input-fields/archived-input.js
@@ -1,8 +1,10 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
 

--- a/app/components/rdf-input-fields/beleidsdomein-code-selector.js
+++ b/app/components/rdf-input-fields/beleidsdomein-code-selector.js
@@ -1,12 +1,14 @@
 import RdfInputFieldsConceptSchemeMultiSelectorWithCreateComponent from './concept-scheme-multi-selector-with-create';
+
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
 import {
   triplesForPath,
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
 import { ORG } from 'frontend-lmb/rdf/namespaces';
-import { inject as service } from '@ember/service';
 import { getByUri } from 'frontend-lmb/utils/get-by-uri';
-import { tracked } from '@glimmer/tracking';
 
 export default class RdfBeleidsdomeinCodeSelector extends RdfInputFieldsConceptSchemeMultiSelectorWithCreateComponent {
   @service store;

--- a/app/components/rdf-input-fields/concept-scheme-multi-selector-with-create.js
+++ b/app/components/rdf-input-fields/concept-scheme-multi-selector-with-create.js
@@ -1,6 +1,8 @@
-import { action } from '@ember/object';
-import { NamedNode } from 'rdflib';
 import RdfInputFieldsConceptSchemeMultiSelectorComponent from './concept-scheme-multi-selector';
+
+import { action } from '@ember/object';
+
+import { NamedNode } from 'rdflib';
 
 export default class RdfInputFieldsConceptSchemeMultiSelectorWithCreateComponent extends RdfInputFieldsConceptSchemeMultiSelectorComponent {
   @action

--- a/app/components/rdf-input-fields/concept-scheme-multi-selector.js
+++ b/app/components/rdf-input-fields/concept-scheme-multi-selector.js
@@ -1,9 +1,11 @@
+import ConceptSchemeSelectorComponent from './concept-selector';
+
 import { action } from '@ember/object';
+
 import {
   triplesForPath,
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
-import ConceptSchemeSelectorComponent from './concept-selector';
 
 export default class RdfInputFieldsConceptSchemeMultiSelectorComponent extends ConceptSchemeSelectorComponent {
   async loadProvidedValue() {

--- a/app/components/rdf-input-fields/concept-scheme-selector-with-create.js
+++ b/app/components/rdf-input-fields/concept-scheme-selector-with-create.js
@@ -1,6 +1,8 @@
-import { action } from '@ember/object';
-import { NamedNode } from 'rdflib';
 import RdfInputFieldsConceptSchemeSelectorComponent from './concept-scheme-selector';
+
+import { action } from '@ember/object';
+
+import { NamedNode } from 'rdflib';
 
 export default class RdfInputFieldsConceptSchemeSelectorWithCreateComponent extends RdfInputFieldsConceptSchemeSelectorComponent {
   @action

--- a/app/components/rdf-input-fields/concept-scheme-selector.js
+++ b/app/components/rdf-input-fields/concept-scheme-selector.js
@@ -1,9 +1,11 @@
+import ConceptSchemeSelectorComponent from './concept-selector';
+
 import { action } from '@ember/object';
+
 import {
   triplesForPath,
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
-import ConceptSchemeSelectorComponent from './concept-selector';
 
 export default class RdfInputFieldsConceptSchemeSelectorComponent extends ConceptSchemeSelectorComponent {
   async loadProvidedValue() {

--- a/app/components/rdf-input-fields/concept-selector.js
+++ b/app/components/rdf-input-fields/concept-selector.js
@@ -1,8 +1,10 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
-import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import { service } from '@ember/service';
+
 import { NamedNode } from 'rdflib';
 import { hasValidFieldOptions } from '@lblod/ember-submission-form-fields/utils/has-valid-field-options';
 import { task, timeout } from 'ember-concurrency';

--- a/app/components/rdf-input-fields/instance-multi-selector.js
+++ b/app/components/rdf-input-fields/instance-multi-selector.js
@@ -1,9 +1,11 @@
+import SelectorComponent from './selector';
+
 import { action } from '@ember/object';
+
 import {
   triplesForPath,
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
-import SelectorComponent from './selector';
 
 export default class RdfInstanceMultiSelectorComponent extends SelectorComponent {
   async loadProvidedValue() {

--- a/app/components/rdf-input-fields/instance-selector.js
+++ b/app/components/rdf-input-fields/instance-selector.js
@@ -1,9 +1,11 @@
+import SelectorComponent from './selector';
+
 import { action } from '@ember/object';
+
 import {
   updateSimpleFormValue,
   triplesForPath,
 } from '@lblod/submission-form-helpers';
-import SelectorComponent from './selector';
 
 export default class RdfInstanceSelectorComponent extends SelectorComponent {
   async loadProvidedValue() {

--- a/app/components/rdf-input-fields/mandataris-fractie-selector.js
+++ b/app/components/rdf-input-fields/mandataris-fractie-selector.js
@@ -1,9 +1,11 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
-import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
-import { triplesForPath } from '@lblod/submission-form-helpers';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
+
+import { triplesForPath } from '@lblod/submission-form-helpers';
 import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
 import { NamedNode } from 'rdflib';
 import { loadBestuursorgaanUrisFromContext } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';

--- a/app/components/rdf-input-fields/mandataris-mandaat-selector.js
+++ b/app/components/rdf-input-fields/mandataris-mandaat-selector.js
@@ -1,10 +1,12 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
-import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
-import { triplesForPath } from '@lblod/submission-form-helpers';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
+
 import { NamedNode } from 'rdflib';
+import { triplesForPath } from '@lblod/submission-form-helpers';
 import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
 import { loadBestuursorgaanUrisFromContext } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';
 

--- a/app/components/rdf-input-fields/mandataris-rangorde.js
+++ b/app/components/rdf-input-fields/mandataris-rangorde.js
@@ -1,8 +1,10 @@
-import { inject as service } from '@ember/service';
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 import { guidFor } from '@ember/object/internals';
+
 import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
 import { ORG } from 'frontend-lmb/rdf/namespaces';
 import { getByUri } from 'frontend-lmb/utils/get-by-uri';

--- a/app/components/rdf-input-fields/mandataris-replacement-selector.js
+++ b/app/components/rdf-input-fields/mandataris-replacement-selector.js
@@ -1,8 +1,10 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+
 import {
   triplesForPath,
   updateSimpleFormValue,

--- a/app/components/rdf-input-fields/mandataris-status-selector.js
+++ b/app/components/rdf-input-fields/mandataris-status-selector.js
@@ -1,9 +1,11 @@
+import RdfInputFieldsConceptSchemeSelectorComponent from './concept-scheme-selector';
+
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+
 import { queryRecord } from 'frontend-lmb/utils/query-record';
 import { burgemeesterOnlyStates } from 'frontend-lmb/utils/well-known-uris';
-import { tracked } from '@glimmer/tracking';
 import { ORG } from 'frontend-lmb/rdf/namespaces';
-import { service } from '@ember/service';
-import RdfInputFieldsConceptSchemeSelectorComponent from './concept-scheme-selector';
 
 export default class RdfInputFieldsMandatarisStatusSelectorComponent extends RdfInputFieldsConceptSchemeSelectorComponent {
   @service store;

--- a/app/components/rdf-input-fields/person-selector.js
+++ b/app/components/rdf-input-fields/person-selector.js
@@ -1,9 +1,11 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
-import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
-import { triplesForPath } from '@lblod/submission-form-helpers';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
+
+import { triplesForPath } from '@lblod/submission-form-helpers';
 import { NamedNode } from 'rdflib';
 import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
 

--- a/app/components/rdf-input-fields/rijksregister-input.js
+++ b/app/components/rdf-input-fields/rijksregister-input.js
@@ -1,8 +1,10 @@
-import { inject as service } from '@ember/service';
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 import { guidFor } from '@ember/object/internals';
+
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
 

--- a/app/components/rdf-input-fields/selector.js
+++ b/app/components/rdf-input-fields/selector.js
@@ -1,7 +1,9 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
-import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+
 import { task, timeout } from 'ember-concurrency';
 import { NamedNode } from 'rdflib';
 import { ACCEPT_HEADER, SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';

--- a/app/components/shared/compact-menu.js
+++ b/app/components/shared/compact-menu.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class SharedCompactMenuComponent extends Component {
-  @service() currentSession;
+  @service currentSession;
 }

--- a/app/components/shared/contact-form.js
+++ b/app/components/shared/contact-form.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+
 import { tracked } from '@glimmer/tracking';
 
 export default class ContactFormComponent extends Component {

--- a/app/components/shared/installatievergadering-status-selector.js
+++ b/app/components/shared/installatievergadering-status-selector.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 

--- a/app/components/shared/main-menu.js
+++ b/app/components/shared/main-menu.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class SharedMainMenuComponent extends Component {
-  @service() currentSession;
+  @service currentSession;
 }

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -1,8 +1,9 @@
 import Component from '@glimmer/component';
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+
 import { orderMandatarissenByRangorde } from 'frontend-lmb/utils/rangorde';
 
 export default class DraftMandatarisListComponent extends Component {

--- a/app/components/verkiezingen/kieslijst-splitter.js
+++ b/app/components/verkiezingen/kieslijst-splitter.js
@@ -1,9 +1,11 @@
 import Component from '@glimmer/component';
+
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
-import { FRACTIETYPE_SAMENWERKINGSVERBAND } from 'frontend-lmb/utils/well-known-uris';
 import { A } from '@ember/array';
+
+import { FRACTIETYPE_SAMENWERKINGSVERBAND } from 'frontend-lmb/utils/well-known-uris';
 
 export default class KieslijstSplitterComponent extends Component {
   @service store;

--- a/app/controllers/contact.js
+++ b/app/controllers/contact.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class ContactController extends Controller {
-  @service() session;
+  @service session;
 }

--- a/app/controllers/forms/form/instance.js
+++ b/app/controllers/forms/form/instance.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
+
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class FormInstanceController extends Controller {
   @service router;

--- a/app/controllers/forms/form/instances.js
+++ b/app/controllers/forms/form/instances.js
@@ -1,7 +1,9 @@
 import Controller from '@ember/controller';
+
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+
 import { task, timeout } from 'ember-concurrency';
 import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
 

--- a/app/controllers/forms/form/new.js
+++ b/app/controllers/forms/form/new.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
+
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class FormNewController extends Controller {
   @service router;

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class IndexController extends Controller {
   @service currentSession;

--- a/app/controllers/leidinggevenden/bestuursfunctie/contact-info.js
+++ b/app/controllers/leidinggevenden/bestuursfunctie/contact-info.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
+
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LeidinggevendenBestuursfunctieContactInfoController extends Controller {
   @service router;

--- a/app/controllers/leidinggevenden/bestuursfunctie/functionarissen/edit.js
+++ b/app/controllers/leidinggevenden/bestuursfunctie/functionarissen/edit.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class LeidinggevendenBestuursfunctieFunctionarissenEditController extends Controller {

--- a/app/controllers/leidinggevenden/bestuursfunctie/functionarissen/index.js
+++ b/app/controllers/leidinggevenden/bestuursfunctie/functionarissen/index.js
@@ -1,9 +1,10 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class LeidinggevendenBestuursfunctieFunctionarissenIndexController extends Controller {
-  @service() router;
+  @service router;
 
   sort = 'start';
   @tracked page = 0;

--- a/app/controllers/leidinggevenden/bestuursfunctie/functionarissen/new.js
+++ b/app/controllers/leidinggevenden/bestuursfunctie/functionarissen/new.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
+
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LeidinggevendenBestuursfunctieFunctionarissenNewIndexController extends Controller {
   @service router;

--- a/app/controllers/leidinggevenden/index.js
+++ b/app/controllers/leidinggevenden/index.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class LeidinggevendenIndexController extends Controller {
   @service router;

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -1,7 +1,8 @@
 import Controller from '@ember/controller';
+
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MandatarissenPersoonMandatenController extends Controller {
   @service router;

--- a/app/controllers/mock-login.js
+++ b/app/controllers/mock-login.js
@@ -1,6 +1,8 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+
 import { task, timeout } from 'ember-concurrency';
 
 export default class MockLoginController extends Controller {

--- a/app/controllers/organen/orgaan/index.js
+++ b/app/controllers/organen/orgaan/index.js
@@ -1,7 +1,8 @@
 import Controller from '@ember/controller';
+
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OrganenOrgaanIndexController extends Controller {
   @service router;

--- a/app/controllers/organen/orgaan/mandataris/new.js
+++ b/app/controllers/organen/orgaan/mandataris/new.js
@@ -1,7 +1,9 @@
 import Controller from '@ember/controller';
+
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
+
 import { getBestuursorganenMetaTtl } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';
 import { buildNewMandatarisSourceTtl } from 'frontend-lmb/utils/build-new-mandataris-source-ttl';
 import { syncNewMandatarisMembership } from 'frontend-lmb/utils/sync-new-mandataris-membership';

--- a/app/controllers/verkiezingen/verkiezingsuitslag.js
+++ b/app/controllers/verkiezingen/verkiezingsuitslag.js
@@ -1,7 +1,9 @@
 import Controller from '@ember/controller';
-import { task, timeout } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+
+import { task, timeout } from 'ember-concurrency';
 import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
 
 export default class VerkiezingenVerkiezingsuitslagController extends Controller {

--- a/app/models/bestuursfunctie-code.js
+++ b/app/models/bestuursfunctie-code.js
@@ -1,4 +1,5 @@
 import Model, { attr } from '@ember-data/model';
+
 import {
   BESTUURSFUNCTIE_CODE_BURGEMEESTER,
   BESTUURSFUNCTIE_CODE_LEIDINGGEVEND_AMBTENAAR,

--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -1,5 +1,7 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import { queryRecord } from 'frontend-lmb/utils/query-record';
 
 /**

--- a/app/models/bestuursperiode.js
+++ b/app/models/bestuursperiode.js
@@ -1,5 +1,6 @@
-import { attr, hasMany } from '@ember-data/model';
 import ConceptModel from './concept';
+
+import { attr, hasMany } from '@ember-data/model';
 
 export default class BestuursperiodeModel extends ConceptModel {
   @attr('number') start;

--- a/app/models/form-definition.js
+++ b/app/models/form-definition.js
@@ -1,5 +1,4 @@
-import Model from '@ember-data/model';
-import { attr } from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
 export default class FormDefinitionModel extends Model {
   @attr('string')

--- a/app/models/fractietype.js
+++ b/app/models/fractietype.js
@@ -1,4 +1,5 @@
 import Model, { attr } from '@ember-data/model';
+
 import {
   FRACTIETYPE_ONAFHANKELIJK,
   FRACTIETYPE_SAMENWERKINGSVERBAND,

--- a/app/models/geslacht-code.js
+++ b/app/models/geslacht-code.js
@@ -1,4 +1,5 @@
 import Model, { attr } from '@ember-data/model';
+
 import { MALE_ID } from 'frontend-lmb/utils/well-known-ids';
 
 export default class GeslachtCodeModel extends Model {

--- a/app/models/installatievergadering.js
+++ b/app/models/installatievergadering.js
@@ -1,4 +1,5 @@
 import Model, { belongsTo } from '@ember-data/model';
+
 import { INSTALLATIEVERGADERING_TE_BEHANDELEN } from 'frontend-lmb/utils/well-known-ids';
 
 export default class InstallatievergaderingModel extends Model {

--- a/app/models/mandaat.js
+++ b/app/models/mandaat.js
@@ -1,4 +1,5 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+
 import {
   MANDAAT_BURGEMEESTER_CODE,
   MANDAAT_DISTRICT_BURGEMEESTER_CODE,

--- a/app/models/mandataris-publication-status-code.js
+++ b/app/models/mandataris-publication-status-code.js
@@ -1,4 +1,5 @@
 import Model, { attr } from '@ember-data/model';
+
 import { MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE } from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarisPublicationStatusCodeModel extends Model {

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -1,4 +1,5 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+
 import moment from 'moment';
 import { MANDATARIS_EDIT_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import { JSON_API_TYPE } from 'frontend-lmb/utils/constants';

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,6 +1,8 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 import { warn } from '@ember/debug';
+
 import ENV from 'frontend-lmb/config/environment';
 import 'moment';
 import 'moment-timezone';

--- a/app/routes/auth/callback.js
+++ b/app/routes/auth/callback.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class AuthCallbackRoute extends Route {
   @service session;

--- a/app/routes/auth/login.js
+++ b/app/routes/auth/login.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import ENV from 'frontend-lmb/config/environment';
 
 export default class AuthLoginRoute extends Route {

--- a/app/routes/auth/logout.js
+++ b/app/routes/auth/logout.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import ENV from 'frontend-lmb/config/environment';
 
 export default class AuthLogoutRoute extends Route {

--- a/app/routes/auth/switch.js
+++ b/app/routes/auth/switch.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import ENV from 'frontend-lmb/config/environment';
 
 export default class AuthSwitchRoute extends Route {

--- a/app/routes/forms.js
+++ b/app/routes/forms.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class FormsRoute extends Route {
   @service session;

--- a/app/routes/forms/form.js
+++ b/app/routes/forms/form.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 
 export default class FormRoute extends Route {

--- a/app/routes/forms/form/instance.js
+++ b/app/routes/forms/form/instance.js
@@ -1,8 +1,10 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class FormInstanceRoute extends Route {
   @service store;
+
   async model(params) {
     const formModel = this.modelFor('forms.form');
     return { form: formModel, instanceId: params.instance_id };

--- a/app/routes/forms/form/new.js
+++ b/app/routes/forms/form/new.js
@@ -1,8 +1,10 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class FormNewRoute extends Route {
   @service store;
+
   async model() {
     const formModel = this.modelFor('forms.form');
     return { formDefinition: formModel };

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
   @service session;

--- a/app/routes/leidinggevenden.js
+++ b/app/routes/leidinggevenden.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class LeidinggevendenRoute extends Route {
   @service session;

--- a/app/routes/leidinggevenden/bestuursfunctie.js
+++ b/app/routes/leidinggevenden/bestuursfunctie.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import { BESTUURSEENHEID_CLASSIFICATIECODE_OCMW } from 'frontend-lmb/utils/well-known-uris';
 
 export default class LeidinggevendenBestuursfunctieRoute extends Route {

--- a/app/routes/leidinggevenden/bestuursfunctie/contact-info.js
+++ b/app/routes/leidinggevenden/bestuursfunctie/contact-info.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import { CONTACTINFO_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 

--- a/app/routes/leidinggevenden/bestuursfunctie/functionarissen/edit.js
+++ b/app/routes/leidinggevenden/bestuursfunctie/functionarissen/edit.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import { FUNCTIONARIS_EDIT_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 

--- a/app/routes/leidinggevenden/bestuursfunctie/functionarissen/index.js
+++ b/app/routes/leidinggevenden/bestuursfunctie/functionarissen/index.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import { BESTUURSEENHEID_CLASSIFICATIECODE_OCMW } from 'frontend-lmb/utils/well-known-uris';
 
 export default class LeidinggevendenBestuursfunctieFunctionarissenIndexRoute extends Route {

--- a/app/routes/leidinggevenden/bestuursfunctie/functionarissen/new.js
+++ b/app/routes/leidinggevenden/bestuursfunctie/functionarissen/new.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import { FUNCTIONARIS_CREATE_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 

--- a/app/routes/leidinggevenden/index.js
+++ b/app/routes/leidinggevenden/index.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import { BESTUURSEENHEID_CLASSIFICATIECODE_OCMW } from 'frontend-lmb/utils/well-known-uris';
 
 export default class LeidinggevendenBestuursfunctiesIndexRoute extends Route {

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -1,8 +1,9 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class LoginRoute extends Route {
-  @service() session;
+  @service session;
 
   beforeModel() {
     this.session.prohibitAuthentication('index');

--- a/app/routes/mandatarissen/mandataris.js
+++ b/app/routes/mandatarissen/mandataris.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import RSVP from 'rsvp';
 
 export default class MandatarissenPersoonMandatarisRoute extends Route {

--- a/app/routes/mandatarissen/persoon.js
+++ b/app/routes/mandatarissen/persoon.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class MandatarissenPersoonRoute extends Route {
   @service store;

--- a/app/routes/mandatarissen/persoon/index.js
+++ b/app/routes/mandatarissen/persoon/index.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class MandatarissenPersoonIndexRoute extends Route {
   @service store;

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
+
 import { service } from '@ember/service';
+
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import {
   MANDATARIS_EDIT_FORM_ID,

--- a/app/routes/mandatarissen/persoon/mandaten.js
+++ b/app/routes/mandatarissen/persoon/mandaten.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import { foldMandatarisses } from 'frontend-lmb/utils/fold-mandatarisses';
 import moment from 'moment';
 

--- a/app/routes/mock-login.js
+++ b/app/routes/mock-login.js
@@ -1,9 +1,10 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class MockLoginRoute extends Route {
-  @service() session;
-  @service() store;
+  @service session;
+  @service store;
 
   queryParams = {
     page: {

--- a/app/routes/organen.js
+++ b/app/routes/organen.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import RSVP from 'rsvp';
 
 export default class OrganenRoute extends Route {

--- a/app/routes/organen/fracties.js
+++ b/app/routes/organen/fracties.js
@@ -1,6 +1,8 @@
 import Route from '@ember/routing/route';
+
 import { service } from '@ember/service';
 import { action } from '@ember/object';
+
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import { FRACTIE_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import { FRACTIETYPE_SAMENWERKINGSVERBAND } from 'frontend-lmb/utils/well-known-uris';

--- a/app/routes/organen/index.js
+++ b/app/routes/organen/index.js
@@ -1,6 +1,8 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 import { action } from '@ember/object';
+
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import { BESTUURSORGAAN_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import RSVP from 'rsvp';

--- a/app/routes/organen/orgaan.js
+++ b/app/routes/organen/orgaan.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import { queryRecord } from 'frontend-lmb/utils/query-record';
 import RSVP from 'rsvp';
 

--- a/app/routes/organen/orgaan/index.js
+++ b/app/routes/organen/orgaan/index.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import { BESTUURSORGAAN_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import { INSTALLATIVERGADERING_BEHANDELD_STATUS } from 'frontend-lmb/utils/well-known-uris';

--- a/app/routes/organen/orgaan/mandataris/new.js
+++ b/app/routes/organen/orgaan/mandataris/new.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import { MANDATARIS_NEW_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import RSVP from 'rsvp';

--- a/app/routes/organen/orgaan/mandatarissen.js
+++ b/app/routes/organen/orgaan/mandatarissen.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
+
 import { service } from '@ember/service';
+
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import { MANDATARIS_NEW_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import { foldMandatarisses } from 'frontend-lmb/utils/fold-mandatarisses';

--- a/app/routes/switch-login.js
+++ b/app/routes/switch-login.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 // This route is only needed because ACM/IDM is configured to redirect to it when switching users.
 // We would need to change the configuration before we can remove it, otherwise we see a "bad request" error message.

--- a/app/routes/verkiezingen.js
+++ b/app/routes/verkiezingen.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import { BESTUURSEENHEID_CLASSIFICATIECODE_GEMEENTE } from 'frontend-lmb/utils/well-known-uris';
 
 export default class VerkiezingenRoute extends Route {

--- a/app/routes/verkiezingen/installatievergadering.js
+++ b/app/routes/verkiezingen/installatievergadering.js
@@ -1,7 +1,8 @@
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
 
 import { service } from '@ember/service';
+
+import RSVP from 'rsvp';
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import { MANDATARIS_NEW_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import {

--- a/app/routes/verkiezingen/verkiezingsuitslag.js
+++ b/app/routes/verkiezingen/verkiezingsuitslag.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class VerkiezingenVerkiezingsuitslagRoute extends Route {

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,6 +1,7 @@
+import JSONAPISerializer from '@ember-data/serializer/json-api';
+
 /* eslint-disable ember/no-mixins */
 import DataTableSerializerMixin from 'ember-data-table/mixins/serializer';
-import JSONAPISerializer from '@ember-data/serializer/json-api';
 
 export default class ApplicationSerializer extends JSONAPISerializer.extend(
   DataTableSerializerMixin

--- a/app/services/addressregister.js
+++ b/app/services/addressregister.js
@@ -1,4 +1,5 @@
 import Service from '@ember/service';
+
 import fetch from 'fetch';
 
 class AddressSuggestion {

--- a/app/services/bestuursorganen.js
+++ b/app/services/bestuursorganen.js
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class BestuursorganenService extends Service {
   @service store;

--- a/app/services/bestuursperioden.js
+++ b/app/services/bestuursperioden.js
@@ -1,4 +1,5 @@
 import Service from '@ember/service';
+
 import { service } from '@ember/service';
 
 export default class BestuursperiodenService extends Service {

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -1,5 +1,8 @@
-import Service, { inject as service } from '@ember/service';
+import Service from '@ember/service';
+
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+
 import { setContext, setUser } from '@sentry/ember';
 import { SHOULD_ENABLE_SENTRY } from 'frontend-lmb/utils/sentry';
 

--- a/app/services/decretale-organen.js
+++ b/app/services/decretale-organen.js
@@ -1,11 +1,13 @@
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+
 import {
   DECRETALE_BESTUURSORGANEN_CONCEPT_SCHEME,
   GEMEENTE_BESTUURSORGANEN_CONCEPT_SCHEME,
   OTHER_BESTUURSORGANEN_CONCEPT_SCHEME,
 } from 'frontend-lmb/utils/well-known-ids';
-import { tracked } from '@glimmer/tracking';
 
 export default class DecretaleOrganenService extends Service {
   @service store;

--- a/app/services/form-dirty-state.js
+++ b/app/services/form-dirty-state.js
@@ -1,4 +1,5 @@
 import Service from '@ember/service';
+
 import ENV from 'frontend-lmb/config/environment';
 
 export default class FormDirtyStateService extends Service {

--- a/app/services/mandataris-status.js
+++ b/app/services/mandataris-status.js
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
+
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MandatarisStatusService extends Service {
   @tracked statuses = [];

--- a/app/services/mandataris.js
+++ b/app/services/mandataris.js
@@ -1,5 +1,7 @@
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
+
 import { getDraftPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
 import moment from 'moment';
 

--- a/app/services/multi-uri-fetcher.js
+++ b/app/services/multi-uri-fetcher.js
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+
+import { service } from '@ember/service';
 
 export default class MultiUriFetcherService extends Service {
   @service store;

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,5 +1,6 @@
-import { inject as service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
+
+import { service } from '@ember/service';
 
 export default class LoketSessionService extends SessionService {
   @service currentSession;


### PR DESCRIPTION
## Description

Importing service with `import { inject as service }` is not needed anymore so we can change that up to `import { service }`

## How to test

The whole application needs to work as before