### PR TITLE
LMB-364: Correctly show instance table column names

### DIFF
--- a/app/components/form/instance-table.hbs
+++ b/app/components/form/instance-table.hbs
@@ -35,11 +35,11 @@
   >
     <t.content as |c|>
       <c.header>
-        {{#each this.formInfo.headers as |header|}}
+        {{#each this.formInfo.headers as |key|}}
           <AuDataTableThSortable
-            @field={{header}}
+            @field={{key}}
             @currentSorting={{@sort}}
-            @label={{header}}
+            @label={{this.labelForHeaderKey key}}
           />
         {{/each}}
         <th>{{! Bewerk }}</th>

--- a/app/components/form/instance-table.js
+++ b/app/components/form/instance-table.js
@@ -92,4 +92,28 @@ export default class InstanceTableComponent extends Component {
       headers: headers,
     };
   }
+
+  @action
+  labelForHeaderKey(key) {
+    const mapping = {
+      id: 'Id',
+      uri: 'Uri',
+      label: 'Label',
+      email: 'Email',
+      naam: 'Naam',
+      start: 'Startdatum',
+      einde: 'Einddatum',
+      voornaam: 'Voornaam',
+      achternaam: 'Achternaam',
+      roepnaam: 'Roepnaam',
+      test: 'Test',
+      startaanstellingsperiode: 'Start aanstellingsperiode',
+    };
+
+    if (!mapping[key]) {
+      return key;
+    }
+
+    return mapping[key];
+  }
 }


### PR DESCRIPTION
## Description

The Table column names are the keys that are used in the migrations. Add a mapping to it so it displays the names with spaces and capital letters.

## How to test

Open the forms route and check the column labels.