### PR TITLE
LMB-631: Add niet beschikbaar text when no status available

### DIFF
--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -11,9 +11,13 @@
     <div class="au-o-grid__item au-u-1-2">
       <div class="au-c-description-label">Status</div>
       <div class="au-c-description-value au-u-margin-top-tiny">
-        <AuPill @skin={{this.skinForStatusPill}}>
-          {{this.status}}
-        </AuPill>
+        {{#if this.status}}
+          <AuPill @skin={{this.skinForStatusPill}}>
+            {{this.status}}
+          </AuPill>
+        {{else}}
+          <p>Niet beschikbaar</p>
+        {{/if}}
       </div>
     </div>
     <div class="au-o-grid__item au-u-1-2">


### PR DESCRIPTION
## Description

Add text "Niet beschikbaar" when status is not available.

## How to test

Open a mandaat for example: http://localhost:4200/mandatarissen/ac7c0cec477cc285a64e2ab49dbf472d72552c43caf849a827ac7766b9894282/persoon/80882aa4de58bc659257e648952ef06e741b9c4bc3ddcb5ba0fe1011359932eb/mandataris

Check if the status is "Niet beschikbaar"

