### PR TITLE
LMB-465 | Remove sorting on tables in legislatuur

### DIFF
--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -26,7 +26,6 @@
       @page={{1}}
       @fields="gebruikteVoornaam achternaam actions"
       @noDataMessage="Geen burgemeester aangewezen"
-      @sort={{this.sort}}
       as |t|
     >
       <t.content as |c|>

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -28,7 +28,7 @@
       as |t|
     >
       <t.content as |c|>
-        <c.header class="au-u-muted">
+        <c.header>
           <th class="au-u-padding-small">Voornaam</th>
           <th>Familienaam</th>
           <th>

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -28,8 +28,8 @@
       as |t|
     >
       <t.content as |c|>
-        <c.header>
-          <th>Voornaam</th>
+        <c.header class="au-u-muted">
+          <th class="au-u-padding-small">Voornaam</th>
           <th>Familienaam</th>
           <th>
             {{! actions }}

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -23,7 +23,6 @@
   {{else}}
     <AuDataTable
       @content={{this.aangewezenBurgemeesters}}
-      @page={{1}}
       @fields="gebruikteVoornaam achternaam actions"
       @noDataMessage="Geen burgemeester aangewezen"
       as |t|

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -31,16 +31,8 @@
     >
       <t.content as |c|>
         <c.header>
-          <AuDataTableThSortable
-            @field="gebruikteVoornaam"
-            @currentSorting={{this.sort}}
-            @label="Voornaam"
-          />
-          <AuDataTableThSortable
-            @field="achternaam"
-            @currentSorting={{this.sort}}
-            @label="Familienaam"
-          />
+          <th>Voornaam</th>
+          <th>Familienaam</th>
           <th>
             {{! actions }}
           </th>

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -4,7 +4,6 @@
     <AuDataTable
       @content={{this.resortedMandatarissen}}
       @noDataMessage="Geen mandatarissen gevonden"
-      @sort={{@sort}}
       @page={{@page}}
       @size={{@size}}
       as |t|

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -9,7 +9,7 @@
       as |t|
     >
       <t.content as |c|>
