### PR TITLE
Ben/lmb 515 duplicate mandatarissen

### DIFF
--- a/app/components/mandatarissen/linked/update-modal.hbs
+++ b/app/components/mandatarissen/linked/update-modal.hbs
@@ -1,0 +1,32 @@
+<div {{did-update this.checkIfMandateAlreadyExists @recentUpdate}}>
+  <AuModal
+    @title={{this.doubleMandateTitle}}
+    @modalOpen={{this.doubleMandateModal}}
+    @closable={{true}}
+    @closeModal={{this.toggleDoubleMandateModal}}
+    as |Modal|
+  >
+    <Modal.Body>
+      <p>
+        {{this.doubleMandateText}}
+      </p>
+    </Modal.Body>
+    <Modal.Footer>
+      <AuToolbar as |Group|>
+        <Group>
+          <AuButtonGroup>
+            <AuButton {{on "click" this.createDoubleMandataris}}>
+              Ja
+            </AuButton>
+            <AuButton
+              @skin="secondary"
+              {{on "click" this.toggleDoubleMandateModal}}
+            >
+              Nee
+            </AuButton>
+          </AuButtonGroup>
+        </Group>
+      </AuToolbar>
+    </Modal.Footer>
+  </AuModal>
+</div>

--- a/app/components/mandatarissen/linked/update-modal.hbs
+++ b/app/components/mandatarissen/linked/update-modal.hbs
@@ -1,9 +1,9 @@
 <div {{did-update this.checkIfMandateAlreadyExists @recentUpdate}}>
   <AuModal
     @title={{this.doubleMandateTitle}}
-    @modalOpen={{this.doubleMandateModal}}
+    @modalOpen={{this.isModalOpen}}
     @closable={{true}}
-    @closeModal={{this.toggleDoubleMandateModal}}
+    @closeModal={{this.closeModal}}
     as |Modal|
   >
     <Modal.Body>
@@ -18,10 +18,7 @@
             <AuButton {{on "click" this.createDoubleMandataris}}>
               Ja
             </AuButton>
-            <AuButton
-              @skin="secondary"
-              {{on "click" this.toggleDoubleMandateModal}}
-            >
+            <AuButton @skin="secondary" {{on "click" this.closeModal}}>
               Nee
             </AuButton>
           </AuButtonGroup>

--- a/app/components/mandatarissen/linked/update-modal.js
+++ b/app/components/mandatarissen/linked/update-modal.js
@@ -1,0 +1,73 @@
+import Component from '@glimmer/component';
+
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
+
+export default class MandatarissenLinkedUpdateModal extends Component {
+  @service store;
+  @service toaster;
+
+  @tracked doubleMandateTitle = '';
+  @tracked doubleMandateText = '';
+  @tracked doubleMandateModal = false;
+
+  @action
+  toggleDoubleMandateModal() {
+    this.doubleMandateModal = !this.doubleMandateModal;
+  }
+
+  @action
+  checkIfMandateAlreadyExists() {
+    console.log('did update triggered');
+    console.log(this.args.recentUpdate);
+    if (!this.args.recentUpdate) {
+      return;
+    }
+    this.checkDoubleMandataris();
+  }
+
+  @action
+  async checkDoubleMandataris() {
+    const response = await fetch(
+      `/mandataris-api/mandatarissen/${this.args.mandataris}/check-possible-double`
+    );
+    const jsonReponse = await response.json();
+
+    if (response.status !== 200) {
+      console.error(jsonReponse.message);
+      throw jsonReponse.message;
+    }
+
+    if (!jsonReponse.duplicateMandate || jsonReponse.hasDouble) {
+      return;
+    }
+
+    this.doubleMandateModal = true;
+    const currentMandate = jsonReponse.currentMandate;
+    const duplicateMandate = jsonReponse.duplicateMandate;
+    this.doubleMandateTitle = `Aanmaken mandaat ${duplicateMandate}`;
+    this.doubleMandateText = `
+    U heeft zonet een mandataris met het mandaat ${currentMandate} aangemaakt.
+    Normaliter heeft een mandataris met dit mandaat ook een corresponderend mandaat als ${duplicateMandate}.
+    Wenst u dit mandaat aan te maken?`;
+  }
+
+  @action
+  async createDoubleMandataris() {
+    const response = await fetch(
+      `/mandataris-api/mandatarissen/${this.args.mandataris}/create-linked-mandataris`,
+      { method: 'POST' }
+    );
+    const jsonReponse = await response.json();
+
+    if (response.status !== 201) {
+      console.error(jsonReponse.message);
+      showErrorToast(this.toaster, jsonReponse.message);
+    }
+    showSuccessToast(this.toaster, `Mandataris werd succesvol aangemaakt.`);
+    this.toggleDoubleMandateModal();
+  }
+}

