### PR TITLE
LMB-501 Update contact technische dienst

### DIFF
--- a/app/components/mandaat/publicatie-status-pill.hbs
+++ b/app/components/mandaat/publicatie-status-pill.hbs
@@ -23,10 +23,10 @@
         <AuIcon @icon="info-circle" />
         <span class="au-u-margin-right-tiny">Om een bekrachtiging terug te
           trekken moet je de
+          <AuLinkExternal
+            href="mailto:lokaalmandatenbeheer@vlaanderen.be?subject=Bekrachtiging terugtrekken - Lokaal Mandatenbeheer"
+          >technische dienst contacteren</AuLinkExternal>
         </span>
-        <AuLinkExternal href="">
-          technische dienst contacteren
-        </AuLinkExternal>
       </p>
     {{/unless}}
   {{/if}}


### PR DESCRIPTION
## Description

Contact technische dienst is replaced with an actual mailto. 

## How to test

Go to a mandataris that has a bekrachtigd status, e.g. [http://localhost:4200/mandatarissen/65C9E0E2653C4BA4B205DE15/persoon/65C9E11C653C4BA4B205DE16/mandataris](http://localhost:4200/mandatarissen/65C9E0E2653C4BA4B205DE15/persoon/65C9E11C653C4BA4B205DE16/mandataris) in gemeente Aalst. And check if your email client pops up with the correct mailadres and title.
