### PR TITLE
LMB-517 | A person's mandatarissen can become onafhankelijk

### DIFF
--- a/app/components/mandatarissen/fractie-selector.js
+++ b/app/components/mandatarissen/fractie-selector.js
@@ -12,6 +12,7 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
   @service store;
   @service currentSession;
   @service bestuursperioden;
+  @service('fractie') fractieService;
 
   @tracked _fractie;
   @tracked bestuursorganen = [];
@@ -55,7 +56,10 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
     );
 
     if (!onafhankelijke) {
-      onafhankelijke = await this.createOnafhankelijkeFractie();
+      onafhankelijke = await this.fractieService.createOnafhankelijkeFractie(
+        this.bestuursorganen,
+        this.args.bestuurseenheid
+      );
       this.fractieOptions = [...fracties, onafhankelijke];
       return;
     }
@@ -139,23 +143,6 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
       include: 'fractietype',
     });
     return onafhankelijke.length ? onafhankelijke[0] : null;
-  }
-
-  async createOnafhankelijkeFractie() {
-    const onafhankelijkeFractieType = (
-      await this.store.query('fractietype', {
-        page: { size: 1 },
-        'filter[:uri:]': FRACTIETYPE_ONAFHANKELIJK,
-      })
-    ).at(0);
-    const onafhankelijke = this.store.createRecord('fractie', {
-      naam: 'Onafhankelijk',
-      fractietype: onafhankelijkeFractieType,
-      bestuursorganenInTijd: this.bestuursorganen,
-      bestuurseenheid: this.args.bestuurseenheid,
-    });
-    onafhankelijke.save();
-    return onafhankelijke;
   }
 
   @action

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -137,7 +137,7 @@ export default class MandatarissenUpdateState extends Component {
   }
 
   async changeMandatarisState() {
-    await this.updateOldLidmaatschap();
+    await this.mandatarisService.updateOldLidmaatschap(this.args.mandataris);
 
     const endDate = this.args.mandataris.einde;
 
@@ -184,28 +184,6 @@ export default class MandatarissenUpdateState extends Component {
     );
 
     return newMandataris;
-  }
-
-  async updateOldLidmaatschap() {
-    const oldLidmaatschap = await this.args.mandataris.heeftLidmaatschap;
-    if (!oldLidmaatschap) {
-      return;
-    }
-    let oldTijdsinterval = await oldLidmaatschap.lidGedurende;
-
-    if (!oldTijdsinterval) {
-      // old membership instances don't necessarily have a tijdsinterval
-      oldTijdsinterval = this.store.createRecord('tijdsinterval', {
-        begin: this.args.mandataris.start,
-        einde: this.date,
-      });
-      await oldTijdsinterval.save();
-      oldLidmaatschap.lidGedurende = oldTijdsinterval;
-      await oldLidmaatschap.save();
-    }
-    oldTijdsinterval.einde = this.date;
-
-    await oldTijdsinterval.save();
   }
 
   endMandataris() {

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -141,16 +141,16 @@ export default class MandatarissenUpdateState extends Component {
 
     const endDate = this.args.mandataris.einde;
 
-    const newMandatarisProps = {
-      rangorde: this.rangorde,
-      start: this.date,
-      einde: endDate,
-      bekleedt: this.args.mandataris.bekleedt,
-      isBestuurlijkeAliasVan: this.args.mandataris.isBestuurlijkeAliasVan,
-      beleidsdomein: (await this.args.mandataris.beleidsdomein).slice(),
-      status: this.newStatus,
-      publicationStatus: await getDraftPublicationStatus(this.store),
-    };
+    const newMandatarisProps = await this.mandatarisService.createNewProps(
+      this.args.mandataris,
+      {
+        rangorde: this.rangorde,
+        start: this.date,
+        einde: endDate,
+        status: this.newStatus,
+        publicationStatus: await getDraftPublicationStatus(this.store),
+      }
+    );
 
     const newMandataris = this.store.createRecord(
       'mandataris',

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -4,6 +4,8 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
+import { task } from 'ember-concurrency';
+
 export default class MandatarissenPersoonMandatenController extends Controller {
   @service router;
 
@@ -39,4 +41,8 @@ export default class MandatarissenPersoonMandatenController extends Controller {
   toggleActiveOnly() {
     this.activeOnly = !this.activeOnly;
   }
+
+  wordtOnafhankelijk = task(async () => {
+    console.log(`Wordt onafhankelijk`);
+  });
 }

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -5,12 +5,14 @@ import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
 import { task } from 'ember-concurrency';
+import moment from 'moment';
 
 export default class MandatarissenPersoonMandatenController extends Controller {
   @service router;
 
   queryParams = ['activeOnly'];
 
+  @tracked isBecomeOnafhankelijkDisabled = false;
   @tracked isModalOpen = false;
   @tracked selectedBestuursorgaan = null;
   @tracked activeOnly = true;
@@ -41,6 +43,48 @@ export default class MandatarissenPersoonMandatenController extends Controller {
   toggleActiveOnly() {
     this.activeOnly = !this.activeOnly;
   }
+
+  isFractieOfFoldedMandatarisOnafhankelijk = task(async (foldedMandataris) => {
+    const lid = await foldedMandataris.mandataris.heeftLidmaatschap;
+    if (!lid) {
+      return true;
+    }
+
+    const fractie = await lid.binnenFractie;
+    if (fractie) {
+      const type = await fractie.fractietype;
+      return type ? type.isOnafhankelijk : false;
+    }
+
+    return false;
+  });
+
+  isDateInbetweenStartAndEnd(foldedMandataris) {
+    const now = moment();
+    return (
+      moment(foldedMandataris.foldedStart).isBefore(now) &&
+      (!foldedMandataris.foldedEnd ||
+        moment(foldedMandataris.foldedEnd).isAfter(now))
+    );
+  }
+
+  checkFracties = task(async (foldedMandatarissen) => {
+    let notAllOnafhankelijk = true;
+    for (const fold of foldedMandatarissen) {
+      if (!this.isDateInbetweenStartAndEnd || !notAllOnafhankelijk) {
+        continue;
+      }
+
+      const isOnafhankelijk =
+        await this.isFractieOfFoldedMandatarisOnafhankelijk.perform(fold);
+      if (!isOnafhankelijk) {
+        notAllOnafhankelijk = false;
+        continue;
+      }
+    }
+
+    this.isBecomeOnafhankelijkDisabled = notAllOnafhankelijk;
+  });
 
   wordtOnafhankelijk = task(async () => {
     console.log(`Wordt onafhankelijk`);

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -110,7 +110,6 @@ export default class MandatarissenPersoonMandatenController extends Controller {
   });
 
   wordtOnafhankelijk = task(async () => {
-    console.log(`Wordt onafhankelijk`);
     if (!this.canBecomeOnafhankelijk) {
       return;
     }

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -110,6 +110,8 @@ export default class MandatarissenPersoonMandatenController extends Controller {
       );
       newMandataris.save();
 
+      person.fractie = onafhankelijkeFractie;
+      person.save();
       await this.mandatarisService.updateOldLidmaatschap(mandataris);
       await this.mandatarisService.createNewLidmaatschap(
         newMandataris,

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -74,7 +74,7 @@ export default class MandatarissenPersoonMandatenController extends Controller {
       this.possibelOnafhankelijkeMandatarissen.length >= 1;
   });
 
-  wordtOnafhankelijk = task(async () => {
+  becomeOnafhankelijk = task(async () => {
     if (!this.canBecomeOnafhankelijk) {
       return;
     }

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -141,5 +141,7 @@ export default class MandatarissenPersoonMandatenController extends Controller {
       mandataris.einde = dateNow;
       mandataris.save();
     }
+
+    this.router.refresh();
   });
 }

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -136,11 +136,8 @@ export default class MandatarissenPersoonMandatenController extends Controller {
         publicationStatus: await getDraftPublicationStatus(this.store),
         fractie: onafhankelijkeFractie,
       };
-      const newMandataris = await this.mandatarisService.createFrom(
-        mandataris,
-        overwrites
-      );
-      console.log(`Newly created mandataris`, newMandataris);
+      await this.mandatarisService.createFrom(mandataris, overwrites);
     }
+    this.checkFracties.perform();
   });
 }

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -116,13 +116,22 @@ export default class MandatarissenPersoonMandatenController extends Controller {
     }
 
     for (const mandataris of this.possibelOnafhankelijkeMandatarissen) {
-      const bestuursorganenInTijd = await getUniqueBestuursorganen(mandataris);
-      const bestuurseenheid = await bestuursorganenInTijd[0]?.bestuurseenheid;
-      const onafhankelijkeFractie =
-        await this.fractieService.createOnafhankelijkeFractie(
-          bestuursorganenInTijd,
-          bestuurseenheid
+      let onafhankelijkeFractie =
+        await this.fractieService.findOnafhankelijkeFractieForPerson(
+          await mandataris.isBestuurlijkeAliasVan
         );
+
+      if (!onafhankelijkeFractie) {
+        const bestuursorganenInTijd =
+          await getUniqueBestuursorganen(mandataris);
+        const bestuurseenheid = await bestuursorganenInTijd[0]?.bestuurseenheid;
+        onafhankelijkeFractie =
+          await this.fractieService.createOnafhankelijkeFractie(
+            bestuursorganenInTijd,
+            bestuurseenheid
+          );
+      }
+
       console.log({ onafhankelijkeFractie });
       const overwrites = {
         publicationStatus: await getDraftPublicationStatus(this.store),

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -16,7 +16,8 @@ export default class MandatarissenPersoonMandatenController extends Controller {
 
   queryParams = ['activeOnly'];
 
-  @tracked isBecomeOnafhankelijkDisabled = false;
+  @tracked canBecomeOnafhankelijk;
+  @tracked possibelOnafhankelijkeMandatarissen = [];
   @tracked isModalOpen = false;
   @tracked selectedBestuursorgaan = null;
   @tracked activeOnly = true;
@@ -83,25 +84,35 @@ export default class MandatarissenPersoonMandatenController extends Controller {
   }
 
   checkFracties = task(async (foldedMandatarissen) => {
-    let notAllOnafhankelijk = true;
+    this.canBecomeOnafhankelijk = false;
+    this.possibelOnafhankelijkeMandatarissen = [];
     for (const fold of foldedMandatarissen) {
       const isActive = await this.isMandatarisActive(fold);
-      if (!isActive || !notAllOnafhankelijk) {
+      if (!isActive) {
         continue;
       }
 
       const isOnafhankelijk =
         await this.isFractieOfFoldedMandatarisOnafhankelijk.perform(fold);
       if (!isOnafhankelijk) {
-        notAllOnafhankelijk = false;
+        this.possibelOnafhankelijkeMandatarissen.push(fold.mandataris);
         continue;
       }
     }
 
-    this.isBecomeOnafhankelijkDisabled = notAllOnafhankelijk;
+    this.canBecomeOnafhankelijk =
+      this.possibelOnafhankelijkeMandatarissen.length >= 1;
   });
 
   wordtOnafhankelijk = task(async () => {
     console.log(`Wordt onafhankelijk`);
+    if (!this.canBecomeOnafhankelijk) {
+      return;
+    }
+
+    console.log(
+      `possibelOnafhankelijkeMandatarissen`,
+      this.possibelOnafhankelijkeMandatarissen
+    );
   });
 }

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -95,14 +95,27 @@ export default class MandatarissenPersoonMandatenController extends Controller {
           );
       }
 
-      await this.mandatarisService.updateOldLidmaatschap(mandataris);
       const dateNow = new Date();
-      const overwrites = {
-        start: dateNow,
-        publicationStatus: await getDraftPublicationStatus(this.store),
-        fractie: onafhankelijkeFractie,
-      };
-      await this.mandatarisService.createNewFrom(mandataris, overwrites);
+      const newMandatarisProps = await this.mandatarisService.createNewProps(
+        mandataris,
+        {
+          start: dateNow,
+          publicationStatus: await getDraftPublicationStatus(this.store),
+          fractie: onafhankelijkeFractie,
+        }
+      );
+      const newMandataris = await this.store.createRecord(
+        'mandataris',
+        newMandatarisProps
+      );
+      newMandataris.save();
+
+      await this.mandatarisService.updateOldLidmaatschap(mandataris);
+      await this.mandatarisService.createNewLidmaatschap(
+        newMandataris,
+        onafhankelijkeFractie
+      );
+
       mandataris.einde = dateNow;
       mandataris.save();
     }

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -115,10 +115,9 @@ export default class MandatarissenPersoonMandatenController extends Controller {
     }
 
     for (const mandataris of this.possibelOnafhankelijkeMandatarissen) {
+      const person = await mandataris.isBestuurlijkeAliasVan;
       let onafhankelijkeFractie =
-        await this.fractieService.findOnafhankelijkeFractieForPerson(
-          await mandataris.isBestuurlijkeAliasVan
-        );
+        await this.fractieService.findOnafhankelijkeFractieForPerson(person);
 
       if (!onafhankelijkeFractie) {
         const bestuursorganenInTijd =
@@ -131,13 +130,16 @@ export default class MandatarissenPersoonMandatenController extends Controller {
           );
       }
 
-      console.log({ onafhankelijkeFractie });
+      await this.mandatarisService.updateOldLidmaatschap(mandataris);
+      const dateNow = new Date();
       const overwrites = {
+        start: dateNow,
         publicationStatus: await getDraftPublicationStatus(this.store),
         fractie: onafhankelijkeFractie,
       };
       await this.mandatarisService.createFrom(mandataris, overwrites);
+      mandataris.einde = dateNow;
+      mandataris.save();
     }
-    this.checkFracties.perform();
   });
 }

--- a/app/routes/mandatarissen/persoon/mandaten.js
+++ b/app/routes/mandatarissen/persoon/mandaten.js
@@ -39,6 +39,7 @@ export default class MandatarissenPersoonMandatenRoute extends Route {
 
     return {
       persoon,
+      foldedMandatarissen,
       mandatarissen: filteredMandatarissen,
       bestuursorganen,
     };
@@ -61,5 +62,11 @@ export default class MandatarissenPersoonMandatenRoute extends Route {
     };
 
     return await this.store.query('mandataris', queryParams);
+  }
+
+  setupController(controller, model) {
+    super.setupController(controller, model);
+
+    controller.checkFracties.perform(model.foldedMandatarissen);
   }
 }

--- a/app/services/fractie.js
+++ b/app/services/fractie.js
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
 
 import { service } from '@ember/service';
+import { fold } from 'frontend-lmb/utils/fold-mandatarisses';
 
 import { FRACTIETYPE_ONAFHANKELIJK } from 'frontend-lmb/utils/well-known-uris';
 
@@ -45,5 +46,22 @@ export default class FractieService extends Service {
     }
 
     return null;
+  }
+
+  async isMandatarisFractieOnafhankelijk(mandataris) {
+    // assuming that there always be a folded mandataris for the mandataris
+    const foldedMandataris = (await fold([mandataris])).at(0);
+    const lid = await foldedMandataris.mandataris.heeftLidmaatschap;
+    if (!lid) {
+      return true;
+    }
+
+    const fractie = await lid.binnenFractie;
+    if (fractie) {
+      const type = await fractie.fractietype;
+      return type ? type.isOnafhankelijk : false;
+    }
+
+    return false;
   }
 }

--- a/app/services/fractie.js
+++ b/app/services/fractie.js
@@ -24,7 +24,7 @@ export default class FractieService extends Service {
       bestuursorganenInTijd: bestuursorganen,
       bestuurseenheid: bestuurseenheid,
     });
-    // onafhankelijke.save(); TODO: uncomment this
+    onafhankelijke.save();
 
     return onafhankelijke;
   }

