### PR TITLE
remove check if mandaat of replacement is burgemeester

### DIFF
--- a/app/services/mandataris.js
+++ b/app/services/mandataris.js
@@ -44,7 +44,7 @@ export default class MandatarisService extends Service {
     newMandatarisState,
     newFractie
   ) {
-    let mandatarisStatus = await this.store.findRecord(
+    const mandatarisStatus = await this.store.findRecord(
       'mandataris-status-code',
       MANDATARIS_WAARNEMEND_STATE_ID
     );

--- a/app/services/mandataris.js
+++ b/app/services/mandataris.js
@@ -44,20 +44,15 @@ export default class MandatarisService extends Service {
     newMandatarisState,
     newFractie
   ) {
-    let mandatarisStatus = toReplace.status;
+    let mandatarisStatus = await this.store.findRecord(
+      'mandataris-status-code',
+      MANDATARIS_WAARNEMEND_STATE_ID
+    );
 
-    const mandaat = await toReplace.bekleedt;
     const existing = await this.getOverlappingMandate(
       toReplace,
       replacementPerson
     );
-
-    if (mandaat && mandaat.isBurgemeester) {
-      mandatarisStatus = await this.store.findRecord(
-        'mandataris-status-code',
-        MANDATARIS_WAARNEMEND_STATE_ID
-      );
-    }
 
     if (existing) {
       existing.status = mandatarisStatus;


### PR DESCRIPTION
## Description

If you select a replacement, the status of this replacement is now always waarnemend.

## How to test

Update the state of a mandataris to verhinderd and add a replacement. Check that the status of this mandataris is correct.
