### PR TITLE
Ben/lmb 461 nb members bestuursorgaan

### DIFF
--- a/app/components/mandatarissen/history.js
+++ b/app/components/mandatarissen/history.js
@@ -62,6 +62,12 @@ export default class MandatarisHistoryComponent extends Component {
         };
       })
       .sort((a, b) => {
+        if (!b?.mandataris?.start) {
+          return -1;
+        }
+        if (!a?.mandataris?.start) {
+          return 1;
+        }
         return b.mandataris.start.getTime() - a.mandataris.start.getTime();
       });
   });

--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -167,10 +167,13 @@ export default class BestuursorgaanModel extends Model {
     });
 
     const mandaten = currentOrgaan ? await currentOrgaan.bevat : [];
-    // TODO not entirely correct, can contain inactive mandatarissen...
     const mandatenAmounts = await Promise.all(
       mandaten.map(async (mandaat) => {
-        return (await mandaat.bekleedDoor).meta.count;
+        const response = await fetch(
+          `/mandataris-api/mandaten/nbMembers/${mandaat.id}`
+        );
+        const result = await response.json();
+        return result.count;
       })
     );
     const amount = mandatenAmounts.reduce((acc, curr) => acc + curr, 0);

--- a/app/models/mandataris-status-code.js
+++ b/app/models/mandataris-status-code.js
@@ -1,11 +1,6 @@
 import Model, { attr } from '@ember-data/model';
-import { MANDATARIS_EFFECTIEF_STATE } from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarisStatusCodeModel extends Model {
   @attr label;
   @attr uri;
-
-  isEffective() {
-    return this.uri === MANDATARIS_EFFECTIEF_STATE;
-  }
 }

--- a/app/models/mandataris-status-code.js
+++ b/app/models/mandataris-status-code.js
@@ -1,6 +1,11 @@
 import Model, { attr } from '@ember-data/model';
+import { MANDATARIS_EFFECTIEF_STATE } from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarisStatusCodeModel extends Model {
   @attr label;
   @attr uri;
+
+  isEffective() {
+    return this.uri === MANDATARIS_EFFECTIEF_STATE;
+  }
 }

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -77,10 +77,6 @@ export default class MandatarisModel extends Model {
     );
   }
 
-  get isEffective() {
-    return this.status.isEffective;
-  }
-
   get isActive() {
     if (!this.einde) {
       return true;

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -76,6 +76,11 @@ export default class MandatarisModel extends Model {
         uri == 'http://mu.semte.ch/vocabularies/ext/mandatenExtractorService'
     );
   }
+
+  get isEffective() {
+    return this.status.isEffective;
+  }
+
   get isActive() {
     if (!this.einde) {
       return true;


### PR DESCRIPTION
## Description

Show the number of active members of a mandaat instead of the total number of members of a mandaat in the orgaan page. 

## How to test

Just go to a few orgaan overview pages (also different bestuursperiodes) and count if the number of members is correct (might be a good idea to also terminate a mandataris and see if the number is still correct). It might be a bit confusing, because the mandatarissen page also shows inactive mandatarissen and shows mandatarissen with all statussen.

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/27