--- a/app/services/fractie.js
+++ b/app/services/fractie.js
@@ -1,0 +1,31 @@
+import Service from '@ember/service';
+
+import { service } from '@ember/service';
+
+import { FRACTIETYPE_ONAFHANKELIJK } from 'frontend-lmb/utils/well-known-uris';
+
+export default class FractieService extends Service {
+  @service store;
+
+  async createOnafhankelijkeFractie(bestuursorganen, bestuurseenheid) {
+    if (!bestuurseenheid) {
+      throw `Could not create onafhankelijke fractie`;
+    }
+
+    const onafhankelijkeFractieType = (
+      await this.store.query('fractietype', {
+        page: { size: 1 },
+        'filter[:uri:]': FRACTIETYPE_ONAFHANKELIJK,
+      })
+    ).at(0);
+    const onafhankelijke = this.store.createRecord('fractie', {
+      naam: 'Onafhankelijk',
+      fractietype: onafhankelijkeFractieType,
+      bestuursorganenInTijd: bestuursorganen,
+      bestuurseenheid: bestuurseenheid,
+    });
+    // onafhankelijke.save(); TODO: uncomment this
+
+    return onafhankelijke;
+  }
+}

--- a/app/services/fractie.js
+++ b/app/services/fractie.js
@@ -28,4 +28,20 @@ export default class FractieService extends Service {
 
     return onafhankelijke;
   }