-        <c.header class="au-u-muted">
+        <c.header>
           <th class="au-u-padding-small">Voornaam</th>
           <th>Familienaam</th>
           {{#if @showFractie}}

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -1,4 +1,4 @@
-<div {{did-update this.onInit @sort}}>
+<div {{did-update this.onInit}}>
   <div class="au-o-box no-pagination">
     <h1 class="au-u-h2 au-u-margin-bottom-small">{{@title}}</h1>
     <AuDataTable

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -11,55 +11,23 @@
     >
       <t.content as |c|>
         <c.header>
-          <AuDataTableThSortable
-            @field="isBestuurlijkeAliasVan.gebruikteVoornaam"
-            @currentSorting={{@sort}}
-            @label="Voornaam"
-          />
-          <AuDataTableThSortable
-            @field="isBestuurlijkeAliasVan.achternaam"
-            @currentSorting={{@sort}}
-            @label="Familienaam"
-          />
+          <th>Voornaam</th>
+          <th>Familienaam</th>
           {{#if @showFractie}}
-            <AuDataTableThSortable
-              @field="heeftLidmaatschap.binnenFractie.naam"
-              @currentSorting={{@sort}}
-              @label="Fractie"
-            />
+            <th>Fractie</th>
           {{/if}}
           {{#if @showFunctie}}
-            <AuDataTableThSortable
-              @field="bekleedt.bestuursfunctie.label"
-              @currentSorting={{@sort}}
-              @label="Mandaat"
-            />
+            <th>Mandaat</th>
           {{/if}}
           {{#if @showRangorde}}
-            <AuDataTableThSortable
-              @field="rangorde"
-              @currentSorting={{@sort}}
-              @label="Rangorde"
-            />
+            <th>Rangorde</th>
           {{/if}}
           {{#if @showBevoegdheid}}
-            <AuDataTableThSortable
-              @field="beleidsdomein"
-              @currentSorting={{@sort}}
-              @label="Bevoegdheden"
-            />
+            <th>Bevoegdheden</th>
           {{/if}}
           {{#if @showStartEndDate}}
-            <AuDataTableThSortable
-              @field="start"
-              @currentSorting={{@sort}}
-              @label="Start mandaat"
-            />
-            <AuDataTableThSortable
-              @field="einde"
-              @currentSorting={{@sort}}
-              @label="Einde mandaat"
-            />
+            <th>Start mandaat</th>
+            <th>Einde mandaat</th>
           {{/if}}
           {{#unless @readOnly}}
             <th>{{! Delete }}</th>

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -9,8 +9,8 @@
       as |t|
     >
       <t.content as |c|>
-        <c.header>
-          <th>Voornaam</th>
+        <c.header class="au-u-muted">
+          <th class="au-u-padding-small">Voornaam</th>
           <th>Familienaam</th>
           {{#if @showFractie}}
             <th>Fractie</th>

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -22,20 +22,16 @@ export default class DraftMandatarisListComponent extends Component {
   }
 
   get resortedMandatarissen() {
-    if (!this.args.sort || this.args.sort.indexOf('rangorde') < 0) {
-      return this.mandatarissen;
+    if (!this.mandatarissen) {
+      return [];
     }
-    const sorted = orderMandatarissenByRangorde([...this.mandatarissen]);
-    if (this.args.sort.startsWith('-')) {
-      return sorted.reverse();
-    }
-    return sorted;
+
+    return orderMandatarissenByRangorde([...this.mandatarissen]);
   }
 
   @action
   async onInit() {
     const queryParams = {
-      sort: this.args.sort,
       page: {
         number: 0,
         size: 9999,
@@ -60,7 +56,7 @@ export default class DraftMandatarisListComponent extends Component {
       queryParams['filter']['is-bestuurlijke-alias-van'] = this.args.filter;
     }
 
-    this.mandatarissen = this.store.query('mandataris', queryParams);
+    this.mandatarissen = await this.store.query('mandataris', queryParams);
   }
 
   @action

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -56,7 +56,6 @@
     <Verkiezingen::DraftMandatarisList
       @readOnly={{@isBehandeld}}
       @bestuursorgaan={{@bestuursorgaan}}
-      @sort={{@sort}}
       @page={{0}}
       @size={{9999}}
       @title=""

--- a/app/controllers/verkiezingen/installatievergadering.js
+++ b/app/controllers/verkiezingen/installatievergadering.js
@@ -12,7 +12,7 @@ import {
 
 import { task } from 'ember-concurrency';
 
-export default class VerkiezingenInstallatievergaderingController extends Controller {
+export default class PrepareInstallatievergaderingController extends Controller {
   queryParams = ['bestuursperiode'];
   @service store;
   @service router;

--- a/app/routes/verkiezingen/installatievergadering.js
+++ b/app/routes/verkiezingen/installatievergadering.js
@@ -21,8 +21,6 @@ export default class PrepareInstallatievergaderingRoute extends Route {
   @service bestuursorganen;
 
   queryParams = {
-    filter: { refreshModel: true },
-    sort: { refreshModel: true },
     bestuursperiode: { refreshModel: true },
   };
 

--- a/app/templates/verkiezingen/installatievergadering.hbs
+++ b/app/templates/verkiezingen/installatievergadering.hbs
@@ -80,7 +80,6 @@
         @isBehandeld={{@model.isBehandeld}}
         @bestuursorgaan={{bestuursorgaan}}
         @bestuursorganen={{@model.bestuursorganenInTijd}}
-        @sort={{this.sort}}
         @form={{@model.mandatarisForm}}
       />
     {{/each}}


### PR DESCRIPTION
## Description

We do not want sorting on the tables in the legislatuur page. When a rangorde is shown in the tables the values should be sorted by that property. This is logic that already existed so we just need to remove the sorting in the columns and the parameter in the query. NBot that the burgmeester selector is also shown as a table from now on so the sorting should also be removed there. (This should always be one value so it's in general a little stupid to be able to sort this ;p)

## How to test

Go to the legislatuur page and see that you cannot sort the values anymore

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/267 => **Created from this PR**
