### PR TITLE
LMB-481 | Update UI to show besluit

### DIFF
--- a/app/components/mandaat/publicatie-status-pill.hbs
+++ b/app/components/mandaat/publicatie-status-pill.hbs
@@ -25,18 +25,16 @@
       class="au-u-margin-left-tiny"
     >Bekijk besluit</AuLinkExternal>
   {{/if}}
-  {{#if @showInfoText}}
-    {{#if this.isMandatarisBekrachtigd}}
-      <p
-        class="au-u-italic au-u-h-functional au-u-flex au-u-flex--vertical-center"
-      >
-        <span class="au-u-margin-top-small u-u-margin-right-tiny">Om een
-          bekrachtiging terug te trekken moet je de
-          <AuLinkExternal
-            href="mailto:lokaalmandatenbeheer@vlaanderen.be?subject=Bekrachtiging terugtrekken - Lokaal Mandatenbeheer"
-          >technische dienst contacteren</AuLinkExternal>
-        </span>
-      </p>
-    {{/if}}
+  {{#if (and @showInfoText this.isMandatarisBekrachtigd)}}
+    <p
+      class="au-u-italic au-u-h-functional au-u-flex au-u-flex--vertical-center"
+    >
+      <span class="au-u-margin-top-small u-u-margin-right-tiny">Om een
+        bekrachtiging terug te trekken moet je de
+        <AuLinkExternal
+          href="mailto:lokaalmandatenbeheer@vlaanderen.be?subject=Bekrachtiging terugtrekken - Lokaal Mandatenbeheer"
+        >technische dienst contacteren</AuLinkExternal>
+      </span>
+    </p>
   {{/if}}
 </div>

--- a/app/components/mandaat/publicatie-status-pill.hbs
+++ b/app/components/mandaat/publicatie-status-pill.hbs
@@ -15,14 +15,18 @@
   >
     {{or @mandataris.publicationStatus.label "Bekrachtigd"}}
   </AuPill>
-  {{#if (and @showBekijkBewijs @mandataris.linkToBesluit)}}
+  {{#if
+    (and
+      @showBekijkBewijs @mandataris.linkToBesluit this.isMandatarisBekrachtigd
+    )
+  }}
     <AuLinkExternal
       href={{@mandataris.linkToBesluit}}
       class="au-u-margin-left-tiny"
     >Bekijk besluit</AuLinkExternal>
   {{/if}}
   {{#if @showInfoText}}
-    {{#unless @mandataris.publicationStatus.label}}
+    {{#if this.isMandatarisBekrachtigd}}
       <p
         class="au-u-italic au-u-h-functional au-u-flex au-u-flex--vertical-center"
       >
@@ -33,6 +37,6 @@
           >technische dienst contacteren</AuLinkExternal>
         </span>
       </p>
-    {{/unless}}
+    {{/if}}
   {{/if}}
 </div>

--- a/app/components/mandaat/publicatie-status-pill.hbs
+++ b/app/components/mandaat/publicatie-status-pill.hbs
@@ -15,6 +15,12 @@
   >
     {{or @mandataris.publicationStatus.label "Bekrachtigd"}}
   </AuPill>
+  {{#if (and @showBekijkBewijs @mandataris.linkToBesluit)}}
+    <AuLinkExternal
+      href={{@mandataris.linkToBesluit}}
+      class="au-u-margin-left-tiny"
+    >Bekijk besluit</AuLinkExternal>
+  {{/if}}
   {{#if @showInfoText}}
     {{#unless @mandataris.publicationStatus.label}}
       <p

--- a/app/components/mandaat/publicatie-status-pill.hbs
+++ b/app/components/mandaat/publicatie-status-pill.hbs
@@ -26,9 +26,8 @@
       <p
         class="au-u-italic au-u-h-functional au-u-flex au-u-flex--vertical-center"
       >
-        <AuIcon @icon="info-circle" />
-        <span class="au-u-margin-right-tiny">Om een bekrachtiging terug te
-          trekken moet je de
+        <span class="au-u-margin-top-small u-u-margin-right-tiny">Om een
+          bekrachtiging terug te trekken moet je de
           <AuLinkExternal
             href="mailto:lokaalmandatenbeheer@vlaanderen.be?subject=Bekrachtiging terugtrekken - Lokaal Mandatenbeheer"
           >technische dienst contacteren</AuLinkExternal>

--- a/app/components/mandaat/publicatie-status-pill.js
+++ b/app/components/mandaat/publicatie-status-pill.js
@@ -1,0 +1,20 @@
+import Component from '@glimmer/component';
+
+import { MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE } from 'frontend-lmb/utils/well-known-uris';
+
+export default class MandaatPublicatieStatusPillComponent extends Component {
+  get isMandatarisBekrachtigd() {
+    if (!this.args.mandataris.publicationStatus.label) {
+      return true;
+    }
+
+    if (
+      this.args.mandataris.publicationStatus.uri ===
+      MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -22,13 +22,8 @@
         <Mandaat::PublicatieStatusPill
           @mandataris={{@mandataris}}
           @showInfoText={{true}}
+          @showBekijkBewijs={{true}}
         />
-        {{#if @mandataris.linkToBesluit}}
-          <AuLinkExternal
-            href={{@mandataris.linkToBesluit}}
-            class="au-u-margin-left-tiny"
-          >Bekijk besluit</AuLinkExternal>
-        {{/if}}
       </div>
     </div>
     {{#if @mandataris.bekleedt.isSchepen}}
@@ -61,14 +56,6 @@
         {{/if}}
       </div>
     </div>
-    {{#if @mandataris.linkToBesluit}}
-      <div class="au-o-grid__item au-u-5-6">
-        <div class="au-c-description-label"><div>Link naar besluit</div></div>
-        <div class="au-c-description-value au-u-margin-top-tiny"><AuLink
-          >{{@mandataris.linkToBesluit}}</AuLink></div>
-      </div>
-    {{/if}}
-
     {{#if (await this.vervangersVan)}}
       <div class="au-o-grid__item au-u-5-6">
         <div class="au-c-description-label"><div>Vervanger van:</div></div>

--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -23,8 +23,11 @@
           @mandataris={{@mandataris}}
           @showInfoText={{true}}
         />
-        {{#if this.hasBesluit}}
-          <AuLinkExternal href="" class="au-u-margin-left-tiny">Bekijk besluit</AuLinkExternal>
+        {{#if @mandataris.linkToBesluit}}
+          <AuLinkExternal
+            href={{@mandataris.linkToBesluit}}
+            class="au-u-margin-left-tiny"
+          >Bekijk besluit</AuLinkExternal>
         {{/if}}
       </div>
     </div>

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -29,8 +29,4 @@ export default class MandatarisCardComponent extends Component {
 
     return 'default';
   }
-
-  get hasBesluit() {
-    return false;
-  }
 }


### PR DESCRIPTION
## Description

We want to make the link to the besluit available for the user when the status of the mandataris is bekrachtigd.

Also removed the info icon next to "contacteer technische dienst" as UI wise this was very ugly

## How to test

1. Add a link to bewijs by filling a url in into the link to besluit field when correcting mistakes.
2. Now the "Bekijk bewijs" link is shown next to the status pill and goes to that link in a new window

## Attachments

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/36266973/2de6bf04-83b6-4498-a870-235715f5167e)
