### PR TITLE
Ben/lmb 548 min max nb members

### DIFF
--- a/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
+++ b/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
@@ -9,8 +9,10 @@
     <t.content as |c|>
       <c.header>
         <th>Naam</th>
-        <th>Min aantal houders</th>
-        <th>Max aantal houders</th>
+        {{#if this.showMinMax}}
+          <th>Min aantal houders</th>
+          <th>Max aantal houders</th>
+        {{/if}}
         <th>Aantal houders</th>
         <th></th>
       </c.header>
@@ -18,13 +20,14 @@
         <td class="au-u-visible-small-up">
           {{mandaat.bestuursfunctie.label}}
         </td>
-
-        <td class="au-u-visible-small-up">
-          {{mandaat.minAantalHouders}}
-        </td>
-        <td class="au-u-visible-small-up">
-          {{mandaat.maxAantalHouders}}
-        </td>
+        {{#if this.showMinMax}}
+          <td class="au-u-visible-small-up">
+            {{mandaat.minAantalHouders}}
+          </td>
+          <td class="au-u-visible-small-up">
+            {{mandaat.maxAantalHouders}}
+          </td>
+        {{/if}}
         <td class="au-u-visible-small-up">
           {{#if (eq this.editMandaat.id mandaat.id)}}
             <AuInput

--- a/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
+++ b/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
@@ -9,7 +9,9 @@
     <t.content as |c|>
       <c.header>
         <th>Naam</th>
-        <th>Aantal Houders</th>
+        <th>Min aantal houders</th>
+        <th>Max aantal houders</th>
+        <th>Aantal houders</th>
         <th></th>
       </c.header>
       <c.body as |mandaat|>
@@ -17,6 +19,12 @@
           {{mandaat.bestuursfunctie.label}}
         </td>
 
+        <td class="au-u-visible-small-up">
+          {{mandaat.minAantalHouders}}
+        </td>
+        <td class="au-u-visible-small-up">
+          {{mandaat.maxAantalHouders}}
+        </td>
         <td class="au-u-visible-small-up">
           {{#if (eq this.editMandaat.id mandaat.id)}}
             <AuInput

--- a/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
+++ b/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
@@ -22,10 +22,10 @@
         </td>
         {{#if this.showMinMax}}
           <td class="au-u-visible-small-up">
-            {{mandaat.minAantalHouders}}
+            {{if mandaat.minAantalHouders mandaat.minAantalHouders "Onbepaald"}}
           </td>
           <td class="au-u-visible-small-up">
-            {{mandaat.maxAantalHouders}}
+            {{if mandaat.maxAantalHouders mandaat.maxAantalHouders "Onbepaald"}}
           </td>
         {{/if}}
         <td class="au-u-visible-small-up">

--- a/app/components/mandatenbeheer/bestuursorgaan-mandaten.js
+++ b/app/components/mandatenbeheer/bestuursorgaan-mandaten.js
@@ -19,11 +19,15 @@ export default class MandatenbeheerBestuursorgaanMandatenComponent extends Compo
   @tracked editMandaat = null;
   @tracked aantalHouders;
   @tracked errorMessageAantalHouders;
+  @tracked showMinMax = false;
 
   constructor() {
     super(...arguments);
     this.selectedBestuursfunctie =
       this.args.availableBestuursfuncties.firstObject;
+    this.showMinMax = this.args.orderedMandaten.some(
+      (obj) => obj.minAantalHouders !== undefined
+    );
   }
 
   createMandaat = task({ drop: true }, async () => {

--- a/app/models/mandaat.js
+++ b/app/models/mandaat.js
@@ -14,6 +14,8 @@ const identity = Boolean;
 export default class MandaatModel extends Model {
   @attr uri;
   @attr aantalHouders;
+  @attr minAantalHouders;
+  @attr maxAantalHouders;
 
   @belongsTo('bestuursfunctie-code', {
     async: true,


### PR DESCRIPTION
## Description

Extend mandate model to make it possible to add a minimum and maximum aantal houders. Also show this in the bestuursorgaan detail page.

![Screenshot 2024-07-23 at 18 13 01](https://github.com/user-attachments/assets/5df61be9-f2d5-4239-bcb0-4c51b22e3dd8)

## How to test

Run the migration in the linked PR and check a few bestuursorganen to see if they have actually a minimum and maximum number of members. Toegevoegde schepenen will never have a min and max and only very few rmw's will have these filled in. Not all bestuursorganen will have filled in data, this is based on the following Excel, so if you don't find data for a bestuursorgaan, it is probably because it is not in this file. https://vlaamseoverheid.sharepoint.com/:x:/r/sites/ABB_LMB/_layouts/15/doc.aspx?sourcedoc=%7B5bd175d5-3dbe-4e41-9adc-51552b96b9c3%7D&action=edit

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/181
