### PR TITLE
LMB-445: Remove adding modified from frontend

### DIFF
--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -144,7 +144,6 @@ export default class MandatarissenUpdateState extends Component {
       beleidsdomein: (await this.args.mandataris.beleidsdomein).slice(),
       status: this.newStatus,
       publicationStatus: await getDraftPublicationStatus(this.store),
-      modified: new Date(),
     };
 
     const newMandataris = this.store.createRecord(
@@ -205,7 +204,6 @@ export default class MandatarissenUpdateState extends Component {
 
   endMandataris() {
     this.args.mandataris.einde = this.date;
-    this.args.mandataris.modified = new Date();
 
     return this.args.mandataris.save();
   }

--- a/app/models/fractie.js
+++ b/app/models/fractie.js
@@ -4,12 +4,7 @@ export default class FractieModel extends Model {
   @attr uri;
   @attr naam;
   @attr('uri-set') generatedFrom;
-  @attr('datetime', {
-    defaultValue() {
-      return new Date();
-    },
-  })
-  modified;
+  @attr('datetime') modified;
 
   @belongsTo('fractietype', {
     async: true,

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -10,12 +10,7 @@ export default class MandatarisModel extends Model {
   @attr duplicationReason;
   @attr uri;
   @attr('string') linkToBesluit;
-  @attr('datetime', {
-    defaultValue() {
-      return new Date();
-    },
-  })
-  modified;
+  @attr('datetime') modified;
 
   @belongsTo('mandaat', { async: true, inverse: 'bekleedDoor' })
   bekleedt;

--- a/app/models/persoon.js
+++ b/app/models/persoon.js
@@ -7,12 +7,7 @@ export default class PersoonModel extends Model {
   @attr gebruikteVoornaam;
   @attr uri;
   @attr('boolean') possibleDuplicate;
-  @attr('datetime', {
-    defaultValue() {
-      return new Date();
-    },
-  })
-  modified;
+  @attr('datetime') modified;
 
   @belongsTo('geboorte', {
     async: true,


### PR DESCRIPTION
## Description

As the modified is now added through the track-modified service in our app we do not have to add it in our frontend anymore.

## How to test

Make sure that you cannot find any records being updated/created with a modified property set.

I looked at the [PR](https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/173/files) for what changed when doing the opposite of this logic 

The only thing im noticing is that the data in the Ember tab shows modified as undefined when The data is not fetched again from the database => ⚠️? When refreshing and looking in the Ember tab the modified is updated. I think this is no issue? We can always add the default value for the modified property back and than it will aways be set on the ember site first and than updated in the backend. (Which will differ in a few seconds off ;p)
