### PR TITLE
Ben/lmb 512 titelvoerend vs verhinderd status

### DIFF
--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -90,10 +90,8 @@ export default class MandatarissenUpdateState extends Component {
       (this.newStatus?.get('uri') === MANDATARIS_VERHINDERD_STATE ||
         this.newStatus?.get('uri') === MANDATARIS_TITELVOEREND_STATE) &&
       // if we are already verhinderd it does not make sense to change the replacements here, keep them  the same and don't show the selector
-      (this.args.mandataris.status?.get('uri') !==
-        MANDATARIS_VERHINDERD_STATE ||
-        this.args.mandataris.status?.get('uri') !==
-          MANDATARIS_TITELVOEREND_STATE)
+      this.args.mandataris.status?.get('uri') !== MANDATARIS_VERHINDERD_STATE &&
+      this.args.mandataris.status?.get('uri') !== MANDATARIS_TITELVOEREND_STATE
     );
   }
 

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -6,9 +6,10 @@ import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
 import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
-import { VERHINDERD_STATE_ID } from 'frontend-lmb/utils/well-known-ids';
 import { getDraftPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
 import {
+  MANDATARIS_TITELVOEREND_STATE,
+  MANDATARIS_VERHINDERD_STATE,
   burgemeesterOnlyStates,
   notBurgemeesterStates,
 } from 'frontend-lmb/utils/well-known-uris';
@@ -86,9 +87,13 @@ export default class MandatarissenUpdateState extends Component {
 
   get showReplacement() {
     return (
-      this.newStatus?.id === VERHINDERD_STATE_ID &&
+      (this.newStatus?.get('uri') === MANDATARIS_VERHINDERD_STATE ||
+        this.newStatus?.get('uri') === MANDATARIS_TITELVOEREND_STATE) &&
       // if we are already verhinderd it does not make sense to change the replacements here, keep them  the same and don't show the selector
-      this.args.mandataris.status?.id !== VERHINDERD_STATE_ID
+      (this.args.mandataris.status?.get('uri') !==
+        MANDATARIS_VERHINDERD_STATE ||
+        this.args.mandataris.status?.get('uri') !==
+          MANDATARIS_TITELVOEREND_STATE)
     );
   }
 

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -8,7 +8,10 @@ import { service } from '@ember/service';
 import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
 import { VERHINDERD_STATE_ID } from 'frontend-lmb/utils/well-known-ids';
 import { getDraftPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
-import { burgemeesterOnlyStates } from 'frontend-lmb/utils/well-known-uris';
+import {
+  burgemeesterOnlyStates,
+  notBurgemeesterStates,
+} from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarissenUpdateState extends Component {
   @tracked newStatus = null;
@@ -62,7 +65,9 @@ export default class MandatarissenUpdateState extends Component {
     const statuses = this.mandatarisStatus.statuses.slice();
 
     if (isBurgemeester) {
-      return statuses;
+      return statuses.filter(
+        (status) => !notBurgemeesterStates.includes(status.uri)
+      );
     }
     return statuses.filter(
       (status) => !burgemeesterOnlyStates.includes(status.uri)

--- a/app/components/rdf-input-fields/mandataris-replacement-selector.js
+++ b/app/components/rdf-input-fields/mandataris-replacement-selector.js
@@ -12,7 +12,10 @@ import {
 import { task, timeout } from 'ember-concurrency';
 import { MANDAAT, ORG } from 'frontend-lmb/rdf/namespaces';
 import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
-import { MANDATARIS_VERHINDERD_STATE } from 'frontend-lmb/utils/well-known-uris';
+import {
+  MANDATARIS_TITELVOEREND_STATE,
+  MANDATARIS_VERHINDERD_STATE,
+} from 'frontend-lmb/utils/well-known-uris';
 import { NamedNode } from 'rdflib';
 
 export default class MandatarisReplacementSelector extends InputFieldComponent {
@@ -53,12 +56,19 @@ export default class MandatarisReplacementSelector extends InputFieldComponent {
   }
 
   checkIfShouldRender() {
-    this.shouldRender = this.storeOptions.store.any(
-      this.storeOptions.sourceNode,
-      MANDAAT('status'),
-      new NamedNode(MANDATARIS_VERHINDERD_STATE),
-      this.storeOptions.sourceGraph
-    );
+    this.shouldRender =
+      this.storeOptions.store.any(
+        this.storeOptions.sourceNode,
+        MANDAAT('status'),
+        new NamedNode(MANDATARIS_VERHINDERD_STATE),
+        this.storeOptions.sourceGraph
+      ) ||
+      this.storeOptions.store.any(
+        this.storeOptions.sourceNode,
+        MANDAAT('status'),
+        new NamedNode(MANDATARIS_TITELVOEREND_STATE),
+        this.storeOptions.sourceGraph
+      );
     if (!this.shouldRender && this.replacements?.length > 0) {
       // without timeout, the form ttl doesn't update immediately
       setTimeout(() => this.selectReplacement([]), 100);

--- a/app/components/rdf-input-fields/mandataris-status-selector.js
+++ b/app/components/rdf-input-fields/mandataris-status-selector.js
@@ -4,7 +4,10 @@ import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
 import { queryRecord } from 'frontend-lmb/utils/query-record';
-import { burgemeesterOnlyStates } from 'frontend-lmb/utils/well-known-uris';
+import {
+  burgemeesterOnlyStates,
+  notBurgemeesterStates,
+} from 'frontend-lmb/utils/well-known-uris';
 import { ORG } from 'frontend-lmb/rdf/namespaces';
 
 export default class RdfInputFieldsMandatarisStatusSelectorComponent extends RdfInputFieldsConceptSchemeSelectorComponent {
@@ -56,7 +59,9 @@ export default class RdfInputFieldsMandatarisStatusSelectorComponent extends Rdf
       ?.isBurgemeester;
 
     if (isBurgemeester) {
-      return statuses;
+      return statuses.filter(
+        (status) => !notBurgemeesterStates.includes(status.subject.value)
+      );
     }
 
     return statuses.filter(

--- a/app/utils/well-known-ids.js
+++ b/app/utils/well-known-ids.js
@@ -16,7 +16,6 @@ export const OTHER_BESTUURSORGANEN_CONCEPT_SCHEME =
 export const CREATE_PERSON_FORM_ID = 'persoon';
 export const BESTUURSORGAAN_FORM_ID = 'bestuursorgaan';
 export const BESTUURSPERIODE_FORM_ID = 'bestuursperiode';
-export const VERHINDERD_STATE_ID = 'c301248f-0199-45ca-b3e5-4c596731d5fe';
 export const BESTUURSEENHEID_CONTACT_FORM_ID = 'bestuurseenheid-contact';
 
 export const INSTALLATIEVERGADERING_TE_BEHANDELEN =

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -62,10 +62,12 @@ export const MANDAAT_TOEGEVOEGDE_SCHEPEN_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/59a90e03-4f22-4bb9-8c91-132618db4b38';
 export const MANDAAT_DISTRICT_SCHEPEN_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001e';
+
 export const burgemeesterOnlyStates = [
   MANDATARIS_AANGEWEZEN_STATE,
   MANDATARIS_TITELVOEREND_STATE,
 ];
+export const notBurgemeesterStates = [MANDATARIS_VERHINDERD_STATE];
 
 export const INSTALLATIEVERGADERING_BEHANDELD_STATUS =
   'http://data.lblod.info/id/concept/InstallatievergaderingStatus/c9fc3292-1576-4a82-8dcd-60795e22131f';


### PR DESCRIPTION
## Description

The mandataris status verhinderd is only available for not burgemeesters and the status titelvoerend is only available for burgemeesters.

## How to test

Every place a mandataris status code selector is used, it should only be possible to select a status that is valid with the selected mandate. This can be done in the form for creating a new mandataris or in the form for updating the status of a mandataris. 
Also if you update the status of a burgemeester to titelvoerend, this should also activate the possibility to add a replacement.