+
+  async findOnafhankelijkeFractieForPerson(person) {
+    const mandatarissen = await person.isAangesteldAls;
+    const onafhankelijkeLidmaatschappen = await this.store.query(
+      'lidmaatschap',
+      {
+        include: 'lid,binnen-fractie,binnen-fractie.fractietype',
+        'filter[lid][:uri:]': mandatarissen
+          .map((mandataris) => mandataris.uri)
+          .join(','),
+        'filter[binnen-fractie][fractietype][:uri:]': FRACTIETYPE_ONAFHANKELIJK,
+      }
+    );
+
+    return onafhankelijkeLidmaatschappen[0]?.binnenFractie ?? null;
+  }
 }

--- a/app/services/fractie.js
+++ b/app/services/fractie.js
@@ -31,17 +31,19 @@ export default class FractieService extends Service {
 
   async findOnafhankelijkeFractieForPerson(person) {
     const mandatarissen = await person.isAangesteldAls;
-    const onafhankelijkeLidmaatschappen = await this.store.query(
-      'lidmaatschap',
-      {
-        include: 'lid,binnen-fractie,binnen-fractie.fractietype',
-        'filter[lid][:uri:]': mandatarissen
-          .map((mandataris) => mandataris.uri)
-          .join(','),
-        'filter[binnen-fractie][fractietype][:uri:]': FRACTIETYPE_ONAFHANKELIJK,
+    for (const mandataris of mandatarissen) {
+      const lid = await mandataris.heeftLidmaatschap;
+      if (!lid) {
+        continue;
       }
-    );
 
-    return onafhankelijkeLidmaatschappen[0]?.binnenFractie ?? null;
+      const fractie = await lid.binnenFractie;
+      const type = await fractie.fractietype;
+      if (type.isOnafhankelijk) {
+        return fractie;
+      }
+    }
+
+    return null;
   }
 }

--- a/app/services/mandataris.js
+++ b/app/services/mandataris.js
@@ -5,10 +5,7 @@ import { fold } from 'frontend-lmb/utils/fold-mandatarisses';
 
 import { getDraftPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
 import { MANDATARIS_WAARNEMEND_STATE_ID } from 'frontend-lmb/utils/well-known-ids';
-import {
-  MANDATARIS_BEEINDIGD_STATE,
-  MANDATARIS_VERHINDERD_STATE,
-} from 'frontend-lmb/utils/well-known-uris';
+import { MANDATARIS_BEEINDIGD_STATE } from 'frontend-lmb/utils/well-known-uris';
 
 import moment from 'moment';
 
@@ -160,10 +157,6 @@ export default class MandatarisService extends Service {
     }
 
     const status = await foldedMandataris.mandataris.status;
-    return (
-      status &&
-      status.uri !== MANDATARIS_VERHINDERD_STATE &&
-      status.uri !== MANDATARIS_BEEINDIGD_STATE
-    );
+    return status && status.uri !== MANDATARIS_BEEINDIGD_STATE;
   }
 }

