### PR TITLE
LMB-642 fetch mandatarissen in mandaten as links based on bestuursperiode

### DIFF
--- a/app/components/mandatarissen/mandaten-as-links.js
+++ b/app/components/mandatarissen/mandaten-as-links.js
@@ -2,15 +2,23 @@ import Component from '@glimmer/component';
 
 import { A } from '@ember/array';
 import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
 
 import { restartableTask } from 'ember-concurrency';
 import { foldMandatarisses } from 'frontend-lmb/utils/fold-mandatarisses';
 
 export default class MandatarissenMandatenAsLinks extends Component {
   @tracked mandatenAsLinks = A([]);
+  @service store;
 
   setup = restartableTask(async () => {
-    const mandatarissen = await this.args.persoon.isAangesteldAls;
+    const mandatarissen = await this.store.query('mandataris', {
+      'filter[is-bestuurlijke-alias-van][:id:]': this.args.persoon.id,
+      'filter[bekleedt][bevat-in][heeft-bestuursperiode][:id:]':
+        this.args.bestuursperiode.id,
+      include: ['bekleedt', 'bekleedt.bestuursfunctie'].join(','),
+    });
+
     const foldedMandatarissen = await foldMandatarisses(null, mandatarissen);
 
     for (const foldedMandataris of foldedMandatarissen) {


### PR DESCRIPTION
## Description

Fetch mandatarissen in mandataris search page with bestuursperiode. This way the mandaten as links shown in the table don't show mandates of other bestuursperiodes.

## How to test

Go to the mandataris search page of a few bestuurseenheden and see that there are nu duplicate mandates shown in the mandate column. 