### PR TITLE
LMB-555 - legislatuur disables mandatees

### DIFF
--- a/app/controllers/mandatarissen/persoon/mandataris.js
+++ b/app/controllers/mandatarissen/persoon/mandataris.js
@@ -17,7 +17,8 @@ export default class MandatarissenPersoonMandatarisController extends Controller
 
   @tracked isChanging;
   @tracked isCorrecting;
-  @tracked isInTeBehandelenLegislatuur;
+  @tracked periodeHasLegislatuur;
+  @tracked behandeldeVergaderingen;
 
   get bestuursorganenTitle() {
     const bestuursfunctie = this.model.mandataris.bekleedt
@@ -71,23 +72,38 @@ export default class MandatarissenPersoonMandatarisController extends Controller
     return getBestuursorganenMetaTtl(this.model.bestuursorganen);
   }
 
-  canEditAndCorrect = task(async () => {
+  checkLegislatuur = task(async () => {
     const mandaat = await this.model.mandataris.bekleedt;
     const bestuursorganen = await mandaat.bevatIn;
 
     if (!bestuursorganen[0]) {
-      this.isInTeBehandelenLegislatuur = true;
+      this.periodeHasLegislatuur = false;
+      this.behandeldeVergaderingen = null;
       return;
     }
 
     const bestuursperiode = await bestuursorganen[0].heeftBestuursperiode;
-    const behandeldeVergaderingen = await this.store.query(
+    this.periodeHasLegislatuur =
+      (await bestuursperiode.installatievergaderingen).length >= 1;
+
+    this.behandeldeVergaderingen = await this.store.query(
       'installatievergadering',
       {
         'filter[status][:uri:]': INSTALLATIVERGADERING_BEHANDELD_STATUS,
         'filter[bestuursperiode][:id:]': bestuursperiode.id,
       }
     );
-    this.isInTeBehandelenLegislatuur = behandeldeVergaderingen.length === 0;
   });
+
+  get isDisabledBecauseLegislatuur() {
+    if (
+      this.periodeHasLegislatuur &&
+      this.behandeldeVergaderingen &&
+      this.behandeldeVergaderingen.length === 0
+    ) {
+      return true;
+    }
+
+    return false;
+  }
 }

--- a/app/controllers/mandatarissen/persoon/mandataris.js
+++ b/app/controllers/mandatarissen/persoon/mandataris.js
@@ -17,7 +17,7 @@ export default class MandatarissenPersoonMandatarisController extends Controller
 
   @tracked isChanging;
   @tracked isCorrecting;
-  @tracked inCompletedLegislatuur;
+  @tracked isInTeBehandelenLegislatuur;
 
   get bestuursorganenTitle() {
     const bestuursfunctie = this.model.mandataris.bekleedt
@@ -76,7 +76,7 @@ export default class MandatarissenPersoonMandatarisController extends Controller
     const bestuursorganen = await mandaat.bevatIn;
 
     if (!bestuursorganen[0]) {
-      this.inCompletedLegislatuur = false;
+      this.isInTeBehandelenLegislatuur = true;
       return;
     }
 
@@ -88,7 +88,6 @@ export default class MandatarissenPersoonMandatarisController extends Controller
         'filter[bestuursperiode][:id:]': bestuursperiode.id,
       }
     );
-
-    this.inCompletedLegislatuur = behandeldeVergaderingen.length >= 1;
+    this.isInTeBehandelenLegislatuur = behandeldeVergaderingen.length === 0;
   });
 }

