### PR TITLE
Ben/lmg 477 mandataris search installatievergadering

### DIFF
--- a/app/controllers/mandatarissen/search.js
+++ b/app/controllers/mandatarissen/search.js
@@ -41,8 +41,8 @@ export default class MandatarissenSearchController extends Controller {
   }
 
   @action
-  selectPeriod(period) {
-    this.bestuursperiode = period.period.id;
+  selectPeriod(periodMap) {
+    this.bestuursperiode = periodMap.period.id;
   }
 
   @action

--- a/app/controllers/mandatarissen/search.js
+++ b/app/controllers/mandatarissen/search.js
@@ -42,7 +42,7 @@ export default class MandatarissenSearchController extends Controller {
 
   @action
   selectPeriod(period) {
-    this.bestuursperiode = period.id;
+    this.bestuursperiode = period.period.id;
   }
 
   @action

--- a/app/routes/mandatarissen/search.js
+++ b/app/routes/mandatarissen/search.js
@@ -26,6 +26,7 @@ export default class MandatarissenSearchRoute extends Route {
       params.bestuursperiode
     );
 
+    // This map is made for disabling certain options in the powerselect
     const periodMap = await Promise.all(
       bestuursPeriods.map(async (period) => {
         const ivs = await period.installatievergaderingen;

--- a/app/routes/mandatarissen/search.js
+++ b/app/routes/mandatarissen/search.js
@@ -33,7 +33,7 @@ export default class MandatarissenSearchRoute extends Route {
           return { period, disabled: false };
         }
         if (
-          (await ivs.at(0).get('status')) ==
+          ivs.at(0).get('status').get('uri') ==
           INSTALLATIVERGADERING_BEHANDELD_STATUS
         ) {
           return { period, disabled: false };

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -327,3 +327,8 @@
   height: 0px !important;
   padding: 0px !important;
 }
+
+.ember-power-select-group[aria-disabled=true] .ember-power-select-option,
+.ember-power-select-option[aria-disabled=true] {
+  color: var(--au-gray-400);
+}

--- a/app/templates/mandatarissen/search.hbs
+++ b/app/templates/mandatarissen/search.hbs
@@ -20,7 +20,8 @@
             >
               {{#if period.disabled}}
                 {{period.period.label}}
-                <AuPill @icon="info-circle" @size="small">Niet beschikbaar</AuPill>
+                <AuPill @icon="info-circle" @size="small">Voorbereiding
+                  legislatuur nog actief</AuPill>
               {{else}}
                 {{period.period.label}}
               {{/if}}

--- a/app/templates/mandatarissen/search.hbs
+++ b/app/templates/mandatarissen/search.hbs
@@ -8,11 +8,23 @@
         <form class="au-o-grid au-o-grid--small">
           <div class="au-o-grid__item au-u-1-2 au-u-1-1@medium">
             <div class="au-c-label">Bestuursperiode</div>
-            <Mandatenbeheer::BestuursperiodenSelector
-              @options={{this.model.bestuursPeriods}}
+            <PowerSelect
+              @renderInPlace={{true}}
               @selected={{this.model.selectedPeriod}}
-              @onSelect={{this.selectPeriod}}
-            />
+              @options={{this.model.bestuursPeriods}}
+              class="is-optional"
+              @onChange={{this.selectPeriod}}
+              @searchEnabled={{false}}
+              @noMatchesMessage="Geen bestuursperioden"
+              as |period|
+            >
+              {{#if period.disabled}}
+                {{period.period.label}}
+                <AuPill @icon="info-circle" @size="small">Niet beschikbaar</AuPill>
+              {{else}}
+                {{period.period.label}}
+              {{/if}}
+            </PowerSelect>
           </div>
           <div class="au-o-grid__item au-u-1-2 au-u-1-1@medium">
             <div class="au-c-label">Persoon</div>
@@ -89,7 +101,7 @@
       <div class="au-c-body-container au-c-body-container--scroll">
         <Mandatarissen::PersoonTable
           @content={{@model.personen}}
-          @bestuursperiode={{@model.selectedPeriod}}
+          @bestuursperiode={{@model.selectedPeriod.period}}
           @sort={{this.sort}}
           @page={{this.page}}
           @size={{this.size}}


### PR DESCRIPTION
## Description

Mandataris search page is not available if the legislature is still in preperation. This is implemented by disabling the disabling the bestuursperiode in the selector.

![Screenshot 2024-06-27 at 12 54 34](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/43848896/5dc8c650-c024-47cf-a5d7-65c5bca5f79d)

## How to test

Test for a bestuurseenheid with installatievergadering if the bestuursperiode in the mandataris search route is disabled. And if it becomes enabled again if you update the state of the prepare legislature to behandeld.
