### PR TITLE
LMB-620 Open modal when updating status installatievergadering

### DIFF
--- a/app/controllers/verkiezingen/installatievergadering.js
+++ b/app/controllers/verkiezingen/installatievergadering.js
@@ -38,10 +38,10 @@ export default class PrepareInstallatievergaderingController extends Controller 
   @tracked isModalOpen = false;
 
   @action
-  async selectStatus() {
+  async selectStatus(status) {
     this.isModalOpen = false;
     const installatievergadering = this.model.installatievergadering;
-    installatievergadering.status = this.nextStatus.status;
+    installatievergadering.status = status;
     await installatievergadering.save();
 
     if (

--- a/app/controllers/verkiezingen/installatievergadering.js
+++ b/app/controllers/verkiezingen/installatievergadering.js
@@ -12,6 +12,20 @@ import {
 
 import { task } from 'ember-concurrency';
 
+const uriLabelMap = {
+  [INSTALLATIEVERGADERING_BEHANDELD_STATUS]: {
+    skin: 'success',
+    label: 'Behandeld',
+  },
+  [INSTALLATIEVERGADERING_TE_BEHANDELEN_STATUS]: {
+    skin: 'info',
+    label: 'Te behandelen',
+  },
+  [INSTALLATIEVERGADERING_KLAAR_VOOR_VERGADERING_STATUS]: {
+    skin: 'warning',
+    label: 'Klaar voor vergadering',
+  },
+};
 export default class PrepareInstallatievergaderingController extends Controller {
   queryParams = ['bestuursperiode'];
   @service store;
@@ -21,11 +35,13 @@ export default class PrepareInstallatievergaderingController extends Controller 
   @tracked statusPillSkin = 'info';
   @tracked statusPillLabel = 'info';
   @tracked nextStatus;
+  @tracked isModalOpen = false;
 
   @action
-  async selectStatus(status) {
+  async selectStatus() {
+    this.isModalOpen = false;
     const installatievergadering = this.model.installatievergadering;
-    installatievergadering.status = status;
+    installatievergadering.status = this.nextStatus.status;
     await installatievergadering.save();
 
     if (
@@ -55,20 +71,6 @@ export default class PrepareInstallatievergaderingController extends Controller 
 
   setInstallatievergaderingStatusPill = task(async () => {
     const status = await this.model.installatievergadering.status;
-    const uriLabelMap = {
-      [INSTALLATIEVERGADERING_BEHANDELD_STATUS]: {
-        skin: 'success',
-        label: 'Behandeld',
-      },
-      [INSTALLATIEVERGADERING_TE_BEHANDELEN_STATUS]: {
-        skin: 'info',
-        label: 'Te behandelen',
-      },
-      [INSTALLATIEVERGADERING_KLAAR_VOOR_VERGADERING_STATUS]: {
-        skin: 'warning',
-        label: 'Klaar voor vergadering',
-      },
-    };
 
     this.statusPillSkin = uriLabelMap[status.uri].skin;
     this.statusPillLabel = uriLabelMap[status.uri].label;
@@ -87,11 +89,25 @@ export default class PrepareInstallatievergaderingController extends Controller 
         ),
         label: 'Klaarzetten voor vergadering',
         icon: 'circle-step-3',
+        modalMessage:
+          'Ben je klaar met de voorbereiding? Als je naar de volgende status gaat wordt deze beschikbaar gemaakt voor een compatibel notuleringspakket.',
+        statusLabel:
+          uriLabelMap[INSTALLATIEVERGADERING_KLAAR_VOOR_VERGADERING_STATUS]
+            .label,
+        statusPillSkin:
+          uriLabelMap[INSTALLATIEVERGADERING_KLAAR_VOOR_VERGADERING_STATUS]
+            .skin,
       },
       [INSTALLATIEVERGADERING_KLAAR_VOOR_VERGADERING_STATUS]: {
         status: findStatusForUri(INSTALLATIEVERGADERING_BEHANDELD_STATUS),
         label: 'Voorbereiding afronden',
         icon: 'circle-step-4',
+        modalMessage:
+          'Door naar de volgende status te gaan wordt de voorbereiding afgesloten en zal je de deze niet meer kunnen bewerken.',
+        statusPillLabel:
+          uriLabelMap[INSTALLATIEVERGADERING_BEHANDELD_STATUS].label,
+        statusPillSkin:
+          uriLabelMap[INSTALLATIEVERGADERING_BEHANDELD_STATUS].skin,
       },
       [INSTALLATIEVERGADERING_BEHANDELD_STATUS]: {
         status: null,
@@ -102,4 +118,13 @@ export default class PrepareInstallatievergaderingController extends Controller 
 
     this.nextStatus = nextStatusFor[currentStatus.uri];
   });
+  @action
+  openModal() {
+    this.isModalOpen = true;
+  }
+
+  @action
+  closeModal() {
+    this.isModalOpen = false;
+  }
 }

--- a/app/controllers/verkiezingen/installatievergadering.js
+++ b/app/controllers/verkiezingen/installatievergadering.js
@@ -91,7 +91,7 @@ export default class PrepareInstallatievergaderingController extends Controller 
         icon: 'circle-step-3',
         modalMessage:
           'Ben je klaar met de voorbereiding? Als je naar de volgende status gaat wordt deze beschikbaar gemaakt voor een compatibel notuleringspakket.',
-        statusLabel:
+        statusPillLabel:
           uriLabelMap[INSTALLATIEVERGADERING_KLAAR_VOOR_VERGADERING_STATUS]
             .label,
         statusPillSkin:

--- a/app/templates/verkiezingen/installatievergadering.hbs
+++ b/app/templates/verkiezingen/installatievergadering.hbs
@@ -3,7 +3,6 @@
   this.model.selectedPeriod.label
   route="verkiezingen.installatievergadering"
 }}
-
 {{#if (or (not @model.isRelevant) (not @model.installatievergadering))}}
   <div class="au-o-box">
     <div class="au-o-flow">
@@ -60,7 +59,7 @@
         @icon={{this.nextStatus.icon}}
         @loading={{this.setNextStatus.isRunning}}
         @loadingMessage="Volgende status ophalen"
-        {{on "click" (fn this.selectStatus this.nextStatus.status)}}
+        {{on "click" this.openModal}}
       >
         {{this.nextStatus.label}}
       </AuButton>
@@ -98,4 +97,40 @@
       </div>
     {{/unless}}
   </div>
+  <AuModalContainer />
+  <AuModal
+    @title="Volgende status"
+    @modalOpen={{this.isModalOpen}}
+    @closable={{true}}
+    @closeModal={{this.closeModal}}
+    as |Modal|
+  >
+    <Modal.Body>
+      <p>
+        {{this.nextStatus.modalMessage}}
+      </p>
+      <p>We veranderen de status van de installatievergadering van
+        <AuPill @skin={{this.statusPillSkin}}>
+          {{this.statusPillLabel}}
+        </AuPill>
+        naar
+        <AuPill @skin={{this.nextStatus.statusPillSkin}}>
+          {{this.nextStatus.statusPillLabel}}
+        </AuPill>.</p>
+    </Modal.Body>
+    <Modal.Footer>
+      <AuToolbar as |Group|>
+        <Group class="au-u-1-1">
+          <AuButtonGroup class="au-u-flex au-u-flex--between au-u-1-1">
+            <AuButton @skin="secondary" {{on "click" this.closeModal}}>
+              Annuleer
+            </AuButton>
+            <AuButton {{on "click" this.selectStatus}}>
+              Bevestigen
+            </AuButton>
+          </AuButtonGroup>
+        </Group>
+      </AuToolbar>
+    </Modal.Footer>
+  </AuModal>
 {{/if}}

--- a/app/templates/verkiezingen/installatievergadering.hbs
+++ b/app/templates/verkiezingen/installatievergadering.hbs
@@ -106,17 +106,18 @@
     as |Modal|
   >
     <Modal.Body>
-      <p>
-        {{this.nextStatus.modalMessage}}
-      </p>
-      <p>We veranderen de status van de installatievergadering van
+      <p>Van
         <AuPill @skin={{this.statusPillSkin}}>
           {{this.statusPillLabel}}
         </AuPill>
-        naar
+        →
         <AuPill @skin={{this.nextStatus.statusPillSkin}}>
           {{this.nextStatus.statusPillLabel}}
-        </AuPill>.</p>
+        </AuPill></p>
+      <br />
+      <p>
+        {{this.nextStatus.modalMessage}}
+      </p>
     </Modal.Body>
     <Modal.Footer>
       <AuToolbar as |Group|>
@@ -125,7 +126,9 @@
             <AuButton @skin="secondary" {{on "click" this.closeModal}}>
               Annuleer
             </AuButton>
-            <AuButton {{on "click" this.selectStatus}}>
+            <AuButton
+              {{on "click" (fn this.selectStatus this.nextStatus.status)}}
+            >
               Bevestigen
             </AuButton>
           </AuButtonGroup>


### PR DESCRIPTION
## Description

On select new status installatievergadering open a popup to tell the user the status will change from old status to new status.
The user can save it or cancel it. 

## How to test

- Go to http://localhost:4200/verkiezingen/installatievergadering
- Click on the button `Klaarzetten voor vergadering` 
- Popup should open
- Click on cancel -> the popup should close and the status is still the old one 
- Click on Save -> the popup should close and the status should be `Klaar voor vergadering`
- Click on the button `Voorbereiding afronden` 
- Popup should open 
- Click on Save -> the popup should close and the status should be `Behandeld`


## Links to other PR's
/
