### PR TITLE
LMB-513 | Remove aangewezen mandataris status

### DIFF
--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -8,8 +8,6 @@ export const BESTUURSEENHEID_CLASSIFICATIECODE_OCMW =
   'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002';
 export const MANDATARIS_VERHINDERD_STATE =
   'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/c301248f-0199-45ca-b3e5-4c596731d5fe';
-export const MANDATARIS_AANGEWEZEN_STATE =
-  'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/e371f89a-9e83-4a8c-a98e-cd09226fa549';
 export const MANDATARIS_TITELVOEREND_STATE =
   'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/aacb3fed-b51d-4e0b-a411-f3fa641da1b3';
 export const MANDATARIS_EFFECTIEF_STATE =
@@ -63,10 +61,7 @@ export const MANDAAT_TOEGEVOEGDE_SCHEPEN_CODE =
 export const MANDAAT_DISTRICT_SCHEPEN_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001e';
 
-export const burgemeesterOnlyStates = [
-  MANDATARIS_AANGEWEZEN_STATE,
-  MANDATARIS_TITELVOEREND_STATE,
-];
+export const burgemeesterOnlyStates = [MANDATARIS_TITELVOEREND_STATE];
 export const notBurgemeesterStates = [MANDATARIS_VERHINDERD_STATE];
 
 export const INSTALLATIEVERGADERING_BEHANDELD_STATUS =


### PR DESCRIPTION
## Description

Aangewezen status is not used anymore. Aangeqwezen burgemeester has become a mandaat.

## How to test

1. The id of the status is not used anymore
2. The constant is not used anymore

## Link to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/173 