--- a/app/services/mandataris.js
+++ b/app/services/mandataris.js
@@ -92,7 +92,7 @@ export default class MandatarisService extends Service {
       einde: newMandataris.einde,
     });
 
-    // await newTijdsinterval.save(); TODO: uncomment this
+    await newTijdsinterval.save();
 
     const newLidmaatschap = this.store.createRecord('lidmaatschap', {
       binnenFractie: fractie,
@@ -100,7 +100,7 @@ export default class MandatarisService extends Service {
       lidGedurende: newTijdsinterval,
     });
     console.log({ newLidmaatschap });
-    // await newLidmaatschap.save(); TODO: uncomment this
+    await newLidmaatschap.save();
   }
 
   async createFrom(mandataris, newMandatarisProps) {
@@ -119,7 +119,7 @@ export default class MandatarisService extends Service {
         newMandatarisProps.publicationStatus ??
         (await mandataris.publicationStatus),
     });
-    // await newMandataris.save(); TODO: uncomment this
+    await newMandataris.save();
     await this.createNewLidmaatschap(
       newMandataris,
       newMandatarisProps.fractie ?? mandataris.fractie

--- a/app/services/mandataris.js
+++ b/app/services/mandataris.js
@@ -92,13 +92,39 @@ export default class MandatarisService extends Service {
       einde: newMandataris.einde,
     });
 