--- a/app/components/mandatarissen/linked/update-modal.js
+++ b/app/components/mandatarissen/linked/update-modal.js
@@ -12,21 +12,22 @@ export default class MandatarissenLinkedUpdateModal extends Component {
 
   @tracked doubleMandateTitle = '';
   @tracked doubleMandateText = '';
-  @tracked doubleMandateModal = false;
-
-  @action
-  toggleDoubleMandateModal() {
-    this.doubleMandateModal = !this.doubleMandateModal;
-  }
+  @tracked isModalOpen = false;
 
   @action
   checkIfMandateAlreadyExists() {
-    console.log('did update triggered');
-    console.log(this.args.recentUpdate);
     if (!this.args.recentUpdate) {
       return;
     }
     this.checkDoubleMandataris();
+  }
+
+  @action
+  closeModal() {
+    this.isModalOpen = false;
+    if (this.args.callback) {
+      this.args.callback();
+    }
   }
 
   @action
@@ -42,10 +43,13 @@ export default class MandatarissenLinkedUpdateModal extends Component {
     }
 
     if (!jsonReponse.duplicateMandate || jsonReponse.hasDouble) {
+      if (this.args.callback) {
+        this.args.callback();
+      }
       return;
     }
 
-    this.doubleMandateModal = true;
+    this.isModalOpen = true;
     const currentMandate = jsonReponse.currentMandate;
     const duplicateMandate = jsonReponse.duplicateMandate;
     this.doubleMandateTitle = `Aanmaken mandaat ${duplicateMandate}`;
@@ -68,6 +72,10 @@ export default class MandatarissenLinkedUpdateModal extends Component {
       showErrorToast(this.toaster, jsonReponse.message);
     }
     showSuccessToast(this.toaster, `Mandataris werd succesvol aangemaakt.`);
-    this.toggleDoubleMandateModal();
+    this.isModalOpen = false;
+
+    if (this.args.callback) {
+      this.args.callback();
+    }
   }
 }

--- a/app/components/rdf-input-fields/mandataris-fractie-selector.js
+++ b/app/components/rdf-input-fields/mandataris-fractie-selector.js
@@ -37,6 +37,7 @@ export default class MandatarisFractieSelector extends InputFieldComponent {
   @tracked bestuurseenheid = null;
   @tracked bestuursperiode;
   @tracked person;
+  @tracked previousPerson;
   @tracked isPersonInForm;
 
   emptySelectorOptions = [];
@@ -112,6 +113,7 @@ export default class MandatarisFractieSelector extends InputFieldComponent {
       newPerson = await this.findMandatarisPersonByQuery(mandatarisNode.value);
     }
     await this.clearFractieIfDifferentPerson(newPerson);
+    this.previousPerson = newPerson;
     this.person = newPerson;
   });
 
