### PR TITLE
only fetch mandatarissen that have a person attached to them

### DIFF
--- a/app/routes/organen/orgaan/mandatarissen.js
+++ b/app/routes/organen/orgaan/mandatarissen.js
@@ -54,6 +54,7 @@ export default class OrganenMandatarissenRoute extends Route {
             id: bestuursOrgaan.id,
           },
         },
+        ':has:is-bestuurlijke-alias-van': true,
       },
       include: [
         'is-bestuurlijke-alias-van',


### PR DESCRIPTION
## Description

If you went to the college van burgemeester en schepenen with a bestuursperiode that has a prepare legislature (and you did not add a burgemeester yet), you sometimes got the following error because a default burgemeester was created, which is not atttached to a person (you do have to have opened the prepare legislature page before this happens). This PR only fetches mandatarissen that have a person attached to them, which fixes this.

<img width="1089" alt="Screenshot 2024-07-03 at 08 24 23" src="https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/43848896/5454162a-d84a-4716-83ac-728b8d6bc255">

## How to test

Best to first run the migration in the linked PR, the prepare installatievergadering did not have all bestuursorganen yet, which might not throw the error. 
Then go to the prepare legislature page of a bestuurseenheid and then go to the orgaan page of burgemeester and cbs, no errors should be thrown. 

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/170