-    await newTijdsinterval.save();
+    // await newTijdsinterval.save(); TODO: uncomment this
 
     const newLidmaatschap = this.store.createRecord('lidmaatschap', {
       binnenFractie: fractie,
       lid: newMandataris,
       lidGedurende: newTijdsinterval,
     });
-    await newLidmaatschap.save();
+    console.log({ newLidmaatschap });
+    // await newLidmaatschap.save(); TODO: uncomment this
+  }
+
+  async createFrom(mandataris, newMandatarisProps) {
+    const newMandataris = this.store.createRecord('mandataris', {
+      rangorde: newMandatarisProps.rangorde ?? mandataris.rangorde,
+      start: newMandatarisProps.start ?? mandataris.start,
+      einde: newMandatarisProps.einde ?? mandataris.einde,
+      bekleedt: newMandatarisProps.bekleedt ?? (await mandataris.bekleedt),
+      isBestuurlijkeAliasVan:
+        newMandatarisProps.isBestuurlijkeAliasVan ??
+        (await mandataris.isBestuurlijkeAliasVan),
+      beleidsdomein:
+        newMandatarisProps.beleidsdomein ?? (await mandataris.beleidsdomein),
+      status: newMandatarisProps.status ?? (await mandataris.status),
+      publicationStatus:
+        newMandatarisProps.publicationStatus ??
+        (await mandataris.publicationStatus),
+    });
+    // await newMandataris.save(); TODO: uncomment this
+    await this.createNewLidmaatschap(
+      newMandataris,
+      newMandatarisProps.fractie ?? mandataris.fractie
+    );
+
+    return newMandataris;
   }
 }