@@ -119,7 +121,10 @@ export default class MandatarisFractieSelector extends InputFieldComponent {
     if (!this.selectedFractie) {
       return;
     }
-    if (!newPerson || this.person !== newPerson) {
+    if (
+      !newPerson ||
+      (this.previousPerson && this.previousPerson !== newPerson)
+    ) {
       this.initialized = false;
       await this.onSelectFractie(null);
       // hack to have the fractie selector reinitialize and recompute the possible fractions

--- a/app/controllers/organen/orgaan/mandataris/new.js
+++ b/app/controllers/organen/orgaan/mandataris/new.js
@@ -17,6 +17,8 @@ export default class OrganenMandatarisNewController extends Controller {
   queryParams = ['person'];
 
   @tracked person = null;
+  @tracked createdMandataris = false;
+  @tracked newestMandatarisId = null;
 
   @action
   cancel() {
@@ -29,6 +31,12 @@ export default class OrganenMandatarisNewController extends Controller {
     await syncNewMandatarisMembership(this.store, instanceTtl, instanceId);
     await this.fractieApi.updateCurrentFractie(instanceId);
     await this.mandatarisService.removeDanglingFractiesInPeriod(instanceId);
+    this.newestMandatarisId = instanceId;
+    this.createdMandataris = true;
+  }
+
+  @action
+  callbackAfterCreate() {
     this.router.transitionTo('organen.orgaan.mandatarissen');
   }
 

--- a/app/controllers/organen/orgaan/mandatarissen.js
+++ b/app/controllers/organen/orgaan/mandatarissen.js
@@ -7,11 +7,13 @@ import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
 import { getBestuursorganenMetaTtl } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';
 import { buildNewMandatarisSourceTtl } from 'frontend-lmb/utils/build-new-mandataris-source-ttl';
 import { syncNewMandatarisMembership } from 'frontend-lmb/utils/sync-new-mandataris-membership';
+import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
 
 export default class OrganenMandatarissenController extends Controller {
   @service router;
   @service store;
   @service fractieApi;
+  @service toaster;
   @service('mandataris') mandatarisService;
 
   queryParams = ['activeOnly'];
@@ -24,6 +26,11 @@ export default class OrganenMandatarissenController extends Controller {
   // we are folding the mandataris instances, so just pick a very high number here and hope our government is reasonable about the
   // number of mandatarisses that can exist
   size = 900000;
+
+  @tracked doubleMandateTitle = '';
+  @tracked doubleMandateText = '';
+  @tracked doubleMandateModal = false;
+  newestMandatarisId = null;
 
   search = task({ restartable: true }, async (searchData) => {
     await timeout(SEARCH_TIMEOUT);
@@ -41,8 +48,11 @@ export default class OrganenMandatarissenController extends Controller {
     await syncNewMandatarisMembership(this.store, instanceTtl, instanceId);
     await this.fractieApi.updateCurrentFractie(instanceId);
     await this.mandatarisService.removeDanglingFractiesInPeriod(instanceId);
-    setTimeout(() => this.router.refresh(), 1000);
     this.isCreatingMandataris = false;
+    this.newestMandatarisId = instanceId;
+    await this.checkDoubleMandataris();
+
+    setTimeout(() => this.router.refresh(), 1000); // need to give the resources cache time to update
   }
 
   @action
@@ -62,5 +72,54 @@ export default class OrganenMandatarissenController extends Controller {
   @action
   toggleActiveOnly() {
     this.activeOnly = !this.activeOnly;
+  }
+
+  toggleDoubleMandateModal() {
+    this.doubleMandateModal = !this.doubleMandateModal;
+  }
+
+  @action
+  async checkDoubleMandataris() {
+    const response = await fetch(
+      `/mandataris-api/mandatarissen/${this.newestMandatarisId}/check-possible-double`
+    );
+    const jsonReponse = await response.json();
+
+    if (response.status !== 200) {
+      console.error(jsonReponse.message);
+      throw jsonReponse.message;
+    }
+
+    if (!jsonReponse.duplicateMandate || jsonReponse.hasDouble) {
+      return;
+    }
+
+    this.doubleMandateModal = true;
+    const currentMandate = jsonReponse.currentMandate;
+    const duplicateMandate = jsonReponse.duplicateMandate;
+    this.doubleMandateTitle = `Aanmaken mandaat ${duplicateMandate}`;
+    this.doubleMandateText = `
+    U heeft zonet een mandataris met het mandaat ${currentMandate} aangemaakt.
+    Normaliter heeft een mandataris met dit mandaat ook een corresponderend mandaat als ${duplicateMandate}.
+    Wenst u dit mandaat aan te maken?`;
+  }
+
+  @action
+  async createDoubleMandataris() {
+    const response = await fetch(
+      `/mandataris-api/mandatarissen/${this.newestMandatarisId}/create-linked-mandataris`,
+      { method: 'POST' }
+    );
+    const jsonReponse = await response.json();
+
+    if (response.status !== 201) {
+      console.error(jsonReponse.message);
+      showErrorToast(this.toaster, jsonReponse.message);
+    }
+    showSuccessToast(
+      this.toaster,
+      `Mandataris ${jsonReponse.createdMandate} werd succesvol aangemaakt.`
+    );
+    this.toggleDoubleMandateModal();
   }
 }

--- a/app/controllers/organen/orgaan/mandatarissen.js
+++ b/app/controllers/organen/orgaan/mandatarissen.js
@@ -116,10 +116,7 @@ export default class OrganenMandatarissenController extends Controller {
       console.error(jsonReponse.message);
       showErrorToast(this.toaster, jsonReponse.message);
     }
-    showSuccessToast(
-      this.toaster,
-      `Mandataris ${jsonReponse.createdMandate} werd succesvol aangemaakt.`
-    );
+    showSuccessToast(this.toaster, `Mandataris werd succesvol aangemaakt.`);
     this.toggleDoubleMandateModal();
   }
 }

--- a/app/controllers/organen/orgaan/mandatarissen.js
+++ b/app/controllers/organen/orgaan/mandatarissen.js
@@ -7,11 +7,11 @@ import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
 import { getBestuursorganenMetaTtl } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';
 import { buildNewMandatarisSourceTtl } from 'frontend-lmb/utils/build-new-mandataris-source-ttl';
 import { syncNewMandatarisMembership } from 'frontend-lmb/utils/sync-new-mandataris-membership';
-import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
 
 export default class OrganenMandatarissenController extends Controller {
   @service router;
   @service store;
+
   @service fractieApi;
   @service toaster;
   @service('mandataris') mandatarisService;
@@ -21,16 +21,14 @@ export default class OrganenMandatarissenController extends Controller {
   @tracked filter = '';
   @tracked page = 0;
   @tracked isCreatingMandataris = false;
+  @tracked createdMandataris = false;
   @tracked activeOnly = false;
   sort = 'is-bestuurlijke-alias-van.achternaam';
   // we are folding the mandataris instances, so just pick a very high number here and hope our government is reasonable about the
   // number of mandatarisses that can exist
   size = 900000;
 
-  @tracked doubleMandateTitle = '';
-  @tracked doubleMandateText = '';
-  @tracked doubleMandateModal = false;
-  newestMandatarisId = null;
+  @tracked newestMandatarisId = null;
 
   search = task({ restartable: true }, async (searchData) => {
     await timeout(SEARCH_TIMEOUT);
@@ -50,9 +48,8 @@ export default class OrganenMandatarissenController extends Controller {
     await this.mandatarisService.removeDanglingFractiesInPeriod(instanceId);
     this.isCreatingMandataris = false;
     this.newestMandatarisId = instanceId;
-    await this.checkDoubleMandataris();
-
-    setTimeout(() => this.router.refresh(), 1000); // need to give the resources cache time to update
+    this.createdMandataris = true;
+    this.router.refresh();
   }
 
   @action
@@ -72,51 +69,5 @@ export default class OrganenMandatarissenController extends Controller {
   @action
   toggleActiveOnly() {
     this.activeOnly = !this.activeOnly;
-  }
-
-  toggleDoubleMandateModal() {
-    this.doubleMandateModal = !this.doubleMandateModal;
-  }
-
-  @action
-  async checkDoubleMandataris() {
-    const response = await fetch(
-      `/mandataris-api/mandatarissen/${this.newestMandatarisId}/check-possible-double`
-    );
-    const jsonReponse = await response.json();
-
-    if (response.status !== 200) {
-      console.error(jsonReponse.message);
-      throw jsonReponse.message;
-    }
-
-    if (!jsonReponse.duplicateMandate || jsonReponse.hasDouble) {
-      return;
-    }
-
-    this.doubleMandateModal = true;
-    const currentMandate = jsonReponse.currentMandate;
-    const duplicateMandate = jsonReponse.duplicateMandate;
-    this.doubleMandateTitle = `Aanmaken mandaat ${duplicateMandate}`;
-    this.doubleMandateText = `
-    U heeft zonet een mandataris met het mandaat ${currentMandate} aangemaakt.
-    Normaliter heeft een mandataris met dit mandaat ook een corresponderend mandaat als ${duplicateMandate}.
-    Wenst u dit mandaat aan te maken?`;
-  }
-
-  @action
-  async createDoubleMandataris() {
-    const response = await fetch(
-      `/mandataris-api/mandatarissen/${this.newestMandatarisId}/create-linked-mandataris`,
-      { method: 'POST' }
-    );
-    const jsonReponse = await response.json();
-
-    if (response.status !== 201) {
-      console.error(jsonReponse.message);
-      showErrorToast(this.toaster, jsonReponse.message);
-    }
-    showSuccessToast(this.toaster, `Mandataris werd succesvol aangemaakt.`);
-    this.toggleDoubleMandateModal();
   }
 }

--- a/app/templates/organen/orgaan/mandataris/new.hbs
+++ b/app/templates/organen/orgaan/mandataris/new.hbs
@@ -21,3 +21,9 @@
     >Annuleer</Form::CancelWithConfirm>
   </Group>
 </AuToolbar>
+
+<Mandatarissen::Linked::UpdateModal
+  @recentUpdate={{this.createdMandataris}}
+  @mandataris={{this.newestMandatarisId}}
+  @callback={{this.callbackAfterCreate}}
+/>

--- a/app/templates/organen/orgaan/mandatarissen.hbs
+++ b/app/templates/organen/orgaan/mandatarissen.hbs
@@ -65,3 +65,34 @@
     />
   </div>
 </AuModal>
+
+<AuModal
+  @title={{this.doubleMandateTitle}}
+  @modalOpen={{this.doubleMandateModal}}
+  @closable={{true}}
+  @closeModal={{this.toggleDoubleMandateModal}}
+  as |Modal|
+>
+  <Modal.Body>
+    <p>
+      {{this.doubleMandateText}}
+    </p>
+  </Modal.Body>
+  <Modal.Footer>
+    <AuToolbar as |Group|>
+      <Group>
+        <AuButtonGroup>
+          <AuButton {{on "click" this.createDoubleMandataris}}>
+            Ja
+          </AuButton>
+          <AuButton
+            @skin="secondary"
+            {{on "click" this.toggleDoubleMandateModal}}
+          >
+            Nee
+          </AuButton>
+        </AuButtonGroup>
+      </Group>
+    </AuToolbar>
+  </Modal.Footer>
+</AuModal>

--- a/app/templates/organen/orgaan/mandatarissen.hbs
+++ b/app/templates/organen/orgaan/mandatarissen.hbs
@@ -66,33 +66,7 @@
   </div>
 </AuModal>
 
-<AuModal
-  @title={{this.doubleMandateTitle}}
-  @modalOpen={{this.doubleMandateModal}}
-  @closable={{true}}
-  @closeModal={{this.toggleDoubleMandateModal}}
-  as |Modal|
->
-  <Modal.Body>
-    <p>
-      {{this.doubleMandateText}}
-    </p>
-  </Modal.Body>
-  <Modal.Footer>
-    <AuToolbar as |Group|>
-      <Group>
-        <AuButtonGroup>
-          <AuButton {{on "click" this.createDoubleMandataris}}>
-            Ja
-          </AuButton>
-          <AuButton
-            @skin="secondary"
-            {{on "click" this.toggleDoubleMandateModal}}
-          >
-            Nee
-          </AuButton>
-        </AuButtonGroup>
-      </Group>
-    </AuToolbar>
-  </Modal.Footer>
-</AuModal>
+<Mandatarissen::Linked::UpdateModal
+  @recentUpdate={{this.createdMandataris}}
+  @mandataris={{this.newestMandatarisId}}
+/>


### PR DESCRIPTION
## Description

When creating a mandataris that has a possible linked mandataris (e.g. a mandate of gemeenteraadslid usually also implies a lid van rmw). You get a pop-up notifying you if you want to create this linked mandataris.

## How to test

Create a new mandataris (just in the orgaan page) and check the different use cases. 
1. A mandate Toegevoegde schepenen has no linked mandate, so this should not show a pop-up
2. The pop-up appears when you add a burgemeester, schepen, gemeenteraardslid or voorzitter gemeenteraadslid.
3. The flow also works in the other direction OCMW -> Gemeente
4. Closing the pop-up results in no added mandataris
5. Accepting results in a mandataris in the corresponding bestuurseenheid in the correct bestuursorgaan
6. If the person does not exist yet it gets created
7. If the fractie does not exist yet, it gets created

There are some issues with resources unfortunately. Which can't be tackled here, it is a semantic works issue. If you go to the organen page of the corresponding bestuurseenheid after creating a "linked" mandataris, mu-cl-resources sometimes fails, either you have to restart your resources or you go to the mandatarissen page and then go back to the orgaan page, which should also solve it.

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/32