--- a/app/controllers/organen/index.js
+++ b/app/controllers/organen/index.js
@@ -15,7 +15,7 @@ export default class OrganenIndexController extends Controller {
   @tracked bestuursperiode;
 
   @tracked isModalActive = false;
-  @tracked isInTeBehandelenLegislatuur;
+  @tracked isDisabledBecauseLegislatuur;
 
   @action
   filterActiveOrgans() {
@@ -79,6 +79,13 @@ export default class OrganenIndexController extends Controller {
 
   @action
   async setIsLegislatuurBehandeld() {
+    const periodeHasLegislatuur =
+      (await this.model.selectedPeriod.installatievergaderingen).length >= 1;
+    if (!periodeHasLegislatuur) {
+      this.isDisabledBecauseLegislatuur = false;
+      return;
+    }
+
     const behandeldeVergaderingen = await this.store.query(
       'installatievergadering',
       {
@@ -87,6 +94,6 @@ export default class OrganenIndexController extends Controller {
       }
     );
 
-    this.isInTeBehandelenLegislatuur = behandeldeVergaderingen.length === 0;
+    this.isDisabledBecauseLegislatuur = behandeldeVergaderingen.length === 0;
   }
 }

--- a/app/controllers/organen/index.js
+++ b/app/controllers/organen/index.js
@@ -15,7 +15,7 @@ export default class OrganenIndexController extends Controller {
   @tracked bestuursperiode;
 
   @tracked isModalActive = false;
-  @tracked isInBehandeldLegislatuur;
+  @tracked isInTeBehandelenLegislatuur;
 
   @action
   filterActiveOrgans() {
@@ -87,6 +87,6 @@ export default class OrganenIndexController extends Controller {
       }
     );
 
-    this.isInBehandeldLegislatuur = behandeldeVergaderingen.length >= 1;
+    this.isInTeBehandelenLegislatuur = behandeldeVergaderingen.length === 0;
   }
 }

--- a/app/routes/organen/orgaan/index.js
+++ b/app/routes/organen/orgaan/index.js
@@ -25,17 +25,20 @@ export default class OrganenOrgaanIndexRoute extends Route {
       BESTUURSORGAAN_FORM_ID
     );
 
+    const bestuursperiode = await currentBestuursorgaan.heeftBestuursperiode;
+    const periodeHasLegislatuur =
+      (await bestuursperiode.installatievergaderingen).length >= 1;
     const behandeldeVergaderingen = await this.store.query(
       'installatievergadering',
       {
         'filter[status][:uri:]': INSTALLATIVERGADERING_BEHANDELD_STATUS,
-        'filter[bestuursperiode][:id:]':
-          currentBestuursorgaan.get('bestuursperiode.id'),
+        'filter[bestuursperiode][:id:]': bestuursperiode.id,
       }
     );
 
     return RSVP.hash({
-      isInTeBehandelenLegislatuur: behandeldeVergaderingen.length === 0,
+      isDisabledBecauseLegislatuur:
+        periodeHasLegislatuur && behandeldeVergaderingen.length === 0,
       bestuursorgaanFormDefinition,
       mandaten,
       orderedMandaten,

--- a/app/routes/organen/orgaan/index.js
+++ b/app/routes/organen/orgaan/index.js
@@ -35,7 +35,7 @@ export default class OrganenOrgaanIndexRoute extends Route {
     );
 
     return RSVP.hash({
-      isInBehandeldeLegislatuur: behandeldeVergaderingen.length >= 1,
+      isInTeBehandelenLegislatuur: behandeldeVergaderingen.length === 0,
       bestuursorgaanFormDefinition,
       mandaten,
       orderedMandaten,

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -22,14 +22,14 @@
       <AuButton
         class="au-u-margin-right-small"
         @disabled={{(or
-          (not this.model.mandataris.isActive) this.inCompletedLegislatuur
+          (not this.model.mandataris.isActive) this.isInTeBehandelenLegislatuur
         )}}
         {{on "click" (fn (mut this.isChanging) true)}}
       >Wijzig huidig mandaat</AuButton>
       <AuButton
         @alert={{true}}
         @skin="secondary"
-        @disabled={{this.inCompletedLegislatuur}}
+        @disabled={{this.isInTeBehandelenLegislatuur}}
         {{on "click" (fn (mut this.isCorrecting) true)}}
       >Corrigeer fouten</AuButton>
     </div>
@@ -61,7 +61,7 @@
     <Mandatarissen::MandatarisExtraInfoCard
       @mandataris={{@model.mandataris}}
       @form={{@model.mandatarisExtraInfoForm}}
-      @canEdit={{not this.inCompletedLegislatuur}}
+      @canEdit={{not this.isInTeBehandelenLegislatuur}}
     />
   </div>
 

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -17,19 +17,19 @@
   <div class="au-o-grid__item au-u-1-2 au-u-text-left">
     <div
       class="au-u-flex au-u-flex--end au-u-margin-bottom"
-      {{did-insert (perform this.canEditAndCorrect)}}
+      {{did-insert (perform this.checkLegislatuur)}}
     >
       <AuButton
         class="au-u-margin-right-small"
         @disabled={{(or
-          (not this.model.mandataris.isActive) this.isInTeBehandelenLegislatuur
+          (not this.model.mandataris.isActive) this.isDisabledBecauseLegislatuur
         )}}
         {{on "click" (fn (mut this.isChanging) true)}}
       >Wijzig huidig mandaat</AuButton>
       <AuButton
         @alert={{true}}
         @skin="secondary"
-        @disabled={{this.isInTeBehandelenLegislatuur}}
+        @disabled={{this.isDisabledBecauseLegislatuur}}
         {{on "click" (fn (mut this.isCorrecting) true)}}
       >Corrigeer fouten</AuButton>
     </div>
@@ -61,7 +61,7 @@
     <Mandatarissen::MandatarisExtraInfoCard
       @mandataris={{@model.mandataris}}
       @form={{@model.mandatarisExtraInfoForm}}
-      @canEdit={{not this.isInTeBehandelenLegislatuur}}
+      @canEdit={{not this.isDisabledBecauseLegislatuur}}
     />
   </div>
 

--- a/app/templates/organen/index.hbs
+++ b/app/templates/organen/index.hbs
@@ -59,7 +59,7 @@
           <AuHeading @skin="2">Organen</AuHeading>
         </Group>
         <Group {{did-insert this.setIsLegislatuurBehandeld}}>
-          {{#if this.isInTeBehandelenLegislatuur}}
+          {{#if this.isDisabledBecauseLegislatuur}}
             <AuButton @disabled={{true}}>
               Beheer fracties
             </AuButton>

--- a/app/templates/organen/index.hbs
+++ b/app/templates/organen/index.hbs
@@ -59,8 +59,8 @@
           <AuHeading @skin="2">Organen</AuHeading>
         </Group>
         <Group {{did-insert this.setIsLegislatuurBehandeld}}>
-          {{#if this.isInBehandeldLegislatuur}}
-            <AuButton @disabled={{this.isInBehandeldLegislatuur}}>
+          {{#if this.isInTeBehandelenLegislatuur}}
+            <AuButton @disabled={{true}}>
               Beheer fracties
             </AuButton>
           {{else}}
@@ -71,10 +71,7 @@
             >Beheer fracties
             </AuLink>
           {{/if}}
-          <AuButton
-            @disabled={{this.isInBehandeldLegislatuur}}
-            {{on "click" this.toggleModal}}
-          >Voeg orgaan toe</AuButton>
+          <AuButton {{on "click" this.toggleModal}}>Voeg orgaan toe</AuButton>
         </Group>
       </AuToolbar>
 

--- a/app/templates/organen/orgaan/index.hbs
+++ b/app/templates/organen/orgaan/index.hbs
@@ -12,7 +12,7 @@
   <Group>
     <AuButtonGroup>
       <AuButton
-        @disabled={{@model.isInBehandeldeLegislatuur}}
+        @disabled={{@model.isInTeBehandelenLegislatuur}}
         {{on "click" this.toggleModal}}
       >Bewerk</AuButton>
       {{#unless (await @model.bestuursorgaan.isDecretaal)}}

--- a/app/templates/organen/orgaan/index.hbs
+++ b/app/templates/organen/orgaan/index.hbs
@@ -12,7 +12,7 @@
   <Group>
     <AuButtonGroup>
       <AuButton
-        @disabled={{@model.isInTeBehandelenLegislatuur}}
+        @disabled={{@model.isDisabledBecauseLegislatuur}}
         {{on "click" this.toggleModal}}
       >Bewerk</AuButton>
       {{#unless (await @model.bestuursorgaan.isDecretaal)}}


### PR DESCRIPTION
## Description

Right now the wrong resources are locked when dealing with the preparation of a legislature.

It should be the case that mandatarissen (and also the fracties) are locked whenever they have a corresponding preparation of a legislature that is still in preparation or ready for review.

So when you are preparing a legislature, the mandatarissen you add in this page should not be editable in  their corresponding mandataris page. When this preparation is done and handled, they should become editable.

For mandatarissen that have no corresponding legislature, they should still be editable.

## How to test

When a legislatuur is not behandeld the buttons should be disabled for that besuursperiode
