### PR TITLE
LMB-130 | Feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Frontend of the lokaal mandatenbeheer application
 
 Feature flags are used to enable/disable features in the application. They are defined in config/environment.js.
 
-```
+```javascript
 // in config/environment.js
 let ENV = {
   // Other configuration settings...
@@ -49,11 +49,11 @@ The overriding will be saved in a cookie, so it will persist across page reloads
 
 The feature flags can be used in the application by injecting the features service and calling the isEnabled method.
 
-```
+```javascript
 import { inject as service } from "@ember/service";
 
 export default class ExampleComponent extends Component {
-@service features;
+  @service features;
 
   doSomething() {
     if (this.features.isEnabled("new-feature")) {
@@ -69,7 +69,7 @@ export default class ExampleComponent extends Component {
 
 Or in template files by using the is-feature-enabled helper:
 
-```
+```handlebars
 {{#if (is-feature-enabled "new-feature")}}
   <p>New feature is enabled!</p>
 {{else}}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The configuration can be manually overridden by adding a query parameter to the 
 `?feature-beta-feature=true` to enable the 'beta-feature'
 The overriding will be saved in a cookie, so it will persist across page reloads. The cookie can be cleared by adding `?clear-feature-overrides=true` to the URL.
 
-The feature flags can be used in the application by injecting the features service and calling the isEnabled method.
+The feature flags can be used in the application by injecting the `features` service and calling the `isEnabled` method.
 
 ```javascript
 import { inject as service } from "@ember/service";

--- a/README.md
+++ b/README.md
@@ -26,6 +26,63 @@ Frontend of the lokaal mandatenbeheer application
 
 5. Browse to: <http://localhost:4200>. This is the view that the unauthenticated users will see. For the view of authenticated users, browse to: <http://localhost:4200/mock-login>.
 
+## Feature flags
+
+Feature flags are used to enable/disable features in the application. They are defined in config/environment.js.
+
+```
+// in config/environment.js
+let ENV = {
+  // Other configuration settings...
+  features: {
+    "new-feature": true, // Enable the 'new-feature' by default
+    "beta-feature": false, // Disable the 'beta-feature' by default
+  },
+};
+```
+
+The configuration can be manually overridden by adding a query parameter to the URL:
+
+?feature-new-feature=false to disable the 'new-feature'
+?feature-beta-feature=true to enable the 'beta-feature'
+The overriding will be saved in a cookie, so it will persist across page reloads. The cookie can be cleared by adding ?clear-feature-overrides=true to the URL.
+
+The feature flags can be used in the application by injecting the features service and calling the isEnabled method.
+
+```
+import { inject as service } from "@ember/service";
+
+export default class ExampleComponent extends Component {
+@service features;
+
+  doSomething() {
+    if (this.features.isEnabled("new-feature")) {
+      // Implement the logic for the new feature
+      console.log("New feature is enabled!");
+    } else {
+      // Implement the logic for the default behaviour without the new feature
+      console.log("New feature is disabled!");
+    }
+  }
+}
+```
+
+Or in template files by using the is-feature-enabled helper:
+
+```
+{{#if (is-feature-enabled "new-feature")}}
+  <p>New feature is enabled!</p>
+{{else}}
+  <p>New feature is disabled!</p>
+{{/if}}
+```
+
+### List of feature flags
+
+| Name                | Description                                                                                        |
+| ------------------- | -------------------------------------------------------------------------------------------------- |
+| `show-forms-module` | Show the forms module in overview and navigation, the route remains functional, defaults to false. |
+
 ## Environment variables
 
 This frontend is hosted by the [static-file-service](https://github.com/mu-semtech/static-file-service) microservice. It supports configuring our Ember application at runtime using environment variables. The following options are available for the lokaal mandatenbeheer image.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Frontend of the lokaal mandatenbeheer application
 
 ## Feature flags
 
-Feature flags are used to enable/disable features in the application. They are defined in config/environment.js.
+Feature flags are used to enable/disable features in the application. They are defined in [config/environment.js](config/environment.js).
 
 ```javascript
 // in config/environment.js
@@ -43,9 +43,9 @@ let ENV = {
 
 The configuration can be manually overridden by adding a query parameter to the URL:
 
-?feature-new-feature=false to disable the 'new-feature'
-?feature-beta-feature=true to enable the 'beta-feature'
-The overriding will be saved in a cookie, so it will persist across page reloads. The cookie can be cleared by adding ?clear-feature-overrides=true to the URL.
+`?feature-new-feature=false` to disable the 'new-feature'
+`?feature-beta-feature=true` to enable the 'beta-feature'
+The overriding will be saved in a cookie, so it will persist across page reloads. The cookie can be cleared by adding `?clear-feature-overrides=true` to the URL.
 
 The feature flags can be used in the application by injecting the features service and calling the isEnabled method.
 
@@ -67,7 +67,7 @@ export default class ExampleComponent extends Component {
 }
 ```
 
-Or in template files by using the is-feature-enabled helper:
+Or in template files by using the `is-feature-enabled` helper:
 
 ```handlebars
 {{#if (is-feature-enabled "new-feature")}}

--- a/app/components/shared/compact-menu.hbs
+++ b/app/components/shared/compact-menu.hbs
@@ -17,8 +17,10 @@
     <AuIcon @icon="vote" @alignment="left" />
     Opstart nieuwe legislatuur
   </AuLink>
-  <AuLink @route="forms" role="menuitem">
-    <AuIcon @icon="draft" @alignment="left" />
-    Forms
-  </AuLink>
+  {{#if (is-feature-enabled "show-forms-module")}}
+    <AuLink @route="forms" role="menuitem">
+      <AuIcon @icon="draft" @alignment="left" />
+      Forms
+    </AuLink>
+  {{/if}}
 </AuDropdown>

--- a/app/components/shared/main-menu.hbs
+++ b/app/components/shared/main-menu.hbs
@@ -21,11 +21,13 @@
         Opstart nieuwe legislatuur
       </AuNavigationLink>
     </li>
-    <li class="au-c-list-navigation__item">
-      <AuNavigationLink @route="forms">
-        <AuIcon @icon="draft" @alignment="left" />
-        Forms
-      </AuNavigationLink>
-    </li>
+    {{#if (is-feature-enabled "show-forms-module")}}
+      <li class="au-c-list-navigation__item">
+        <AuNavigationLink @route="forms">
+          <AuIcon @icon="draft" @alignment="left" />
+          Forms
+        </AuNavigationLink>
+      </li>
+    {{/if}}
   </ul>
 </nav>

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -4,4 +4,5 @@ import { service } from '@ember/service';
 
 export default class IndexController extends Controller {
   @service currentSession;
+  @service features;
 }

--- a/app/helpers/is-feature-enabled.js
+++ b/app/helpers/is-feature-enabled.js
@@ -1,0 +1,16 @@
+import Helper from '@ember/component/helper';
+
+import { assert } from '@ember/debug';
+import { service } from '@ember/service';
+
+export default class IsFeatureEnabledHelper extends Helper {
+  @service features;
+
+  compute(positional) {
+    assert(
+      'is-feature-enabled expects exactly one argument',
+      positional.length === 1
+    );
+    return this.features.isEnabled(positional[0] || '');
+  }
+}

--- a/app/services/features.js
+++ b/app/services/features.js
@@ -1,0 +1,110 @@
+import Service from '@ember/service';
+
+import { assert } from '@ember/debug';
+import config from '../config/environment';
+
+export default class FeaturesService extends Service {
+  static PREFIX = 'feature-';
+  #features = {};
+
+  constructor() {
+    super();
+    const queryParams = this.#getQueryParams();
+    if (queryParams.get('clear-feature-overrides') === 'true') {
+      this.#clearCookieFeatures();
+    }
+
+    const configFeatures = this.#getConfigFeatures();
+    const cookieFeatures = this.#getCookieFeatures();
+    const queryFeatures = this.#getQueryParamsFeatures(queryParams);
+    this.setup({
+      ...configFeatures,
+      ...cookieFeatures,
+      ...queryFeatures,
+    });
+
+    // save query params in cookie
+    if (Object.keys(queryFeatures).length > 0) {
+      this.#setCookieFeatures(queryFeatures);
+    }
+  }
+
+  setup(features) {
+    this.#features = { ...features };
+    console.log('Feature flags:', this.#features);
+  }
+
+  isEnabled(feature) {
+    assert(
+      `The "${feature}" feature is not defined. Make sure the feature is defined in the "features" object in the config/environment.js file and that there are no typos in the name.`,
+      feature in this.#features
+    );
+
+    return this.#features[feature] ?? false;
+  }
+
+  #getConfigFeatures() {
+    const configFeatures = Object.fromEntries(
+      Object.entries(config.features).map(([featureName, value]) => {
+        return [featureName, value === 'true' || value === true];
+      })
+    );
+
+    return configFeatures;
+  }
+
+  // cookie has to start with 'feature-{{feature-name}}'
+  #getCookieFeatures() {
+    const cookieFeatures = {};
+    const cookies = document.cookie.split('; ');
+
+    for (const cookie of cookies) {
+      const [key, value] = cookie.split('=');
+      const featureName = this.#extractFeatureNameFromKey(key);
+      if (featureName) {
+        cookieFeatures[featureName] = value === 'true';
+      }
+    }
+
+    return cookieFeatures;
+  }
+
+  #setCookieFeatures(features) {
+    for (const [featureName, featureValue] of Object.entries(features)) {
+      document.cookie = `${FeaturesService.PREFIX}${featureName}=${featureValue}; path=/`;
+    }
+  }
+
+  #clearCookieFeatures() {
+    const featuresToClear = Object.keys(this.#getCookieFeatures());
+    for (const featureName of featuresToClear) {
+      document.cookie = `${FeaturesService.PREFIX}${featureName}=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+    }
+  }
+
+  #getQueryParams() {
+    const queryString = window.location.search.substring(1);
+    return new URLSearchParams(queryString);
+  }
+
+  //query param has to start with 'feature-{{feature-name}}'
+  #getQueryParamsFeatures(queryParams) {
+    const queryFeatures = {};
+
+    for (const [key, value] of queryParams.entries()) {
+      const featureName = this.#extractFeatureNameFromKey(key);
+      if (featureName) {
+        queryFeatures[featureName] = value === 'true';
+      }
+    }
+
+    return queryFeatures;
+  }
+
+  #extractFeatureNameFromKey(key) {
+    if (key?.startsWith(FeaturesService.PREFIX)) {
+      return key.replace(FeaturesService.PREFIX, '');
+    }
+    return null;
+  }
+}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -53,15 +53,17 @@
           </:link>
         </LoketModuleCard>
       </li>
-      <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
-        <LoketModuleCard @icon="draft">
-          <:title>Forms</:title>
-          <:description>Hier vind je een overzicht van de huidige forms.</:description>
-          <:link>
-            <AuLink @route="forms" @skin="button">Ga naar forms</AuLink>
-          </:link>
-        </LoketModuleCard>
-      </li>
+      {{#if (is-feature-enabled "show-forms-module-on-overview")}}
+        <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
+          <LoketModuleCard @icon="draft">
+            <:title>Forms</:title>
+            <:description>Hier vind je een overzicht van de huidige forms.</:description>
+            <:link>
+              <AuLink @route="forms" @skin="button">Ga naar forms</AuLink>
+            </:link>
+          </LoketModuleCard>
+        </li>
+      {{/if}}
     </ul>
   </div>
 </div>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -53,7 +53,7 @@
           </:link>
         </LoketModuleCard>
       </li>
-      {{#if (is-feature-enabled "show-forms-module-on-overview")}}
+      {{#if (is-feature-enabled "show-forms-module")}}
         <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
           <LoketModuleCard @icon="draft">
             <:title>Forms</:title>

--- a/config/environment.js
+++ b/config/environment.js
@@ -32,7 +32,7 @@ module.exports = function (environment) {
       switchRedirectUrl: '{{ACMIDM_SWITCH_REDIRECT_URL}}',
     },
     features: {
-      // 'feature-name': '{{FEATURE_ENV_VAR_NAME}}',
+      'show-forms-module-on-overview': false,
     },
     lpdcUrl: '{{LPDC_URL}}',
     worshipDecisionsDatabaseUrl: '{{WORSHIP_DECISIONS_DATABASE_URL}}',

--- a/config/environment.js
+++ b/config/environment.js
@@ -32,7 +32,7 @@ module.exports = function (environment) {
       switchRedirectUrl: '{{ACMIDM_SWITCH_REDIRECT_URL}}',
     },
     features: {
-      'show-forms-module-on-overview': false,
+      'show-forms-module': false,
     },
     lpdcUrl: '{{LPDC_URL}}',
     worshipDecisionsDatabaseUrl: '{{WORSHIP_DECISIONS_DATABASE_URL}}',

--- a/tests/integration/helpers/is-feature-enabled-test.js
+++ b/tests/integration/helpers/is-feature-enabled-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | is-feature-enabled', function (hooks) {
+  setupRenderingTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it renders', async function (assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{is-feature-enabled this.inputValue}}`);
+
+    assert.dom(this.element).hasText('1234');
+  });
+});

--- a/tests/unit/services/features-test.js
+++ b/tests/unit/services/features-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-lmb/tests/helpers';
+
+module('Unit | Service | features', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:features');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
## Description

Add feature flags to our app in the same way organisatie-portaal did (link in ticket). I created a test feature flag for the forms module on the overview page.

## How to test

1. Go to the overview page and normally the forms module will not be shown.
2. Add the feature flag to your url `?feature-show-forms-module-on-overview=false` http://localhost:4200/?feature-show-forms-module-on-overview=true and the forms module should be visible.
