### PR TITLE
LMB-553 | Person, mandaat and  fractie selector support warning and error validations

### DIFF
--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -103,7 +103,7 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
     this.errorMessages = [
       ...this.errorMessages,
       `Er zijn meerdere personen gevonden met het mandaat ${mandaatName}. Enkel de eerste zal aangepast worden:
-      ${toUserReadableListing(personen, (p) => `${p.gebruikteVoornaam} ${p.achternaam}`)}.`,
+      ${toUserReadableListing(personen, (p) => `${p?.gebruikteVoornaam} ${p?.achternaam}`)}.`,
     ];
   }
 

--- a/app/components/rdf-input-fields/mandataris-fractie-selector.hbs
+++ b/app/components/rdf-input-fields/mandataris-fractie-selector.hbs
@@ -1,4 +1,9 @@
-<AuLabel>{{this.title}}</AuLabel>
+<AuLabel
+  for="fractie"
+  @error={{this.hasErrors}}
+  @warning={{this.hasWarnings}}
+  @required={{this.isRequired}}
+>{{this.title}}</AuLabel>
 {{#if this.initialized}}
   <div class={{if this.hasErrors "ember-power-select--error"}}>
     <Mandatarissen::FractieSelector
@@ -9,6 +14,13 @@
       @onClose={{fn (mut this.hasBeenFocused) true}}
     />
   </div>
+  {{#each this.errors as |error|}}
+    <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
+  {{/each}}
+
+  {{#each this.warnings as |warning|}}
+    <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
+  {{/each}}
 {{else}}
   <p class="skeleton-input-full au-u-margin-top"></p>
 {{/if}}

--- a/app/components/rdf-input-fields/mandataris-fractie-selector.js
+++ b/app/components/rdf-input-fields/mandataris-fractie-selector.js
@@ -79,7 +79,6 @@ export default class MandatarisFractieSelector extends InputFieldComponent {
   @action
   async onSelectFractie(fractie) {
     const uri = fractie?.uri;
-
     replaceSingleFormValue(this.storeOptions, uri ? new NamedNode(uri) : null);
     this.selectedFractie = fractie;
     this.hasBeenFocused = true;

--- a/app/components/rdf-input-fields/mandataris-fractie-selector.js
+++ b/app/components/rdf-input-fields/mandataris-fractie-selector.js
@@ -79,6 +79,7 @@ export default class MandatarisFractieSelector extends InputFieldComponent {
   @action
   async onSelectFractie(fractie) {
     const uri = fractie?.uri;
+
     replaceSingleFormValue(this.storeOptions, uri ? new NamedNode(uri) : null);
     this.selectedFractie = fractie;
     this.hasBeenFocused = true;

--- a/app/components/rdf-input-fields/mandataris-mandaat-selector.hbs
+++ b/app/components/rdf-input-fields/mandataris-mandaat-selector.hbs
@@ -1,13 +1,25 @@
-<div>
-  <AuLabel for="mandaat">Mandaat</AuLabel>
-  {{#if this.initialized}}
+<AuLabel
+  for="mandaat"
+  @error={{this.hasErrors}}
+  @warning={{this.hasWarnings}}
+  @required={{this.isRequired}}
+>Mandaat</AuLabel>
+{{#if this.initialized}}
+  <div class={{if this.hasErrors "ember-power-select--error"}}>
     <Mandatenbeheer::MandaatBestuursorganenSelector
       @onSelect={{this.updateMandaat}}
       @bestuursorganen={{this.bestuursorganen}}
       @mandaat={{this.mandaat}}
-      @allowClear={{true}}
+      @allowClear={{false}}
     />
-  {{else}}
-    <p class="skeleton-input-full au-u-margin-top"></p>
-  {{/if}}
-</div>
+  </div>
+  {{#each this.errors as |error|}}
+    <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
+  {{/each}}
+
+  {{#each this.warnings as |warning|}}
+    <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
+  {{/each}}
+{{else}}
+  <p class="skeleton-input-full au-u-margin-top"></p>
+{{/if}}

--- a/app/components/rdf-input-fields/mandataris-mandaat-selector.js
+++ b/app/components/rdf-input-fields/mandataris-mandaat-selector.js
@@ -60,8 +60,8 @@ export default class MandatarisMandaatSelector extends InputFieldComponent {
 
   @action
   async updateMandaat(mandate) {
-    const uri = mandate.uri;
-    replaceSingleFormValue(this.storeOptions, new NamedNode(uri));
+    const uri = mandate?.uri;
+    replaceSingleFormValue(this.storeOptions, uri ? new NamedNode(uri) : null);
     this.hasBeenFocused = true;
     super.updateValidations();
   }

--- a/app/components/rdf-input-fields/mandataris-mandaat-selector.js
+++ b/app/components/rdf-input-fields/mandataris-mandaat-selector.js
@@ -61,6 +61,7 @@ export default class MandatarisMandaatSelector extends InputFieldComponent {
   @action
   async updateMandaat(mandate) {
     const uri = mandate?.uri;
+
     replaceSingleFormValue(this.storeOptions, uri ? new NamedNode(uri) : null);
     this.hasBeenFocused = true;
     super.updateValidations();

--- a/app/components/rdf-input-fields/person-selector.hbs
+++ b/app/components/rdf-input-fields/person-selector.hbs
@@ -1,6 +1,20 @@
-<AuLabel>{{this.title}}</AuLabel>
+<AuLabel
+  for="person"
+  @error={{this.hasErrors}}
+  @warning={{this.hasWarnings}}
+  @required={{this.isRequired}}
+>{{this.title}}</AuLabel>
 {{#if this.initialized}}
-  <Person::Selector @person={{this.person}} @onUpdate={{this.onUpdate}} />
+  <div class={{if this.hasErrors "ember-power-select--error"}}>
+    <Person::Selector @person={{this.person}} @onUpdate={{this.onUpdate}} />
+  </div>
+  {{#each this.errors as |error|}}
+    <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
+  {{/each}}
+
+  {{#each this.warnings as |warning|}}
+    <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
+  {{/each}}
 {{else}}
   <p class="skeleton-input-full au-u-margin-top"></p>
 {{/if}}


### PR DESCRIPTION
## Description

We did not see any visual errors when a validation was added through the ttl code (form) for person, mandaat and fracties. These custoim components now display errors when not valid. 

## How to test

When the field for person, fractie or mandaat is not filled in you should not be able to save the form

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/178

## Attachments

![image](https://github.com/user-attachments/assets/bbb9e9ab-eb62-4e89-9c41-5b35467f0f96)