--- a/app/services/mandataris.js
+++ b/app/services/mandataris.js
@@ -129,27 +129,21 @@ export default class MandatarisService extends Service {
     await oldTijdsinterval.save();
   }
 
-  async createNewFrom(mandataris, newMandatarisProps) {
-    const newMandataris = this.store.createRecord('mandataris', {
-      rangorde: newMandatarisProps.rangorde ?? mandataris.rangorde,
-      start: newMandatarisProps.start ?? mandataris.start,
-      einde: newMandatarisProps.einde ?? mandataris.einde,
-      bekleedt: newMandatarisProps.bekleedt ?? (await mandataris.bekleedt),
+  async createNewProps(mandataris, overwrites) {
+    return {
+      rangorde: overwrites.rangorde ?? mandataris.rangorde,
+      start: overwrites.start ?? mandataris.start,
+      einde: overwrites.einde ?? mandataris.einde,
+      bekleedt: overwrites.bekleedt ?? (await mandataris.bekleedt),
       isBestuurlijkeAliasVan:
-        newMandatarisProps.isBestuurlijkeAliasVan ??
+        overwrites.isBestuurlijkeAliasVan ??
         (await mandataris.isBestuurlijkeAliasVan),
       beleidsdomein:
-        newMandatarisProps.beleidsdomein ?? (await mandataris.beleidsdomein),
-      status: newMandatarisProps.status ?? (await mandataris.status),
+        overwrites.beleidsdomein ?? (await mandataris.beleidsdomein).slice(),
+      status: overwrites.status ?? (await mandataris.status),
       publicationStatus:
-        newMandatarisProps.publicationStatus ??
-        (await mandataris.publicationStatus),
-    });
-    await newMandataris.save();
-    await this.createNewLidmaatschap(
-      newMandataris,
-      newMandatarisProps.fractie ?? mandataris.fractie
-    );
+        overwrites.publicationStatus ?? (await mandataris.publicationStatus),
+    };
   }
 
   async isMandatarisActive(mandataris) {

--- a/app/services/mandataris.js
+++ b/app/services/mandataris.js
@@ -99,8 +99,29 @@ export default class MandatarisService extends Service {
       lid: newMandataris,
       lidGedurende: newTijdsinterval,
     });
-    console.log({ newLidmaatschap });
     await newLidmaatschap.save();
+  }
+
+  async updateOldLidmaatschap(mandataris) {
+    const oldLidmaatschap = await mandataris.heeftLidmaatschap;
+    if (!oldLidmaatschap) {
+      return;
+    }
+    let oldTijdsinterval = await oldLidmaatschap.lidGedurende;
+
+    if (!oldTijdsinterval) {
+      // old membership instances don't necessarily have a tijdsinterval
+      oldTijdsinterval = this.store.createRecord('tijdsinterval', {
+        begin: mandataris.start,
+        einde: moment(new Date()),
+      });
+      await oldTijdsinterval.save();
+      oldLidmaatschap.lidGedurende = oldTijdsinterval;
+      await oldLidmaatschap.save();
+    }
+    oldTijdsinterval.einde = this.date;
+
+    await oldTijdsinterval.save();
   }
 
   async createFrom(mandataris, newMandatarisProps) {
@@ -124,7 +145,7 @@ export default class MandatarisService extends Service {
       newMandataris,
       newMandatarisProps.fractie ?? mandataris.fractie
     );
-
+    console.log({ newMandataris });
     return newMandataris;
   }
 }

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -12,7 +12,7 @@
   <Group>
     <AuButton
       skin="secondary"
-      @disabled={{true}}
+      @disabled={{this.isBecomeOnafhankelijkDisabled}}
       {{on "click" (perform this.wordtOnafhankelijk)}}
     >
       Onafhankelijk worden

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -12,6 +12,8 @@
   <Group>
     <AuButton
       skin="secondary"
