### PR TITLE
Ben/lmb 595 bug fracties aanmaken

### DIFF
--- a/app/routes/organen/fracties.js
+++ b/app/routes/organen/fracties.js
@@ -28,7 +28,7 @@ export default class FractiesRoute extends Route {
 
     const bestuursPeriods = await this.store.query('bestuursperiode', {
       sort: 'label',
-      'filter[:has:heeft-bestuursorganen-in-tijd]': 'true',
+      'filter[:has:heeft-bestuursorganen-in-tijd]': true,
       include: 'installatievergaderingen',
     });
 

--- a/app/routes/organen/fracties.js
+++ b/app/routes/organen/fracties.js
@@ -36,24 +36,17 @@ export default class FractiesRoute extends Route {
       await Promise.all(
         bestuursPeriods.map(async (period) => {
           const ivs = await period.installatievergaderingen;
-          let valid = false;
-          if (ivs.length < 1) {
-            valid = true;
-          } else if (
-            ivs.at(0).get('status').get('uri') ==
-            INSTALLATIEVERGADERING_BEHANDELD_STATUS
+          if (
+            ivs.length === 0 ||
+            ivs[0].get('status').get('uri') ===
+              INSTALLATIEVERGADERING_BEHANDELD_STATUS
           ) {
-            valid = true;
+            return period;
           }
-          return {
-            value: period,
-            valid,
-          };
+          return null;
         })
       )
-    )
-      .filter((v) => v.valid)
-      .map((data) => data.value);
+    ).filter(Boolean);
 
     let selectedPeriod = this.bestuursperioden.getRelevantPeriod(
       filteredBestuursPeriods,

--- a/app/routes/organen/fracties.js
+++ b/app/routes/organen/fracties.js
@@ -25,6 +25,7 @@ export default class FractiesRoute extends Route {
 
     const bestuursPeriods = await this.store.query('bestuursperiode', {
       sort: 'label',
+      'filter[:has:heeft-bestuursorganen-in-tijd]': 'true',
     });
     let selectedPeriod = this.bestuursperioden.getRelevantPeriod(
       bestuursPeriods,

--- a/app/templates/organen/index.hbs
+++ b/app/templates/organen/index.hbs
@@ -59,7 +59,12 @@
           <AuHeading @skin="2">Organen</AuHeading>
         </Group>
         <Group>
-          {{#if @model.legislatuurInBehandeling}}
+          {{#if
+            (or
+              @model.legislatuurInBehandeling
+              (eq @model.bestuursorganen.length 0)
+            )
+          }}
             <AuButton @disabled={{true}}>
               Beheer fracties
             </AuButton>


### PR DESCRIPTION
## Description

It is no longer possible to add fracties if the selected bestuursperiode has no bestuursorganen. This is disabled because if this is possible these fracties are not really useful, they aren't shown, because fracties are only fetched based on bestuursorganen and these fracties would never be added to a bestuursorgaan, even if new bestuursorganen were added, so they have no point at all. 
This is disabled in two places. In the organen page: 
<img width="1059" alt="Screenshot 2024-07-15 at 15 16 24" src="https://github.com/user-attachments/assets/d2fcc149-c3c5-40e0-8ad0-1de0a7e6c071">
And in the bestuursperiode selector of the fractie page.

## How to test

Go to the organen page and see what happens with the beheer fracties button depending on which bestuursperiode is selected. Also if you go to the beheer fracties page, the bestuursperiode selector only shows bestuursperiods for which it makes sense to edit fracties (they should have bestuursorganen and they should not have an active prepare legislature page.
