### PR TITLE
move creation beeindigd mandataris status code to migration

### DIFF
--- a/app/services/mandataris-status.js
+++ b/app/services/mandataris-status.js
@@ -2,6 +2,7 @@ import Service from '@ember/service';
 
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
+import { MANDATARIS_BEEINDIGD_STATE } from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarisStatusService extends Service {
   @tracked statuses = [];
@@ -10,16 +11,12 @@ export default class MandatarisStatusService extends Service {
 
   endedState = null;
 
-  constructor() {
-    super(...arguments);
-    this.endedState = this.store.createRecord('mandataris-status-code', {
-      label: 'Beëindigd',
-    });
-  }
-
   async loadStatusOptions() {
     if (this.statuses.length === 0) {
       this.statuses = await this.store.findAll('mandataris-status-code');
+      this.endedState = this.statuses.find((status) => {
+        return status.uri === MANDATARIS_BEEINDIGD_STATE;
+      });
     }
   }
 }

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -18,6 +18,8 @@ export const MANDATARIS_TITELVOEREND_STATE =
   'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/aacb3fed-b51d-4e0b-a411-f3fa641da1b3';
 export const MANDATARIS_EFFECTIEF_STATE =
   'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/21063a5b-912c-4241-841c-cc7fb3c73e75';
+export const MANDATARIS_BEEINDIGD_STATE =
+  'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/b8866fa2-d61c-4e3d-afaf-8a29eaaa7fb9';
 export const MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE =
   'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6';
 export const MANDATARIS_DRAFT_PUBLICATION_STATE =


### PR DESCRIPTION
## Description

The beeindigd mandataris status code was moved to a migration, this has some influence on the mandataris status service in the frontend.

## How to test

See if the update state in mandataris still works (especially the beeindigd state), or if you can select the beeindigd state is available in a mandataris form.

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/165