+      @loading={{this.checkFracties.isRunning}}
+      @loadingMessage=" "
       @disabled={{not this.canBecomeOnafhankelijk}}
       {{on "click" (perform this.wordtOnafhankelijk)}}
     >

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -10,6 +10,13 @@
     </AuHeading>
   </Group>
   <Group>
+    <AuButton
+      skin="secondary"
+      @disabled={{true}}
+      {{on "click" (perform this.wordtOnafhankelijk)}}
+    >
+      Onafhankelijk worden
+    </AuButton>
     <AuButton {{on "click" this.toggleModal}}>
       Voeg nieuw mandaat toe
     </AuButton>

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -12,7 +12,7 @@
   <Group>
     <AuButton
       skin="secondary"
-      @disabled={{this.isBecomeOnafhankelijkDisabled}}
+      @disabled={{not this.canBecomeOnafhankelijk}}
       {{on "click" (perform this.wordtOnafhankelijk)}}
     >
       Onafhankelijk worden

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -13,11 +13,11 @@
     <AuButton
       skin="secondary"
       @loading={{(or
-        this.checkFracties.isRunning this.wordtOnafhankelijk.isRunning
+        this.checkFracties.isRunning this.becomeOnafhankelijk.isRunning
       )}}
       @loadingMessage="Onafhankelijk worden"
       @disabled={{not this.canBecomeOnafhankelijk}}
-      {{on "click" (perform this.wordtOnafhankelijk)}}
+      {{on "click" (perform this.becomeOnafhankelijk)}}
     >
       Onafhankelijk worden
     </AuButton>

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -12,8 +12,10 @@
   <Group>
     <AuButton
       skin="secondary"
-      @loading={{this.checkFracties.isRunning}}
-      @loadingMessage=" "
+      @loading={{(or
+        this.checkFracties.isRunning this.wordtOnafhankelijk.isRunning
+      )}}
+      @loadingMessage="Onafhankelijk worden"
       @disabled={{not this.canBecomeOnafhankelijk}}
       {{on "click" (perform this.wordtOnafhankelijk)}}
     >

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -37,91 +37,95 @@
 
   </div>
 
