### PR TITLE
LMB-622 | When no mandatarissen in source table show warning when syncing

### DIFF
--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -26,6 +26,7 @@ import {
   getDraftPublicationStatus,
   getEffectiefStatus,
 } from 'frontend-lmb/utils/get-mandataris-status';
+import { showWarningToast } from 'frontend-lmb/utils/toasts';
 
 const CREATE_MODE = 'create';
 
@@ -90,14 +91,22 @@ export default class PrepareLegislatuurSectionComponent extends Component {
     }
 
     if (!bestuursorgaanToSyncFrom) {
-      throw `Kon niet synchroniseren. Geen bestuursorgaan gevonden.`;
+      showWarningToast(
+        this.toaster,
+        'Kon niet synchroniseren. Geen bestuursorgaan gevonden.'
+      );
+      return;
     }
     const mandatarissenToSync = await this.getBestuursorgaanMandatarissen(
       bestuursorgaanToSyncFrom
     );
 
     if (mandatarissenToSync.length == 0) {
-      throw `Geen mandatarissen gevonden om te synchroniseren.`;
+      showWarningToast(
+        this.toaster,
+        'Geen mandatarissen gevonden om over te nemen.'
+      );
+      return;
     }
     this.skeletonRowsOfMirror = mandatarissenToSync.length;
     console.log(`rows`, mandatarissenToSync.length);
@@ -127,7 +136,11 @@ export default class PrepareLegislatuurSectionComponent extends Component {
       );
 
       if (bestuurfunctieCodes.length == 0) {
-        throw `Geen bestuursfunctie gevonden om te synchroniseren.`;
+        showWarningToast(
+          this.toaster,
+          'Geen bestuursfunctie gevonden om te synchroniseren.'
+        );
+        return;
       }
 
       const toBestuursfunctie = bestuurfunctieCodes[0];

--- a/app/utils/toasts.js
+++ b/app/utils/toasts.js
@@ -16,4 +16,15 @@ const showErrorToast = (toaster, message, title = 'Error') => {
   toaster.error(message, title);
 };
 
-export { notifyFormSavedSuccessfully, showSuccessToast, showErrorToast };
+const showWarningToast = (toaster, message, title = 'Opgelet') => {
+  toaster.warning(message, title, {
+    timeOut: 5000,
+  });
+};
+
+export {
+  notifyFormSavedSuccessfully,
+  showSuccessToast,
+  showErrorToast,
+  showWarningToast,
+};


### PR DESCRIPTION
## Description

A user is able to press the sync button on the legislatuur page. When no mandatarissen are foudn to sync nothing happens. As disabling the sync button would be alot of logic for some simple user interaction we are showing a warning toaster message when there are no mandatarissen to sync.

## How to test

Go to legislatuur page and press the sync button when there are not mandatarissen in the table.

## Attachments

![image](https://github.com/user-attachments/assets/3c302005-92d3-4c96-8ec6-4a1a62099a7c)
