### PR TITLE
LMB-481 | Use aangewezen burgemeester in legislatuur

### DIFF
--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -10,7 +10,7 @@ import {
   getEffectiefStatus,
 } from 'frontend-lmb/utils/get-mandataris-status';
 import {
-  BESTUURSFUNCTIE_BURGEMEESTER_ID,
+  BESTUURSFUNCTIE_AANGEWEZEN_BURGEMEESTER_ID,
   BESTUURSFUNCTIE_VOORZITTER_VAST_BUREAU_ID,
   CREATE_PERSON_FORM_ID,
 } from 'frontend-lmb/utils/well-known-ids';
@@ -73,7 +73,7 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
         },
         bestuursfunctie: {
           id: [
-            BESTUURSFUNCTIE_BURGEMEESTER_ID,
+            BESTUURSFUNCTIE_AANGEWEZEN_BURGEMEESTER_ID,
             BESTUURSFUNCTIE_VOORZITTER_VAST_BUREAU_ID,
           ].join(','),
         },
@@ -81,7 +81,10 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
       include: 'bestuursfunctie',
     });
     this.burgemeesterMandate = mandates.find((m) => {
-      return m.get('bestuursfunctie.id') === BESTUURSFUNCTIE_BURGEMEESTER_ID;
+      return (
+        m.get('bestuursfunctie.id') ===
+        BESTUURSFUNCTIE_AANGEWEZEN_BURGEMEESTER_ID
+      );
     });
     this.voorzitterVastBureauMandate = mandates.find((m) => {
       return (


### PR DESCRIPTION
## Description

Now when selecting a burgemeester in the legislatuur this is a burgemeester with a burgemeester mandate. This should change to a AANGEWEZEN burgemeester mandate.

## How to test

1. Go to the legislatuur and select a burgemeester
2. Go to organen (in the correct bestuursperiode) and select burgemeester orgaan
3. You should now see an aangewezen burgemeester mandaat there

## Attachments

![image](https://github.com/lblod/frontend-lokaal-mandatenbeheer/assets/36266973/18286379-cea8-4594-a2f9-565b7564cb7b)


## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/264 => **first review this**