-  <AuDataTable
-    @content={{@model.mandatarissen}}
-    @noDataMessage="Geen mandaten gevonden"
-    @sort={{this.sort}}
-    @page={{this.page}}
-    @size={{this.size}}
-    as |t|
-  >
-    <t.content as |c|>
-      <c.header>
-        <AuDataTableThSortable
-          @field="bekleedt.bevatIn.isTijdsspecialisatieVan.naam"
-          @currentSorting={{this.sort}}
-          @label="Bestuursorgaan"
-        />
-        <AuDataTableThSortable
-          @field="bekleedt.bestuursfunctie.label"
-          @currentSorting={{this.sort}}
-          @label="Mandaat"
-        />
-        <AuDataTableThSortable
-          @field="heeftLidmaatschap.binnenFractie.naam"
-          @currentSorting={{this.sort}}
-          @label="Fractie"
-        />
-        <AuDataTableThSortable
-          @field="start"
-          @currentSorting={{this.sort}}
-          @label="Start mandaat"
-        />
-        <AuDataTableThSortable
-          @field="einde"
-          @currentSorting={{this.sort}}
-          @label="Einde mandaat"
-        />
-        <th>
-          Publicatie Status
-        </th>
-      </c.header>
+  {{#if this.checkFracties.isRunning}}
+    <Skeleton::Table @columns={{6}} @rows={{@model.mandatarissen.length}} />
+  {{else}}
+    <AuDataTable
+      @content={{@model.mandatarissen}}
+      @noDataMessage="Geen mandaten gevonden"
+      @sort={{this.sort}}
+      @page={{this.page}}
+      @size={{this.size}}
+      as |t|
+    >
+      <t.content as |c|>
+        <c.header>
+          <AuDataTableThSortable
+            @field="bekleedt.bevatIn.isTijdsspecialisatieVan.naam"
+            @currentSorting={{this.sort}}
+            @label="Bestuursorgaan"
+          />
+          <AuDataTableThSortable
+            @field="bekleedt.bestuursfunctie.label"
+            @currentSorting={{this.sort}}
+            @label="Mandaat"
+          />
+          <AuDataTableThSortable
+            @field="heeftLidmaatschap.binnenFractie.naam"
+            @currentSorting={{this.sort}}
+            @label="Fractie"
+          />
+          <AuDataTableThSortable
+            @field="start"
+            @currentSorting={{this.sort}}
+            @label="Start mandaat"
+          />
+          <AuDataTableThSortable
+            @field="einde"
+            @currentSorting={{this.sort}}
+            @label="Einde mandaat"
+          />
+          <th>
+            Publicatie Status
+          </th>
+        </c.header>
 
-      <c.body as |row|>
-        <td>
-          {{#each row.mandataris.bekleedt.bevatIn as |orgaan index|}}
-            <LinkTo
-              @route="organen.orgaan.mandatarissen"
-              @model={{orgaan.isTijdsspecialisatieVan.id}}
+        <c.body as |row|>
+          <td>
+            {{#each row.mandataris.bekleedt.bevatIn as |orgaan index|}}
+              <LinkTo
+                @route="organen.orgaan.mandatarissen"
+                @model={{orgaan.isTijdsspecialisatieVan.id}}
+                class="au-c-link"
+              >
+                {{orgaan.isTijdsspecialisatieVan.naam}}{{if
+                  (lt index (sub row.mandataris.bekleedt.bevatIn.length 1))
+                  ", "
+                  ""
+                }}
+              </LinkTo>
+            {{/each}}
+          </td>
+          <td><LinkTo
+              @route="mandatarissen.persoon.mandataris"
+              @models={{array
+                row.mandataris.isBestuurlijkeAliasVan.id
+                row.mandataris.id
+              }}
               class="au-c-link"
             >
-              {{orgaan.isTijdsspecialisatieVan.naam}}{{if
-                (lt index (sub row.mandataris.bekleedt.bevatIn.length 1))
-                ", "
-                ""
-              }}
+              {{row.mandataris.bekleedt.bestuursfunctie.label}}
             </LinkTo>
-          {{/each}}
-        </td>
-        <td><LinkTo
-            @route="mandatarissen.persoon.mandataris"
-            @models={{array
-              row.mandataris.isBestuurlijkeAliasVan.id
-              row.mandataris.id
-            }}
-            class="au-c-link"
-          >
-            {{row.mandataris.bekleedt.bestuursfunctie.label}}
-          </LinkTo>
-        </td>
-        <td>
-          <Mandaat::FoldedFracties
-            @persoon={{row.mandataris.isBestuurlijkeAliasVan}}
-            @mandaat={{row.mandataris.bekleedt}}
-          />
-        </td>
-        <td>
-          {{moment-format row.foldedStart "DD-MM-YYYY"}}
-        </td>
-        <td>
-          {{moment-format row.foldedEnd "DD-MM-YYYY"}}
-        </td>
-        <td>
-          <Mandaat::PublicatieStatusPill @mandataris={{row.mandataris}} />
-        </td>
-      </c.body>
-    </t.content>
-  </AuDataTable>
+          </td>
+          <td>
+            <Mandaat::FoldedFracties
+              @persoon={{row.mandataris.isBestuurlijkeAliasVan}}
+              @mandaat={{row.mandataris.bekleedt}}
+            />
+          </td>
+          <td>
+            {{moment-format row.foldedStart "DD-MM-YYYY"}}
+          </td>
+          <td>
+            {{moment-format row.foldedEnd "DD-MM-YYYY"}}
+          </td>
+          <td>
+            <Mandaat::PublicatieStatusPill @mandataris={{row.mandataris}} />
+          </td>
+        </c.body>
+      </t.content>
+    </AuDataTable>
+  {{/if}}
 </div>
 
 <AuModalContainer />

--- a/app/utils/fold-mandatarisses.js
+++ b/app/utils/fold-mandatarisses.js
@@ -4,7 +4,7 @@ export const foldMandatarisses = async (params, mandatarisses) => {
   return sort(params, await fold(mandatarisses));
 };
 
-async function fold(mandatarissen) {
+export async function fold(mandatarissen) {
   // 'persoonId-mandaatId' to foldedMandataris
   const persoonMandaatData = {};
   await Promise.all(

--- a/tests/unit/services/fractie-test.js
+++ b/tests/unit/services/fractie-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-lmb/tests/helpers';
+
+module('Unit | Service | fractie', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:fractie');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
## Description

A user is able to make al its mandatarissen onafhankelijk with one button. This button is added to the persoon/mandaten route. Check if it is possible to set all mandatarissen to onafhankelijk (active and not status beinidigd or verhinderd).

## How to test

Go to a persons mandaten en configure the information that it is possible to become onafhankelijk for all active, not beeindigde/verhinderde mandatarissen


## Attachments

![image](https://github.com/user-attachments/assets/f921dfcd-d6d0-4bac-bdce-ee7a0d0393b3)
