### PR TITLE
LMB-597 Fix mandate for mandataris not showing in mandataris search

### DIFF
--- a/app/components/mandatarissen/mandaten-as-links.js
+++ b/app/components/mandatarissen/mandaten-as-links.js
@@ -11,13 +11,7 @@ export default class MandatarissenMandatenAsLinks extends Component {
 
   setup = restartableTask(async () => {
     const mandatarissen = await this.args.persoon.isAangesteldAls;
-    const mandatarissenInPeriode = mandatarissen.filter((mandataris) =>
-      mandataris.inSelectedBestuursperiode(this.args.bestuursperiode)
-    );
-    const foldedMandatarissen = await foldMandatarisses(
-      null,
-      mandatarissenInPeriode
-    );
+    const foldedMandatarissen = await foldMandatarisses(null, mandatarissen);
 
     for (const foldedMandataris of foldedMandatarissen) {
       const mandataris = foldedMandataris.mandataris;

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -87,15 +87,6 @@ export default class MandatarisModel extends Model {
     }
     return false;
   }
-  inSelectedBestuursperiode(bestuursperiode) {
-    if (this.start?.getFullYear() < bestuursperiode.start) {
-      return false;
-    }
-    if (this.einde?.getFullYear() > bestuursperiode.einde) {
-      return false;
-    }
-    return true;
-  }
 
   get uniqueVervangersDoor() {
     return this.getUnique(this.tijdelijkeVervangingen);


### PR DESCRIPTION
## Description

In the mandataris search page, some mandatarissen did not seem to have a visible mandate. This PR fixes this.
In the current state mandates are linked to a bestuursperiode, so it is no longer necessary to manually check the date of a mandate, which did sometimes classify a mandataris as not belonging to the correct bestuursperiode, because it had an invalid date.

## How to test

Best to first find a bestuurseenheid where mandataris search has a mandataris with an empty mandate column, then spin up this new branch and see it now does have a mandate filled in. All mandatarissen in the mandataris search page should have a mandate.
