### PR TITLE
LMB-579 quick bugfix

### DIFF
--- a/app/controllers/organen/index.js
+++ b/app/controllers/organen/index.js
@@ -2,7 +2,6 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
-import { INSTALLATIVERGADERING_BEHANDELD_STATUS } from 'frontend-lmb/utils/well-known-uris';
 
 export default class OrganenIndexController extends Controller {
   queryParams = ['sort', 'activeOrgans', 'selectedTypes', 'bestuursperiode'];
@@ -78,25 +77,5 @@ export default class OrganenIndexController extends Controller {
       bindingEinde: similarBestuursorgaanInTijd?.bindingEinde,
     });
     await bestuursorgaanInTijd.save();
-  }
-
-  @action
-  async setIsLegislatuurBehandeld() {
-    const periodeHasLegislatuur =
-      (await this.model.selectedPeriod.installatievergaderingen).length >= 1;
-    if (!periodeHasLegislatuur) {
-      this.isDisabledBecauseLegislatuur = false;
-      return;
-    }
-
-    const behandeldeVergaderingen = await this.store.query(
-      'installatievergadering',
-      {
-        'filter[status][:uri:]': INSTALLATIVERGADERING_BEHANDELD_STATUS,
-        'filter[bestuursperiode][:id:]': this.model.selectedPeriod.id,
-      }
-    );
-
-    this.isDisabledBecauseLegislatuur = behandeldeVergaderingen.length === 0;
   }
 }

--- a/app/routes/organen/index.js
+++ b/app/routes/organen/index.js
@@ -40,7 +40,8 @@ export default class OrganenIndexRoute extends Route {
         selectedPeriod
       );
     const form = await getFormFrom(this.store, BESTUURSORGAAN_FORM_ID);
-    const isBehandeld = await this.isBehandeld(selectedPeriod);
+    const legislatuurInBehandeling =
+      await this.legislatuurInBehandeling(selectedPeriod);
 
     return RSVP.hash({
       bestuurseenheid: parentModel.bestuurseenheid,
@@ -48,11 +49,11 @@ export default class OrganenIndexRoute extends Route {
       form,
       bestuursPeriods,
       selectedPeriod,
-      isBehandeld,
+      legislatuurInBehandeling,
     });
   }
 
-  async isBehandeld(selectedPeriod) {
+  async legislatuurInBehandeling(selectedPeriod) {
     const periodeHasLegislatuur =
       (await selectedPeriod.installatievergaderingen).length >= 1;
     if (!periodeHasLegislatuur) {

--- a/app/routes/organen/index.js
+++ b/app/routes/organen/index.js
@@ -6,6 +6,7 @@ import { action } from '@ember/object';
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import { BESTUURSORGAAN_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import RSVP from 'rsvp';
+import { INSTALLATIVERGADERING_BEHANDELD_STATUS } from 'frontend-lmb/utils/well-known-uris';
 
 export default class OrganenIndexRoute extends Route {
   @service store;
@@ -39,6 +40,7 @@ export default class OrganenIndexRoute extends Route {
         selectedPeriod
       );
     const form = await getFormFrom(this.store, BESTUURSORGAAN_FORM_ID);
+    const isBehandeld = await this.isBehandeld(selectedPeriod);
 
     return RSVP.hash({
       bestuurseenheid: parentModel.bestuurseenheid,
@@ -46,7 +48,26 @@ export default class OrganenIndexRoute extends Route {
       form,
       bestuursPeriods,
       selectedPeriod,
+      isBehandeld,
     });
+  }
+
+  async isBehandeld(selectedPeriod) {
+    const periodeHasLegislatuur =
+      (await selectedPeriod.installatievergaderingen).length >= 1;
+    if (!periodeHasLegislatuur) {
+      return false;
+    }
+
+    const behandeldeVergaderingen = await this.store.query(
+      'installatievergadering',
+      {
+        'filter[status][:uri:]': INSTALLATIVERGADERING_BEHANDELD_STATUS,
+        'filter[bestuursperiode][:id:]': selectedPeriod.id,
+      }
+    );
+
+    return behandeldeVergaderingen.length === 0;
   }
 
   @action

--- a/app/templates/organen/index.hbs
+++ b/app/templates/organen/index.hbs
@@ -58,8 +58,8 @@
         <Group>
           <AuHeading @skin="2">Organen</AuHeading>
         </Group>
-        <Group {{did-insert this.setIsLegislatuurBehandeld}}>
-          {{#if this.isDisabledBecauseLegislatuur}}
+        <Group>
+          {{#if @model.isBehandeld}}
             <AuButton @disabled={{true}}>
               Beheer fracties
             </AuButton>

--- a/app/templates/organen/index.hbs
+++ b/app/templates/organen/index.hbs
@@ -59,7 +59,7 @@
           <AuHeading @skin="2">Organen</AuHeading>
         </Group>
         <Group>
-          {{#if @model.isBehandeld}}
+          {{#if @model.legislatuurInBehandeling}}
             <AuButton @disabled={{true}}>
               Beheer fracties
             </AuButton>


### PR DESCRIPTION
## Description

Bugfix disable beheer fracties button persisted when changing bestuursperiode. 

## How to test

Go to bestuurseenheid Aalst to the orgaan page. Check if the beheer fracties button updates when changing bestuursperiode. It should be disabled on 2025-heden and enabled in the other ones.