### PR TITLE
LMB-131: Cleanup form instance components

### DIFF
--- a/app/components/form/instance.hbs
+++ b/app/components/form/instance.hbs
@@ -1,4 +1,6 @@
-{{#if this.initialized}}
+{{#if this.setupFormForTtl.isRunning}}
+  <AuLoader />
+{{else}}
   <section>
     <RdfForm
       @groupClass="au-o-grid__item"

--- a/app/components/form/instance.hbs
+++ b/app/components/form/instance.hbs
@@ -31,7 +31,7 @@
           @disabled={{or this.save.isRunning (not this.hasChanges)}}
         >Pas aan</AuButton>
         <Form::SaveWithHistory
-          @save={{this.saveInstance}}
+          @save={{perform this.save}}
           @isSaving={{this.save.isRunning}}
           @updateValue={{this.updateHistoryMessage}}
           @isModalOpen={{this.isSaveHistoryModalOpen}}

--- a/app/components/form/instance.hbs
+++ b/app/components/form/instance.hbs
@@ -1,6 +1,4 @@
-{{#if this.setupFormForTtl.isRunning}}
-  <AuLoader />
-{{else}}
+{{#unless this.setupFormForTtl.isRunning}}
   <section>
     <RdfForm
       @groupClass="au-o-grid__item"
@@ -59,4 +57,4 @@
       />
     </section>
   {{/if}}
-{{/if}}
+{{/unless}}

--- a/app/components/form/instance.hbs
+++ b/app/components/form/instance.hbs
@@ -38,7 +38,7 @@
         >Pas aan</Form::SaveWithHistory>
         {{#if @onCancel}}
           <Form::CancelWithConfirm
-            @cancel={{this.cancel}}
+            @cancel={{@onCancel}}
           >Annuleer</Form::CancelWithConfirm>
         {{/if}}
       </AuButtonGroup>

--- a/app/components/form/instance.hbs
+++ b/app/components/form/instance.hbs
@@ -3,14 +3,14 @@
     <RdfForm
       @groupClass="au-o-grid__item"
       @form={{this.formInfo.form}}
-      @show={{(not this.isEditable)}}
+      @show={{false}}
       @graphs={{this.formInfo.graphs}}
       @sourceNode={{this.formInfo.sourceNode}}
       @formStore={{this.formInfo.formStore}}
       @forceShowErrors={{this.forceShowErrors}}
       @useNewListingLayout={{true}}
       @level={{2}}
-      class="au-u-max-width-medium {{unless this.isEditable 'disabled'}}"
+      class="au-u-max-width-medium"
     />
     {{yield}}
   </section>
@@ -21,42 +21,40 @@
     </AuAlert>
   {{/if}}
 
-  {{#if (and this.isEditable this.showEditButtons)}}
-    <AuToolbar as |Group|>
-      <Group>
-        <AuButtonGroup>
-          <AuButton
-            {{on "click" this.tryOpenHistoryModal}}
-            @disabled={{or this.save.isRunning (not this.hasChanges)}}
-          >Pas aan</AuButton>
-          <Form::SaveWithHistory
-            @save={{this.saveInstance}}
-            @isSaving={{this.save.isRunning}}
-            @updateValue={{this.updateHistoryMessage}}
-            @isModalOpen={{this.isSaveHistoryModalOpen}}
-          >Pas aan</Form::SaveWithHistory>
-          {{#if @onCancel}}
-            <Form::CancelWithConfirm
-              @cancel={{this.cancel}}
-            >Annuleer</Form::CancelWithConfirm>
-          {{/if}}
-        </AuButtonGroup>
-      </Group>
-    </AuToolbar>
+  <AuToolbar as |Group|>
+    <Group>
+      <AuButtonGroup>
+        <AuButton
+          {{on "click" this.tryOpenHistoryModal}}
+          @disabled={{or this.save.isRunning (not this.hasChanges)}}
+        >Pas aan</AuButton>
+        <Form::SaveWithHistory
+          @save={{this.saveInstance}}
+          @isSaving={{this.save.isRunning}}
+          @updateValue={{this.updateHistoryMessage}}
+          @isModalOpen={{this.isSaveHistoryModalOpen}}
+        >Pas aan</Form::SaveWithHistory>
+        {{#if @onCancel}}
+          <Form::CancelWithConfirm
+            @cancel={{this.cancel}}
+          >Annuleer</Form::CancelWithConfirm>
+        {{/if}}
+      </AuButtonGroup>
+    </Group>
+  </AuToolbar>
 
-    <Form::TripleContent @triples={{this.sourceTriples}} />
-    {{#if @showHistory}}
-      <section class="au-u-margin-top-small">
-        <AuHeading @level="2" @skin="4" class="au-u-margin-bottom-small">
-          History
-        </AuHeading>
+  <Form::TripleContent @triples={{this.sourceTriples}} />
+  {{#if @showHistory}}
+    <section class="au-u-margin-top-small">
+      <AuHeading @level="2" @skin="4" class="au-u-margin-bottom-small">
+        History
+      </AuHeading>
 
-        <Form::History
-          @instanceId={{@instanceId}}
-          @form={{@form}}
-          @onRestore={{this.onRestore}}
-        />
-      </section>
-    {{/if}}
+      <Form::History
+        @instanceId={{@instanceId}}
+        @form={{@form}}
+        @onRestore={{this.onRestore}}
+      />
+    </section>
   {{/if}}
 {{/if}}

--- a/app/components/form/instance.hbs
+++ b/app/components/form/instance.hbs
@@ -27,7 +27,7 @@
         <AuButtonGroup>
           <AuButton
             {{on "click" this.tryOpenHistoryModal}}
-            @disabled={{or this.isSaving (not this.hasChanges)}}
+            @disabled={{or this.save.isRunning (not this.hasChanges)}}
           >Pas aan</AuButton>
           <Form::SaveWithHistory
             @save={{this.saveInstance}}

--- a/app/components/form/instance.js
+++ b/app/components/form/instance.js
@@ -140,7 +140,7 @@ export default class InstanceComponent extends Component {
       sourceNode,
     };
 
-    await this.registerObserver(formStore);
+    this.registerObserver(formStore);
   });
 
   async retrieveFormInstance(formId, id) {

--- a/app/components/form/instance.js
+++ b/app/components/form/instance.js
@@ -161,7 +161,11 @@ export default class InstanceComponent extends Component {
   }
 
   registerObserver(formStore) {
-    formStore.registerObserver(() => {
+    const onFormUpdate = () => {
+      if (this.isDestroyed) {
+        return;
+      }
+
       this.sourceTriples = this.formInfo.formStore.serializeDataMergedGraph(
         this.formInfo.graphs.sourceGraph
       );

--- a/app/components/form/instance.js
+++ b/app/components/form/instance.js
@@ -50,13 +50,6 @@ export default class InstanceComponent extends Component {
     return this.formInfo !== null;
   }
 
-  get isEditable() {
-    if (this.args.isEditable === undefined) {
-      return true;
-    }
-    return Boolean(this.args.isEditable);
-  }
-
   save = task({ keepLatest: true }, async () => {
     // TODO validation needs to be checked first before the form is actually saved
     const triples = this.sourceTriples;

--- a/app/components/form/instance.js
+++ b/app/components/form/instance.js
@@ -50,10 +50,6 @@ export default class InstanceComponent extends Component {
     return this.formInfo !== null;
   }
 
-  get isSaving() {
-    return this.save.isRunning;
-  }
-
   get isEditable() {
     if (this.args.isEditable === undefined) {
       return true;

--- a/app/components/form/instance.js
+++ b/app/components/form/instance.js
@@ -43,11 +43,7 @@ export default class InstanceComponent extends Component {
 
   constructor() {
     super(...arguments);
-    this.onInit();
-  }
-
-  get initialized() {
-    return this.formInfo !== null;
+    this.setupFormForTtl.perform();
   }
 
   save = task({ keepLatest: true }, async () => {
@@ -136,10 +132,10 @@ export default class InstanceComponent extends Component {
   @action
   async onRestore(historicalInstance) {
     this.formInfo = null;
-    this.onInit(historicalInstance.formInstanceTtl);
+    this.setupFormForTtl.perform(historicalInstance.formInstanceTtl);
   }
 
-  async onInit(newFormTtl = null) {
+  setupFormForTtl = task(async (newFormTtl = null) => {
     const form = this.args.form;
     const instanceId = this.args.instanceId;
 
@@ -181,7 +177,7 @@ export default class InstanceComponent extends Component {
     };
 
     await this.registerObserver(formStore);
-  }
+  });
 
   async retrieveFormInstance(formId, id) {
     const response = await fetch(`/form-content/${formId}/instances/${id}`);

--- a/app/components/form/instance.js
+++ b/app/components/form/instance.js
@@ -40,7 +40,6 @@ export default class InstanceComponent extends Component {
   }
 
   save = task({ keepLatest: true }, async () => {
-    // TODO validation needs to be checked first before the form is actually saved
     const ttlCode = this.sourceTriples;
     const instanceId = this.formInfo.instanceId;
     this.errorMessage = null;

--- a/app/components/form/instance.js
+++ b/app/components/form/instance.js
@@ -73,6 +73,7 @@ export default class InstanceComponent extends Component {
 
     this.formDirtyState.markClean(this.formId);
     this.hasChanges = false;
+    this.isSaveHistoryModalOpen = false;
   });
 
   @action
@@ -83,12 +84,6 @@ export default class InstanceComponent extends Component {
       return;
     }
     this.isSaveHistoryModalOpen = true;
-  }
-
-  @action
-  async saveInstance() {
-    await this.save.perform();
-    this.isSaveHistoryModalOpen = false;
   }
 
   @action

--- a/app/components/form/instance.js
+++ b/app/components/form/instance.js
@@ -157,14 +157,11 @@ export default class InstanceComponent extends Component {
   willDestroy() {
     super.willDestroy(...arguments);
     this.formDirtyState.markClean(this.formId);
+    this.formInfo?.formStore?.clearObservers();
   }
 
   registerObserver(formStore) {
     formStore.registerObserver(() => {
-      if (this.isDestroyed) {
-        return;
-      }
-
       this.sourceTriples = this.formInfo.formStore.serializeDataMergedGraph(
         this.formInfo.graphs.sourceGraph
       );

--- a/app/components/form/instance.js
+++ b/app/components/form/instance.js
@@ -12,7 +12,7 @@ import { FORM_GRAPH, META_GRAPH, SOURCE_GRAPH } from '../../utils/constants';
 import { task } from 'ember-concurrency';
 import { notifyFormSavedSuccessfully } from 'frontend-lmb/utils/toasts';
 import { loadFormInto } from 'frontend-lmb/utils/loadFormInto';
-import { isValidFormFromFormInfo } from 'frontend-lmb/utils/is-valid-form';
+import { isValidForm } from 'frontend-lmb/utils/is-valid-form';
 
 export default class InstanceComponent extends Component {
   @service store;
@@ -75,9 +75,9 @@ export default class InstanceComponent extends Component {
 
   @action
   async tryOpenHistoryModal() {
-    const isValidForm = isValidFormFromFormInfo(this.formInfo);
-    this.forceShowErrors = !isValidForm;
-    if (!isValidForm) {
+    const isValid = isValidForm(this.formInfo);
+    this.forceShowErrors = !isValid;
+    if (!isValid) {
       this.errorMessage =
         'Niet alle velden zijn correct ingevuld. Gelieve deze eerst te corrigeren.';
       return;

--- a/app/components/form/instance.js
+++ b/app/components/form/instance.js
@@ -95,11 +95,6 @@ export default class InstanceComponent extends Component {
   }
 
   @action
-  cancel() {
-    this.args.onCancel();
-  }
-
-  @action
   async onRestore(historicalInstance) {
     this.formInfo = null;
     this.setupFormForTtl.perform(historicalInstance.formInstanceTtl);

--- a/app/components/form/instance.js
+++ b/app/components/form/instance.js
@@ -161,7 +161,7 @@ export default class InstanceComponent extends Component {
   }
 
   registerObserver(formStore) {
-    const onFormUpdate = () => {
+    formStore.registerObserver(() => {
       if (this.isDestroyed) {
         return;
       }

--- a/app/components/form/new-instance.hbs
+++ b/app/components/form/new-instance.hbs
@@ -26,7 +26,7 @@
       <AuButtonGroup>
         <AuButton
           {{on "click" this.createInstance}}
-          @disabled={{this.isSaving}}
+          @disabled={{this.save.isRunning}}
         >
           Bewaar
         </AuButton>

--- a/app/components/form/new-instance.hbs
+++ b/app/components/form/new-instance.hbs
@@ -1,6 +1,4 @@
-{{#if this.setupNewForm.isRunning}}
-  <AuLoader />
-{{else}}
+{{#unless this.setupNewForm.isRunning}}
   <section>
     <RdfForm
       @groupClass="au-o-grid__item"
@@ -42,4 +40,4 @@
   </AuToolbar>
 
   <Form::TripleContent @triples={{this.sourceTriples}} />
-{{/if}}
+{{/unless}}

--- a/app/components/form/new-instance.hbs
+++ b/app/components/form/new-instance.hbs
@@ -34,7 +34,7 @@
         </AuButton>
         {{#if @onCancel}}
           <Form::CancelWithConfirm
-            @cancel={{this.cancel}}
+            @cancel={{@onCancel}}
           >Annuleer</Form::CancelWithConfirm>
         {{/if}}
       </AuButtonGroup>

--- a/app/components/form/new-instance.hbs
+++ b/app/components/form/new-instance.hbs
@@ -27,7 +27,7 @@
     <Group>
       <AuButtonGroup>
         <AuButton
-          {{on "click" this.createInstance}}
+          {{on "click" (perform this.save)}}
           @disabled={{this.save.isRunning}}
         >
           Bewaar

--- a/app/components/form/new-instance.hbs
+++ b/app/components/form/new-instance.hbs
@@ -1,4 +1,6 @@
-{{#if this.initialized}}
+{{#if this.setupNewForm.isRunning}}
+  <AuLoader />
+{{else}}
   <section>
     <RdfForm
       @groupClass="au-o-grid__item"

--- a/app/components/form/new-instance.js
+++ b/app/components/form/new-instance.js
@@ -114,7 +114,7 @@ export default class NewInstanceComponent extends Component {
   }
 
   registerObserver(formStore) {
-    const onFormUpdate = () => {
+    formStore.registerObserver(() => {
       if (this.isDestroyed) {
         return;
       }

--- a/app/components/form/new-instance.js
+++ b/app/components/form/new-instance.js
@@ -71,11 +71,6 @@ export default class NewInstanceComponent extends Component {
     this.formDirtyState.markClean(this.formId);
   });
 
-  @action
-  cancel() {
-    this.args.onCancel();
-  }
-
   setupNewForm = task(async () => {
     const form = this.args.form;
     const uri = `${form.prefix}${uuid()}`;

--- a/app/components/form/new-instance.js
+++ b/app/components/form/new-instance.js
@@ -72,11 +72,6 @@ export default class NewInstanceComponent extends Component {
   });
 
   @action
-  async createInstance() {
-    this.save.perform();
-  }
-
-  @action
   cancel() {
     this.args.onCancel();
   }

--- a/app/components/form/new-instance.js
+++ b/app/components/form/new-instance.js
@@ -12,7 +12,7 @@ import { FORM_GRAPH, META_GRAPH, SOURCE_GRAPH } from '../../utils/constants';
 import { task } from 'ember-concurrency';
 import { notifyFormSavedSuccessfully } from 'frontend-lmb/utils/toasts';
 import { loadFormInto } from 'frontend-lmb/utils/loadFormInto';
-import { isValidFormFromFormInfo } from 'frontend-lmb/utils/is-valid-form';
+import { isValidForm } from 'frontend-lmb/utils/is-valid-form';
 
 export default class NewInstanceComponent extends Component {
   @service store;
@@ -36,9 +36,9 @@ export default class NewInstanceComponent extends Component {
   save = task({ keepLatest: true }, async () => {
     const ttlCode = this.sourceTriples;
     this.errorMessage = null;
-    const isValidForm = isValidFormFromFormInfo(this.formInfo);
-    this.forceShowErrors = !isValidForm;
-    if (!isValidForm) {
+    const isValid = isValidForm(this.formInfo);
+    this.forceShowErrors = !isValid;
+    if (!isValid) {
       this.errorMessage =
         'Niet alle velden zijn correct ingevuld. Probeer het later opnieuw.';
       return;

--- a/app/components/form/new-instance.js
+++ b/app/components/form/new-instance.js
@@ -115,7 +115,11 @@ export default class NewInstanceComponent extends Component {
   }
 
   registerObserver(formStore) {
-    formStore.registerObserver(() => {
+    const onFormUpdate = () => {
+      if (this.isDestroyed) {
+        return;
+      }
+
       this.sourceTriples = this.formInfo.formStore.serializeDataMergedGraph(
         this.formInfo.graphs.sourceGraph
       );
@@ -132,7 +136,6 @@ export default class NewInstanceComponent extends Component {
     };
     formStore.registerObserver(onFormUpdate);
     onFormUpdate();
-    await timeout(55);
     this.args.formInitialized ? this.args.formInitialized() : null;
   }
 }

--- a/app/components/form/new-instance.js
+++ b/app/components/form/new-instance.js
@@ -45,10 +45,6 @@ export default class NewInstanceComponent extends Component {
     return this.formInfo !== null;
   }
 
-  get isSaving() {
-    return this.save.isRunning;
-  }
-
   save = task({ keepLatest: true }, async () => {
     // TODO validation needs to be checked first before the form is actually saved
     const triples = this.sourceTriples;

--- a/app/components/form/new-instance.js
+++ b/app/components/form/new-instance.js
@@ -38,11 +38,7 @@ export default class NewInstanceComponent extends Component {
 
   constructor() {
     super(...arguments);
-    this.onInit();
-  }
-
-  get initialized() {
-    return this.formInfo !== null;
+    this.setupNewForm.perform();
   }
 
   save = task({ keepLatest: true }, async () => {
@@ -108,7 +104,7 @@ export default class NewInstanceComponent extends Component {
     this.args.onCancel();
   }
 
-  async onInit() {
+  setupNewForm = task(async () => {
     const form = this.args.form;
     const uri = `${form.prefix}${uuid()}`;
     const sourceTtl = this.args.buildSourceTtl
@@ -146,7 +142,7 @@ export default class NewInstanceComponent extends Component {
       sourceNode,
     };
     this.registerObserver(formStore);
-  }
+  });
 
   willDestroy() {
     super.willDestroy(...arguments);

--- a/app/components/form/new-instance.js
+++ b/app/components/form/new-instance.js
@@ -111,14 +111,11 @@ export default class NewInstanceComponent extends Component {
   willDestroy() {
     super.willDestroy(...arguments);
     this.formDirtyState.markClean(this.formId);
+    this.formInfo?.formStore?.clearObservers();
   }
 
   registerObserver(formStore) {
     formStore.registerObserver(() => {
-      if (this.isDestroyed) {
-        return;
-      }
-
       this.sourceTriples = this.formInfo.formStore.serializeDataMergedGraph(
         this.formInfo.graphs.sourceGraph
       );

--- a/app/services/form-repository.js
+++ b/app/services/form-repository.js
@@ -1,0 +1,61 @@
+import Service from '@ember/service';
+
+import { timeout } from 'ember-concurrency';
+import {
+  JSON_API_TYPE,
+  RESOURCE_CACHE_TIMEOUT,
+} from 'frontend-lmb/utils/constants';
+
+export default class FormRepositoryService extends Service {
+  async updateFormInstance(
+    instanceId,
+    instanceUri,
+    definitionId,
+    ttlCode,
+    description
+  ) {
+    const result = await fetch(
+      `/form-content/${definitionId}/instances/${instanceId}`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': JSON_API_TYPE,
+        },
+        body: JSON.stringify({
+          contentTtl: ttlCode,
+          instanceUri: instanceUri,
+          description: description,
+        }),
+      }
+    );
+
+    await timeout(RESOURCE_CACHE_TIMEOUT);
+
+    return await this._handleFetchResult(result);
+  }
+
+  async _handleFetchResult(result) {
+    if (!result.ok) {
+      return {
+        body: null,
+        errorMessage:
+          'Er ging iets mis bij het opslaan van het formulier. Probeer het later opnieuw.',
+      };
+    }
+
+    const body = await result.json();
+
+    if (!body?.instance?.instanceUri) {
+      return {
+        body: null,
+        errorMessage:
+          'Het formulier werd niet correct opgeslagen. Probeer het later opnieuw.',
+      };
+    }
+
+    return {
+      body: body,
+      errorMessage: null,
+    };
+  }
+}

--- a/app/services/form-repository.js
+++ b/app/services/form-repository.js
@@ -21,7 +21,7 @@ export default class FormRepositoryService extends Service {
 
     await timeout(RESOURCE_CACHE_TIMEOUT);
 
-    return await this._handleCreateFetchhResult(result);
+    return await this._handleCreateResult(result);
   }
 
   async updateFormInstance(
@@ -48,10 +48,10 @@ export default class FormRepositoryService extends Service {
 
     await timeout(RESOURCE_CACHE_TIMEOUT);
 
-    return await this._handleUpdateFetchhResult(result);
+    return await this._handleUpdateResult(result);
   }
 
-  async _handleCreateFetchhResult(result) {
+  async _handleCreateResult(result) {
     if (!result.ok) {
       return {
         id: null,
@@ -70,7 +70,7 @@ export default class FormRepositoryService extends Service {
     };
   }
 
-  async _handleUpdateFetchhResult(result) {
+  async _handleUpdateResult(result) {
     if (!result.ok) {
       return {
         body: null,

--- a/app/services/form-repository.js
+++ b/app/services/form-repository.js
@@ -62,17 +62,11 @@ export default class FormRepositoryService extends Service {
 
     const { id } = await result.json();
 
-    if (!id) {
-      return {
-        id: null,
-        errorMessage:
-          'Het formulier werd niet correct opgeslagen. Probeer het later opnieuw.',
-      };
-    }
-
     return {
-      id: id,
-      errorMessage: null,
+      id: id ?? null,
+      errorMessage: id
+        ? null
+        : 'Het formulier werd niet correct opgeslagen. Probeer het later opnieuw.',
     };
   }
 
@@ -87,17 +81,11 @@ export default class FormRepositoryService extends Service {
 
     const body = await result.json();
 
-    if (!body?.instance?.instanceUri) {
-      return {
-        body: null,
-        errorMessage:
-          'Het formulier werd niet correct opgeslagen. Probeer het later opnieuw.',
-      };
-    }
-
     return {
-      body: body,
-      errorMessage: null,
+      body: body?.instance?.instanceUri ? body : null,
+      errorMessage: body?.instance?.instanceUri
+        ? null
+        : 'Het formulier werd niet correct opgeslagen. Probeer het later opnieuw.',
     };
   }
 }

--- a/app/services/form-repository.js
+++ b/app/services/form-repository.js
@@ -7,6 +7,23 @@ import {
 } from 'frontend-lmb/utils/constants';
 
 export default class FormRepositoryService extends Service {
+  async createFormInstance(instanceUri, definitionId, ttlCode) {
+    const result = await fetch(`/form-content/${definitionId}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': JSON_API_TYPE,
+      },
+      body: JSON.stringify({
+        contentTtl: ttlCode,
+        instanceUri: instanceUri,
+      }),
+    });
+
+    await timeout(RESOURCE_CACHE_TIMEOUT);
+
+    return await this._handleCreateFetchhResult(result);
+  }
+
   async updateFormInstance(
     instanceId,
     instanceUri,
@@ -31,10 +48,35 @@ export default class FormRepositoryService extends Service {
 
     await timeout(RESOURCE_CACHE_TIMEOUT);
 
-    return await this._handleFetchResult(result);
+    return await this._handleUpdateFetchhResult(result);
   }
 
-  async _handleFetchResult(result) {
+  async _handleCreateFetchhResult(result) {
+    if (!result.ok) {
+      return {
+        id: null,
+        errorMessage:
+          'Er ging iets mis bij het opslaan van het formulier. Probeer het later opnieuw.',
+      };
+    }
+
+    const { id } = await result.json();
+
+    if (!id) {
+      return {
+        id: null,
+        errorMessage:
+          'Het formulier werd niet correct opgeslagen. Probeer het later opnieuw.',
+      };
+    }
+
+    return {
+      id: id,
+      errorMessage: null,
+    };
+  }
+
+  async _handleUpdateFetchhResult(result) {
     if (!result.ok) {
       return {
         body: null,

--- a/app/services/form-repostitory.js
+++ b/app/services/form-repostitory.js
@@ -1,3 +1,0 @@
-import Service from '@ember/service';
-
-export default class FormRepositoryService extends Service {}

--- a/app/services/form-repostitory.js
+++ b/app/services/form-repostitory.js
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class FormRepositoryService extends Service {}

--- a/app/utils/is-valid-form.js
+++ b/app/utils/is-valid-form.js
@@ -1,0 +1,27 @@
+import { validateForm } from '@lblod/ember-submission-form-fields';
+
+export function isValidFormFromFormInfo(formInfo) {
+  if (isFormInfo(formInfo)) {
+    return false;
+  }
+
+  return validateForm(formInfo.formNode, {
+    ...formInfo.graphs,
+    sourceNode: formInfo.sourceNode,
+    store: formInfo.formStore,
+  });
+}
+
+function isFormInfo(formInfo) {
+  if (!formInfo) {
+    return false;
+  }
+
+  const properties = ['graphs', 'sourceNode', 'formStore'];
+
+  const arePropertiesSet = Object.keys(formInfo).map((key) =>
+    properties.includes(key)
+  );
+
+  return arePropertiesSet.every((isSet) => isSet);
+}

--- a/app/utils/is-valid-form.js
+++ b/app/utils/is-valid-form.js
@@ -1,6 +1,6 @@
 import { validateForm } from '@lblod/ember-submission-form-fields';
 
-export function isValidFormFromFormInfo(formInfo) {
+export function isValidForm(formInfo) {
   if (isFormInfo(formInfo)) {
     return false;
   }

--- a/tests/unit/services/form-repository-test.js
+++ b/tests/unit/services/form-repository-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-lmb/tests/helpers';
+
+module('Unit | Service | form-repository', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:form-repository');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
## Description

We have two form components to edit and create entities. The logic in these components are similar on a lot of places. We want to cleanup these components so they are still easy to understand but do not have so many duplicate code.

## How to test

1. Create a new entity with a form (/forms route)
2. Update an entity that is being updated with a form (e.g. correct mandataris)
