### PR TITLE
LMB-473 | Generate rows draft mandataris table

### DIFF
--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -1,4 +1,4 @@
-<div {{did-update this.onInit}}>
+<div>
   <div class="au-o-box no-pagination">
     <h1 class="au-u-h2 au-u-margin-bottom-small">{{@title}}</h1>
     <AuDataTable

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -11,57 +11,25 @@ export default class DraftMandatarisListComponent extends Component {
   @service store;
   @service fractieApi;
 
-  @tracked mandatarissen;
-
   @tracked isEditing;
   @tracked isEditFormInitialized;
   @tracked mandatarisEdit;
 
   constructor() {
     super(...arguments);
-    this.onInit();
+  }
+
+  get mandatarissen() {
+    return this.args.mandatarissen;
   }
 
   get resortedMandatarissen() {
-    if (!this.mandatarissen) {
-      return [];
-    }
-
     return orderMandatarissenByRangorde([...this.mandatarissen]);
   }
 
   @action
-  async onInit() {
-    const queryParams = {
-      page: {
-        number: 0,
-        size: 9999,
-      },
-      filter: {
-        bekleedt: {
-          'bevat-in': {
-            id: this.args.bestuursorgaan.id,
-          },
-        },
-      },
-      include: [
-        'is-bestuurlijke-alias-van',
-        'bekleedt.bestuursfunctie',
-        'heeft-lidmaatschap.binnen-fractie',
-        'status',
-        'beleidsdomein',
-      ].join(','),
-    };
-
-    if (this.args.filter) {
-      queryParams['filter']['is-bestuurlijke-alias-van'] = this.args.filter;
-    }
-
-    this.mandatarissen = await this.store.query('mandataris', queryParams);
-  }
-
-  @action
   async removeMandataris(mandataris) {
+    this.args.updateMandatarissen({ removed: [mandataris] });
     mandataris
       .destroyRecord()
       .then(() => {
@@ -73,7 +41,6 @@ export default class DraftMandatarisListComponent extends Component {
           'Er ging iets mis bij het verwijderen van de mandataris. Probeer het later opnieuw.';
         this.toaster.error(errorMessage, 'Error');
       });
-    await this.onInit();
   }
 
   @action
@@ -90,9 +57,13 @@ export default class DraftMandatarisListComponent extends Component {
 
   @action
   async saveMandatarisChanges({ instanceId }) {
-    this.closeEditMandataris();
     await this.fractieApi.updateCurrentFractie(instanceId);
     this.isEditFormInitialized = false;
-    await this.onInit();
+    const updatedMandataris = await this.store.findRecord(
+      'mandataris',
+      instanceId
+    );
+    this.args.updateMandatarissen({ updated: updatedMandataris });
+    this.closeEditMandataris();
   }
 }

--- a/app/components/verkiezingen/generate-rows-form.hbs
+++ b/app/components/verkiezingen/generate-rows-form.hbs
@@ -4,11 +4,11 @@
 {{else}}
   <RdfForm
     @groupClass="au-o-grid__item"
-    @form={{this.form}}
-    @graphs={{this.graphs}}
-    @sourceNode={{this.sourceNode}}
-    @formStore={{this.forkingStore}}
-    @forceShowErrors={{false}}
+    @form={{this.formInfo.form}}
+    @graphs={{this.formInfo.graphs}}
+    @sourceNode={{this.formInfo.sourceNode}}
+    @formStore={{this.formInfo.formStore}}
+    @forceShowErrors={{this.showErrors}}
     @useNewListingLayout={{true}}
     @level={{2}}
     class="au-u-max-width-medium"

--- a/app/components/verkiezingen/generate-rows-form.hbs
+++ b/app/components/verkiezingen/generate-rows-form.hbs
@@ -15,6 +15,26 @@
   {{mandaat.label}}
 </PowerSelect>
 <br />
+<AuDatePicker
+  @alignment={{this.alignment}}
+  @label="Start mandaat"
+  @value={{this.startDate}}
+  @min={{@startDate}}
+  @max={{@endDate}}
+  @first-day={{1}}
+  @onChange={{fn (mut this.startDate)}}
+/>
+<br />
+<AuDatePicker
+  @alignment={{this.alignment}}
+  @label="Einde mandaat"
+  @value={{this.endDate}}
+  @min={{@startDate}}
+  @max={{@endDate}}
+  @first-day={{1}}
+  @onChange={{fn (mut this.endDate)}}
+/>
+<br />
 <AuLabel for="input">Aantal rijen</AuLabel>
 <AuInput
   @disabled={{not this.selectedMandaat}}

--- a/app/components/verkiezingen/generate-rows-form.hbs
+++ b/app/components/verkiezingen/generate-rows-form.hbs
@@ -50,6 +50,8 @@
   <Group>
     <AuButtonGroup>
       <AuButton
+        @loading={{this.loadingMessage}}
+        @loadingMessage={{this.loadingMessage}}
         @disabled={{this.isInvaldForGeneration}}
         {{on "click" (perform this.onConfigReady)}}
       >

--- a/app/components/verkiezingen/generate-rows-form.hbs
+++ b/app/components/verkiezingen/generate-rows-form.hbs
@@ -1,48 +1,43 @@
-{{#if this.initForm.isRunning}}
-  <AuLabel for="input" class="skeleton-label au-u-margin-top" />
-  <p class="skeleton-input-full au-u-margin-top au-u-margin-bottom"></p>
-{{else}}
-  <PowerSelect
-    @noMatchesMessage="Geen resultaten"
-    @searchMessage="Typ om te zoeken"
-    @searchEnabled={{true}}
-    @allowClear={{false}}
-    @disabled={{@disabled}}
-    @placeholder="Zoek mandaat"
-    @searchField="label"
-    @selected={{this.selectedMandaat}}
-    @onChange={{this.selectMandaat}}
-    @onClose={{@onClose}}
-    @options={{this.mandaatOptions}}
-    as |mandaat|
-  >
-    {{mandaat.label}}
-  </PowerSelect>
-  <br />
-  <AuLabel for="input">Aantal rijen</AuLabel>
-  <AuInput
-    @disabled={{not this.selectedMandaat}}
-    value={{this.rowsToGenerate}}
-    id="input-rows-to-generate"
-    {{on "keyup" (perform this.validateRows)}}
-  />
-  <AuHelpText>{{this.rowsToCreateHelpText}}</AuHelpText>
-  {{#each this.rowWarnings as |warning|}}
-    <AuHelpText @warning={{true}}>{{warning}}</AuHelpText>
-  {{/each}}
-  <AuToolbar class="au-u-margin-top" as |Group|>
-    <Group>
-      <AuButtonGroup>
-        <AuButton
-          @disabled={{this.isInvaldForGeneration}}
-          {{on "click" (perform this.onConfigReady)}}
-        >
-          Genereer
-        </AuButton>
-        <AuButton @skin="secondary" {{on "click" @onCancel}}>
-          Annuleer
-        </AuButton>
-      </AuButtonGroup>
-    </Group>
-  </AuToolbar>
-{{/if}}
+<PowerSelect
+  @noMatchesMessage="Geen resultaten"
+  @searchMessage="Typ om te zoeken"
+  @searchEnabled={{true}}
+  @allowClear={{false}}
+  @disabled={{@disabled}}
+  @placeholder="Zoek mandaat"
+  @searchField="label"
+  @selected={{this.selectedMandaat}}
+  @onChange={{this.selectMandaat}}
+  @onClose={{@onClose}}
+  @options={{@mandaatOptions}}
+  as |mandaat|
+>
+  {{mandaat.label}}
+</PowerSelect>
+<br />
+<AuLabel for="input">Aantal rijen</AuLabel>
+<AuInput
+  @disabled={{not this.selectedMandaat}}
+  value={{this.rowsToGenerate}}
+  id="input-rows-to-generate"
+  {{on "keyup" (perform this.validateRows)}}
+/>
+<AuHelpText>{{this.rowsToCreateHelpText}}</AuHelpText>
+{{#each this.rowWarnings as |warning|}}
+  <AuHelpText @warning={{true}}>{{warning}}</AuHelpText>
+{{/each}}
+<AuToolbar class="au-u-margin-top" as |Group|>
+  <Group>
+    <AuButtonGroup>
+      <AuButton
+        @disabled={{this.isInvaldForGeneration}}
+        {{on "click" (perform this.onConfigReady)}}
+      >
+        Genereer
+      </AuButton>
+      <AuButton @skin="secondary" {{on "click" @onCancel}}>
+        Annuleer
+      </AuButton>
+    </AuButtonGroup>
+  </Group>
+</AuToolbar>

--- a/app/components/verkiezingen/generate-rows-form.hbs
+++ b/app/components/verkiezingen/generate-rows-form.hbs
@@ -2,18 +2,6 @@
   <AuLabel for="input" class="skeleton-label au-u-margin-top" />
   <p class="skeleton-input-full au-u-margin-top au-u-margin-bottom"></p>
 {{else}}
-  <RdfForm
-    @groupClass="au-o-grid__item"
-    @form={{this.formInfo.form}}
-    @graphs={{this.formInfo.graphs}}
-    @sourceNode={{this.formInfo.sourceNode}}
-    @formStore={{this.formInfo.formStore}}
-    @forceShowErrors={{this.showErrors}}
-    @useNewListingLayout={{true}}
-    @level={{2}}
-    class="au-u-max-width-medium"
-  />
-
   <AuToolbar class="au-u-margin-top" as |Group|>
     <Group>
       <AuButtonGroup>

--- a/app/components/verkiezingen/generate-rows-form.hbs
+++ b/app/components/verkiezingen/generate-rows-form.hbs
@@ -11,7 +11,7 @@
     @placeholder="Zoek mandaat"
     @searchField="label"
     @selected={{this.selectedMandaat}}
-    @onChange={{fn (mut this.selectedMandaat)}}
+    @onChange={{this.selectMandaat}}
     @onClose={{@onClose}}
     @options={{this.mandaatOptions}}
     as |mandaat|
@@ -21,10 +21,19 @@
   <br />
   <AuLabel for="input">Aantal rijen</AuLabel>
   <AuInput
+    @disabled={{not this.selectedMandaat}}
     value={{this.rowsToGenerate}}
     id="input-rows-to-generate"
-    {{on "keyup" (perform this.validateRows)}}
+    type="number"
+    min={{0}}
+    max={{100}}
+    {{on "focus" (perform this.validateRows)}}
   />
+  <div>
+    {{#each this.rowWarnings as |warning|}}
+      <AuHelpText @warning={{true}}>{{warning}}</AuHelpText>
+    {{/each}}
+  </div>
   <AuToolbar class="au-u-margin-top" as |Group|>
     <Group>
       <AuButtonGroup>

--- a/app/components/verkiezingen/generate-rows-form.hbs
+++ b/app/components/verkiezingen/generate-rows-form.hbs
@@ -1,0 +1,29 @@
+{{#if this.initForm.isRunning}}
+  <AuLabel for="input" class="skeleton-label au-u-margin-top" />
+  <p class="skeleton-input-full au-u-margin-top au-u-margin-bottom"></p>
+{{else}}
+  <RdfForm
+    @groupClass="au-o-grid__item"
+    @form={{this.form}}
+    @graphs={{this.graphs}}
+    @sourceNode={{this.sourceNode}}
+    @formStore={{this.forkingStore}}
+    @forceShowErrors={{false}}
+    @useNewListingLayout={{true}}
+    @level={{2}}
+    class="au-u-max-width-medium"
+  />
+
+  <AuToolbar class="au-u-margin-top" as |Group|>
+    <Group>
+      <AuButtonGroup>
+        <AuButton {{on "click" (perform this.onConfigReady)}}>
+          Genereer
+        </AuButton>
+        <Form::CancelWithConfirm
+          @cancel={{@onCancel}}
+        >Annuleer</Form::CancelWithConfirm>
+      </AuButtonGroup>
+    </Group>
+  </AuToolbar>
+{{/if}}

--- a/app/components/verkiezingen/generate-rows-form.hbs
+++ b/app/components/verkiezingen/generate-rows-form.hbs
@@ -2,6 +2,22 @@
   <AuLabel for="input" class="skeleton-label au-u-margin-top" />
   <p class="skeleton-input-full au-u-margin-top au-u-margin-bottom"></p>
 {{else}}
+  <PowerSelect
+    @noMatchesMessage="Geen resultaten"
+    @searchMessage="Typ om te zoeken"
+    @searchEnabled={{true}}
+    @allowClear={{false}}
+    @disabled={{@disabled}}
+    @placeholder="Zoek mandaat"
+    @searchField="label"
+    @selected={{this.selectedMandaat}}
+    @onChange={{fn (mut this.selectedMandaat)}}
+    @onClose={{@onClose}}
+    @options={{this.mandaatOptions}}
+    as |mandaat|
+  >
+    {{mandaat.label}}
+  </PowerSelect>
   <AuToolbar class="au-u-margin-top" as |Group|>
     <Group>
       <AuButtonGroup>

--- a/app/components/verkiezingen/generate-rows-form.hbs
+++ b/app/components/verkiezingen/generate-rows-form.hbs
@@ -20,9 +20,9 @@
         <AuButton {{on "click" (perform this.onConfigReady)}}>
           Genereer
         </AuButton>
-        <Form::CancelWithConfirm
-          @cancel={{@onCancel}}
-        >Annuleer</Form::CancelWithConfirm>
+        <AuButton @skin="secondary" {{on "click" @onCancel}}>
+          Annuleer
+        </AuButton>
       </AuButtonGroup>
     </Group>
   </AuToolbar>

--- a/app/components/verkiezingen/generate-rows-form.hbs
+++ b/app/components/verkiezingen/generate-rows-form.hbs
@@ -18,10 +18,20 @@
   >
     {{mandaat.label}}
   </PowerSelect>
+  <br />
+  <AuLabel for="input">Aantal rijen</AuLabel>
+  <AuInput
+    value={{this.rowsToGenerate}}
+    id="input-rows-to-generate"
+    {{on "keyup" (perform this.validateRows)}}
+  />
   <AuToolbar class="au-u-margin-top" as |Group|>
     <Group>
       <AuButtonGroup>
-        <AuButton {{on "click" (perform this.onConfigReady)}}>
+        <AuButton
+          @disabled={{this.isInvaldForGeneration}}
+          {{on "click" (perform this.onConfigReady)}}
+        >
           Genereer
         </AuButton>
         <AuButton @skin="secondary" {{on "click" @onCancel}}>

--- a/app/components/verkiezingen/generate-rows-form.hbs
+++ b/app/components/verkiezingen/generate-rows-form.hbs
@@ -24,16 +24,12 @@
     @disabled={{not this.selectedMandaat}}
     value={{this.rowsToGenerate}}
     id="input-rows-to-generate"
-    type="number"
-    min={{0}}
-    max={{100}}
-    {{on "focus" (perform this.validateRows)}}
+    {{on "keyup" (perform this.validateRows)}}
   />
-  <div>
-    {{#each this.rowWarnings as |warning|}}
-      <AuHelpText @warning={{true}}>{{warning}}</AuHelpText>
-    {{/each}}
-  </div>
+  <AuHelpText>{{this.rowsToCreateHelpText}}</AuHelpText>
+  {{#each this.rowWarnings as |warning|}}
+    <AuHelpText @warning={{true}}>{{warning}}</AuHelpText>
+  {{/each}}
   <AuToolbar class="au-u-margin-top" as |Group|>
     <Group>
       <AuButtonGroup>

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -4,17 +4,6 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { task, restartableTask } from 'ember-concurrency';
-import { ForkingStore } from '@lblod/ember-submission-form-fields';
-
-import {
-  FORM_GRAPH,
-  META_GRAPH,
-  SOURCE_GRAPH,
-} from 'frontend-lmb/utils/constants';
-import { getFormFrom } from 'frontend-lmb/utils/get-form';
-import { VERKIEZINGEN_GENERATE_ROWS_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
-import { EXT, FORM, RDF } from 'frontend-lmb/rdf/namespaces';
-import { isValidForm } from 'frontend-lmb/utils/is-valid-form';
 
 export default class GenerateRowsFormComponent extends Component {
   @service store;
@@ -29,50 +18,12 @@ export default class GenerateRowsFormComponent extends Component {
     this.initForm.perform();
   }
 
-  initForm = task(async () => {
-    const graphs = {
-      formGraph: FORM_GRAPH,
-      metaGraph: META_GRAPH,
-      sourceGraph: SOURCE_GRAPH,
-    };
-    const formDefinition = await getFormFrom(
-      this.store,
-      VERKIEZINGEN_GENERATE_ROWS_FORM_ID
-    );
-    const builderStore = new ForkingStore();
-    builderStore.parse(formDefinition.formTtl, graphs.formGraph, 'text/turtle');
-
-    this.formInfo = {
-      form: builderStore.any(
-        undefined,
-        RDF('type'),
-        FORM('Form'),
-        graphs.formGraph
-      ),
-      formStore: builderStore,
-      graphs,
-      sourceNode: EXT('source'),
-    };
-  });
+  initForm = task(async () => {});
 
   onConfigReady = restartableTask(async () => {
-    this.showErrors = !isValidForm(this.formInfo);
-    if (this.showErrors) {
-      return;
-    }
-
     this.args.onConfigReceived({
-      rows: this.getFieldValue('rows'),
-      startDate: this.getFieldValue('startDate'),
+      rows: 0,
+      startDate: null,
     });
   });
-
-  getFieldValue(predicate) {
-    return this.formInfo.formStore.any(
-      this.formInfo.sourceNode,
-      EXT(predicate),
-      undefined,
-      this.formInfo.graphs.sourceGraph
-    )?.value;
-  }
 }

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -33,6 +33,7 @@ export default class GenerateRowsFormComponent extends Component {
   }
 
   checkPossibleMandatenToGenerate = restartableTask(async () => {
+    this.rowWarnings.clear();
     this.lengthExistingMandaten = (
       await this.store.query('mandataris', {
         page: {
@@ -52,6 +53,7 @@ export default class GenerateRowsFormComponent extends Component {
         this.lengthExistingMandaten;
       this.rowsToCreateHelpText = `Je moet nog minimum ${minimumToCreate} ${minimumToCreate <= 1 ? 'mandaat' : 'mandaten'} aanmaken voor dit bestuursorgaan.`;
     }
+    this.addWarningWhenMandatenAreAtMax();
     if (this.selectedMandaat.parent.maxAantalHouders) {
       this.rowsToGenerate =
         this.selectedMandaat.parent.maxAantalHouders -
@@ -70,15 +72,7 @@ export default class GenerateRowsFormComponent extends Component {
       this.rowWarnings.pushObject('Geef een positief getal in.');
       return;
     }
-    if (
-      this.selectedMandaat.parent.maxAantalHouders &&
-      this.lengthExistingMandaten >=
-        this.selectedMandaat.parent.maxAantalHouders
-    ) {
-      this.rowWarnings.pushObject(
-        `Je hebt het maximum aantal houders voor dit mandaat bereikt.`
-      );
-    }
+    this.addWarningWhenMandatenAreAtMax();
     if (
       inputValue + this.lengthExistingMandaten >
       this.selectedMandaat.parent.maxAantalHouders
@@ -105,6 +99,18 @@ export default class GenerateRowsFormComponent extends Component {
     });
     this.args.onCancel();
   });
+
+  addWarningWhenMandatenAreAtMax() {
+    if (
+      this.selectedMandaat.parent.maxAantalHouders &&
+      this.lengthExistingMandaten >=
+        this.selectedMandaat.parent.maxAantalHouders
+    ) {
+      this.rowWarnings.pushObject(
+        `Je hebt het maximum aantal houders voor dit mandaat bereikt.`
+      );
+    }
+  }
 
   get isInvaldForGeneration() {
     return !this.selectedMandaat || this.rowsToGenerate <= 0;

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 
 import { task, restartableTask } from 'ember-concurrency';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
-import { NamedNode } from 'rdflib';
 
 import {
   FORM_GRAPH,
@@ -14,7 +13,7 @@ import {
 } from 'frontend-lmb/utils/constants';
 import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import { VERKIEZINGEN_GENERATE_ROWS_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
-import { FORM, RDF } from 'frontend-lmb/rdf/namespaces';
+import { EXT, FORM, RDF } from 'frontend-lmb/rdf/namespaces';
 import { isValidForm } from 'frontend-lmb/utils/is-valid-form';
 
 export default class GenerateRowsFormComponent extends Component {
@@ -52,7 +51,7 @@ export default class GenerateRowsFormComponent extends Component {
       ),
       formStore: builderStore,
       graphs,
-      sourceNode: new NamedNode('http://generate-rows/sourceNode'),
+      sourceNode: EXT('source'),
     };
   });
 
@@ -61,6 +60,19 @@ export default class GenerateRowsFormComponent extends Component {
     if (this.showErrors) {
       return;
     }
-    console.log('valid');
+
+    console.log({
+      rows: this.getFieldValue('rows'),
+      startDate: this.getFieldValue('startDate'),
+    });
   });
+
+  getFieldValue(predicate) {
+    return this.formInfo.formStore.any(
+      this.formInfo.sourceNode,
+      EXT(predicate),
+      undefined,
+      this.formInfo.graphs.sourceGraph
+    )?.value;
+  }
 }

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -101,6 +101,7 @@ export default class GenerateRowsFormComponent extends Component {
       startDate: this.startDate ?? this.args.startDate,
       endDate: this.endDate,
       rows: this.rowsToGenerate,
+      existingMandaten: this.lengthExistingMandaten,
     });
     this.args.onCancel();
   });

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -12,32 +12,11 @@ import { INPUT_DEBOUNCE } from 'frontend-lmb/utils/constants';
 export default class GenerateRowsFormComponent extends Component {
   @service store;
 
-  @tracked mandaatOptions;
   @tracked selectedMandaat;
   @tracked rowsToGenerate;
   @tracked rowWarnings = A([]);
   @tracked lengthExistingMandaten = 0;
   @tracked rowsToCreateHelpText;
-
-  constructor() {
-    super(...arguments);
-
-    this.initForm.perform();
-  }
-
-  initForm = task(async () => {
-    const mandaten = await this.args.bestuursorgaan.bevat;
-    this.mandaatOptions = await Promise.all(
-      mandaten.map(async (mandaat) => {
-        const bestuursfunctie = await mandaat.bestuursfunctie;
-
-        return {
-          parent: mandaat,
-          label: bestuursfunctie.label,
-        };
-      })
-    );
-  });
 
   @action
   async selectMandaat(mandaatOption) {

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -61,7 +61,7 @@ export default class GenerateRowsFormComponent extends Component {
       return;
     }
 
-    console.log({
+    this.args.onConfigReceived({
       rows: this.getFieldValue('rows'),
       startDate: this.getFieldValue('startDate'),
     });

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -13,10 +13,18 @@ export default class GenerateRowsFormComponent extends Component {
   @service store;
 
   @tracked selectedMandaat;
+  @tracked startDate;
+  @tracked endDate;
   @tracked rowsToGenerate;
   @tracked rowWarnings = A([]);
   @tracked lengthExistingMandaten = 0;
   @tracked rowsToCreateHelpText;
+
+  constructor() {
+    super(...arguments);
+    this.startDate = this.args.startDate;
+    this.endDate = this.args.endDate;
+  }
 
   @action
   async selectMandaat(mandaatOption) {
@@ -89,8 +97,10 @@ export default class GenerateRowsFormComponent extends Component {
 
   onConfigReady = task(async () => {
     this.args.onConfigReceived({
-      rows: this.rowsToGenerate,
       mandaat: this.selectedMandaat.parent,
+      startDate: this.startDate ?? this.args.startDate,
+      endDate: this.endDate,
+      rows: this.rowsToGenerate,
     });
     this.args.onCancel();
   });

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -108,7 +108,7 @@ export default class GenerateRowsFormComponent extends Component {
     this.rowsToGenerate = inputValue;
   });
 
-  onConfigReady = restartableTask(async () => {
+  onConfigReady = task(async () => {
     this.args.onConfigReceived({
       rows: this.rowsToGenerate,
       mandaat: this.selectedMandaat.parent,

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -97,7 +97,6 @@ export default class GenerateRowsFormComponent extends Component {
       rows: this.rowsToGenerate,
       existingMandaten: this.lengthExistingMandaten,
     });
-    this.args.onCancel();
   });
 
   addWarningWhenMandatenAreAtMax() {
@@ -110,6 +109,10 @@ export default class GenerateRowsFormComponent extends Component {
         `Je hebt het maximum aantal houders voor dit mandaat bereikt.`
       );
     }
+  }
+
+  get loadingMessage() {
+    return this.args.loadingMessage;
   }
 
   get isInvaldForGeneration() {

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -1,0 +1,58 @@
+import Component from '@glimmer/component';
+
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+import { task } from 'ember-concurrency';
+import { ForkingStore } from '@lblod/ember-submission-form-fields';
+import { NamedNode } from 'rdflib';
+
+import {
+  FORM_GRAPH,
+  META_GRAPH,
+  SOURCE_GRAPH,
+} from 'frontend-lmb/utils/constants';
+import { getFormFrom } from 'frontend-lmb/utils/get-form';
+import { VERKIEZINGEN_GENERATE_ROWS_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
+import { FORM, RDF } from 'frontend-lmb/rdf/namespaces';
+
+export default class GenerateRowsFormComponent extends Component {
+  @service store;
+
+  @tracked form;
+  @tracked forkingStore;
+  @tracked graphs;
+  @tracked sourceNode;
+
+  constructor() {
+    super(...arguments);
+
+    this.initForm.perform();
+  }
+
+  initForm = task(async () => {
+    this.graphs = {
+      formGraph: FORM_GRAPH,
+      metaGraph: META_GRAPH,
+      sourceGraph: SOURCE_GRAPH,
+    };
+    this.sourceNode = new NamedNode('http://generate-rows/sourceNode');
+    const formDefinition = await getFormFrom(
+      this.store,
+      VERKIEZINGEN_GENERATE_ROWS_FORM_ID
+    );
+    this.forkingStore = new ForkingStore();
+    this.forkingStore.parse(
+      formDefinition.formTtl,
+      this.graphs.formGraph,
+      'text/turtle'
+    );
+
+    this.form = this.forkingStore.any(
+      undefined,
+      RDF('type'),
+      FORM('Form'),
+      this.graphs.formGraph
+    );
+  });
+}

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -63,7 +63,7 @@ export default class GenerateRowsFormComponent extends Component {
       const minimumToCreate =
         this.selectedMandaat.parent.minAantalHouders -
         this.lengthExistingMandaten;
-      this.rowsToCreateHelpText = `Je moet nog minimum ${minimumToCreate} mandaten aanmaken voor dit bestuursorgaan.`;
+      this.rowsToCreateHelpText = `Je moet nog minimum ${minimumToCreate} ${minimumToCreate <= 1 ? 'mandaat' : 'mandaten'} aanmaken voor dit bestuursorgaan.`;
     }
     if (this.selectedMandaat.parent.maxAantalHouders) {
       this.rowsToGenerate =

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 import { task, restartableTask, timeout } from 'ember-concurrency';
 import { INPUT_DEBOUNCE } from 'frontend-lmb/utils/constants';
@@ -12,6 +13,8 @@ export default class GenerateRowsFormComponent extends Component {
   @tracked mandaatOptions;
   @tracked selectedMandaat;
   @tracked rowsToGenerate;
+  @tracked rowWarnings = [];
+  @tracked lengthExistingMandaten = 0;
 
   constructor() {
     super(...arguments);
@@ -33,17 +36,76 @@ export default class GenerateRowsFormComponent extends Component {
     );
   });
 
+  @action
+  async selectMandaat(mandaatOption) {
+    this.selectedMandaat = mandaatOption;
+    await this.checkPossibleMandatenToGenerate.perform();
+  }
+
+  checkPossibleMandatenToGenerate = restartableTask(async () => {
+    this.rowWarnings = [];
+    this.lengthExistingMandaten = (
+      await this.store.query('mandataris', {
+        page: {
+          size: 9999,
+        },
+        'filter[bekleedt][:id:]': this.selectedMandaat.parent.id,
+        'filter[bekleedt][bevat-in][:id:]': this.args.bestuursorgaan.id,
+      })
+    ).length;
+
+    if (
+      this.selectedMandaat.parent.maxAantalHouders &&
+      this.lengthExistingMandaten >=
+        this.selectedMandaat.parent.maxAantalHouders
+    ) {
+      this.rowWarnings.push(
+        `Je hebt het maximum aantal houders voor dit mandaat bereikt.`
+      );
+    }
+    if (
+      this.selectedMandaat.parent.minAantalHouders &&
+      this.lengthExistingMandaten < this.selectedMandaat.parent.minAantalHouders
+    ) {
+      const minimumToCreate =
+        this.selectedMandaat.parent.minAantalHouders -
+        this.lengthExistingMandaten;
+      this.rowWarnings.push(
+        `Je moet nog minimum ${minimumToCreate} mandaten aanmaken voor dit bestuursorgaan.`
+      );
+    }
+
+    if (this.selectedMandaat.parent.maxAantalHouders) {
+      this.rowsToGenerate =
+        this.selectedMandaat.parent.maxAantalHouders -
+        this.lengthExistingMandaten;
+    } else {
+      this.rowsToGenerate = 1;
+    }
+  });
+
   validateRows = restartableTask(async (event) => {
     await timeout(INPUT_DEBOUNCE);
     const inputValue = parseInt(event.target?.value);
     if (isNaN(inputValue)) {
       this.rowsToGenerate = null;
-      this.rowsError = 'Geef een positief getal in.';
+      this.rowWarnings.push('Geef een positief getal in.');
       return;
+    }
+    if (
+      inputValue + this.lengthExistingMandaten >
+      this.selectedMandaat.parent.maxAantalHouders
+    ) {
+      const toMuch =
+        inputValue -
+        this.selectedMandaat.parent.maxAantalHouders +
+        this.lengthExistingMandaten;
+      this.rowWarnings.push(
+        `Je gaat meer mandaten aanmaken dan er gewenst is ${toMuch} teveel.`
+      );
     }
 
     this.rowsToGenerate = inputValue;
-    console.log(`rowsToGenerate:`, this.rowsToGenerate);
   });
 
   onConfigReady = restartableTask(async () => {

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -113,6 +113,7 @@ export default class GenerateRowsFormComponent extends Component {
       rows: this.rowsToGenerate,
       mandaat: this.selectedMandaat.parent,
     });
+    this.args.onCancel();
   });
 
   get isInvaldForGeneration() {

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -8,9 +8,8 @@ import { task, restartableTask } from 'ember-concurrency';
 export default class GenerateRowsFormComponent extends Component {
   @service store;
 
-  @tracked formInfo;
-  @tracked showErrors;
-  @tracked isFormValid;
+  @tracked mandaatOptions;
+  @tracked selectedMandaat;
 
   constructor() {
     super(...arguments);
@@ -18,7 +17,19 @@ export default class GenerateRowsFormComponent extends Component {
     this.initForm.perform();
   }
 
-  initForm = task(async () => {});
+  initForm = task(async () => {
+    const mandaten = await this.args.bestuursorgaan.bevat;
+    this.mandaatOptions = await Promise.all(
+      mandaten.map(async (mandaat) => {
+        const bestuursfunctie = await mandaat.bestuursfunctie;
+
+        return {
+          parent: mandaat,
+          label: bestuursfunctie.label,
+        };
+      })
+    );
+  });
 
   onConfigReady = restartableTask(async () => {
     this.args.onConfigReceived({

--- a/app/components/verkiezingen/generate-rows.hbs
+++ b/app/components/verkiezingen/generate-rows.hbs
@@ -1,5 +1,19 @@
-<Verkiezingen::GenerateRowsForm
-  @bestuursorgaan={{@bestuursorgaan}}
-  @onCancel={{@onCancel}}
-  @onConfigReceived={{perform this.generateMandatarissen}}
-/>
+{{#if this.initForm.isRunning}}
+  <AuLabel for="input" class="skeleton-label au-u-margin-top" />
+  <p class="skeleton-input-full au-u-margin-top au-u-margin-bottom"></p>
+  <AuLabel for="input" class="skeleton-label au-u-margin-top" />
+  <p class="skeleton-input-full au-u-margin-top au-u-margin-bottom"></p>
+  <AuButtonGroup class="au-u-margin-top">
+    <AuButton class="skeleton-base">Genereer</AuButton>
+    <AuButton class="skeleton-base">Annuleer</AuButton>
+  </AuButtonGroup>
+{{else}}
+  <Verkiezingen::GenerateRowsForm
+    @bestuursorgaan={{@bestuursorgaan}}
+    @startDate={{this.startDate}}
+    @endDate={{this.endDate}}
+    @mandaatOptions={{this.mandaatOptions}}
+    @onCancel={{@onCancel}}
+    @onConfigReceived={{perform this.generateMandatarissen}}
+  />
+{{/if}}

--- a/app/components/verkiezingen/generate-rows.hbs
+++ b/app/components/verkiezingen/generate-rows.hbs
@@ -1,4 +1,5 @@
 <Verkiezingen::GenerateRowsForm
+  @bestuursorgaan={{@bestuursorgaan}}
   @onCancel={{@onCancel}}
   @onConfigReceived={{perform this.generateMandatarissen}}
 />

--- a/app/components/verkiezingen/generate-rows.hbs
+++ b/app/components/verkiezingen/generate-rows.hbs
@@ -1,0 +1,4 @@
+<Verkiezingen::GenerateRowsForm
+  @onCancel={{@onCancel}}
+  @onConfigReceived={{perform this.generateMandatarissen}}
+/>

--- a/app/components/verkiezingen/generate-rows.hbs
+++ b/app/components/verkiezingen/generate-rows.hbs
@@ -3,6 +3,10 @@
   <p class="skeleton-input-full au-u-margin-top au-u-margin-bottom"></p>
   <AuLabel for="input" class="skeleton-label au-u-margin-top" />
   <p class="skeleton-input-full au-u-margin-top au-u-margin-bottom"></p>
+  <AuLabel for="input" class="skeleton-label au-u-margin-top" />
+  <p class="skeleton-input-full au-u-margin-top au-u-margin-bottom"></p>
+  <AuLabel for="input" class="skeleton-label au-u-margin-top" />
+  <p class="skeleton-input-full au-u-margin-top au-u-margin-bottom"></p>
   <AuButtonGroup class="au-u-margin-top">
     <AuButton class="skeleton-base">Genereer</AuButton>
     <AuButton class="skeleton-base">Annuleer</AuButton>

--- a/app/components/verkiezingen/generate-rows.hbs
+++ b/app/components/verkiezingen/generate-rows.hbs
@@ -19,5 +19,6 @@
     @mandaatOptions={{this.mandaatOptions}}
     @onCancel={{@onCancel}}
     @onConfigReceived={{perform this.generateMandatarissen}}
+    @loadingMessage={{this.loadingMessageOfGeneration}}
   />
 {{/if}}

--- a/app/components/verkiezingen/generate-rows.js
+++ b/app/components/verkiezingen/generate-rows.js
@@ -67,5 +67,9 @@ export default class GenerateRowsFormComponent extends Component {
       const mandataris = this.store.createRecord('mandataris', mandatarisProps);
       mandataris.save();
     }
+
+    this.args.onCreated({
+      addedMandatarissen: rows,
+    });
   });
 }

--- a/app/components/verkiezingen/generate-rows.js
+++ b/app/components/verkiezingen/generate-rows.js
@@ -20,6 +20,7 @@ export default class GenerateRowsFormComponent extends Component {
   @tracked startDate;
   @tracked endDate;
   @tracked mandaatOptions;
+  @tracked loadingMessageOfGeneration;
 
   constructor() {
     super(...arguments);
@@ -46,6 +47,7 @@ export default class GenerateRowsFormComponent extends Component {
   });
 
   generateMandatarissen = task(async (config) => {
+    const addedMandatarissen = [];
     const { rows, mandaat, startDate, endDate, existingMandaten } = config;
     const mandatarisProps = {
       rangorde: null,
@@ -65,11 +67,14 @@ export default class GenerateRowsFormComponent extends Component {
       }
 
       const mandataris = this.store.createRecord('mandataris', mandatarisProps);
-      mandataris.save();
+      await mandataris.save();
+      addedMandatarissen.push(mandataris);
+      this.loadingMessageOfGeneration = `Generating ${index + 1} of ${rows}`;
     }
-
+    this.loadingMessageOfGeneration = null;
     this.args.onCreated({
-      addedMandatarissen: rows,
+      added: addedMandatarissen,
     });
+    this.args.onCancel();
   });
 }

--- a/app/components/verkiezingen/generate-rows.js
+++ b/app/components/verkiezingen/generate-rows.js
@@ -1,19 +1,52 @@
 import Component from '@glimmer/component';
 
 import { task } from 'ember-concurrency';
+import { service } from '@ember/service';
+
+import {
+  getDraftPublicationStatus,
+  getEffectiefStatus,
+} from 'frontend-lmb/utils/get-mandataris-status';
+import { rangordeNumberMapping } from 'frontend-lmb/utils/rangorde';
 
 export default class GenerateRowsFormComponent extends Component {
+  @service store;
+
+  effectiefStatus;
+  draftPublicationStatus;
+
   constructor() {
     super(...arguments);
 
-    this.initForm.perform();
+    this.backgroundInit.perform();
   }
 
-  initForm = task(async () => {});
+  backgroundInit = task(async () => {
+    this.effectiefStatus = await getEffectiefStatus(this.store);
+    this.draftPublicationStatus = await getDraftPublicationStatus(this.store);
+  });
 
   generateMandatarissen = task(async (config) => {
     const { rows, mandaat } = config;
-    console.log({ rows });
-    console.log({ mandaat });
+    const mandatarisProps = {
+      rangorde: null,
+      start: new Date(this.args.bestuursorgaan.bindingStart),
+      einde: new Date(this.args.bestuursorgaan.bindingEinde),
+      bekleedt: mandaat,
+      isBestuurlijkeAliasVan: null,
+      beleidsdomein: [],
+      status: this.effectiefStatus,
+      publicationStatus: this.publicationStatus,
+    };
+
+    for (let index = 0; index < rows; index++) {
+      if (mandaat.isSchepen) {
+        const rangordeAsNumber = index + 1;
+        mandatarisProps.rangorde = `${rangordeNumberMapping[rangordeAsNumber] ?? 'Eerste'} schepenen`;
+      }
+
+      const mandataris = this.store.createRecord('mandataris', mandatarisProps);
+      await mandataris.save();
+    }
   });
 }

--- a/app/components/verkiezingen/generate-rows.js
+++ b/app/components/verkiezingen/generate-rows.js
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+
+import { task } from 'ember-concurrency';
+
+export default class GenerateRowsFormComponent extends Component {
+  constructor() {
+    super(...arguments);
+
+    this.initForm.perform();
+  }
+
+  initForm = task(async () => {});
+
+  generateMandatarissen = task(async (config) => {
+    const { rows, startDate } = config;
+    console.log({ rows });
+    console.log({ startDate });
+  });
+}

--- a/app/components/verkiezingen/generate-rows.js
+++ b/app/components/verkiezingen/generate-rows.js
@@ -12,8 +12,8 @@ export default class GenerateRowsFormComponent extends Component {
   initForm = task(async () => {});
 
   generateMandatarissen = task(async (config) => {
-    const { rows, startDate } = config;
+    const { rows, mandaat } = config;
     console.log({ rows });
-    console.log({ startDate });
+    console.log({ mandaat });
   });
 }

--- a/app/components/verkiezingen/generate-rows.js
+++ b/app/components/verkiezingen/generate-rows.js
@@ -46,7 +46,7 @@ export default class GenerateRowsFormComponent extends Component {
   });
 
   generateMandatarissen = task(async (config) => {
-    const { rows, mandaat, startDate, endDate } = config;
+    const { rows, mandaat, startDate, endDate, existingMandaten } = config;
     const mandatarisProps = {
       rangorde: null,
       start: startDate,
@@ -60,12 +60,12 @@ export default class GenerateRowsFormComponent extends Component {
 
     for (let index = 0; index < rows; index++) {
       if (mandaat.isSchepen) {
-        const rangordeAsNumber = index + 1;
+        const rangordeAsNumber = existingMandaten + index + 1;
         mandatarisProps.rangorde = `${rangordeNumberMapping[rangordeAsNumber] ?? 'Eerste'} schepenen`;
       }
 
       const mandataris = this.store.createRecord('mandataris', mandatarisProps);
-      await mandataris.save();
+      mandataris.save();
     }
   });
 }

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -9,6 +9,16 @@
       {{@bestuursorgaan.isTijdsspecialisatieVan.naam}}</AuHeading>
     {{#unless @isBehandeld}}
       <AuContent @skin="small" class="au-u-flex-self-end">
+        {{#if (or (await @bestuursorgaan.isGR) (await @bestuursorgaan.isCBS))}}
+          {{! template-lint-disable no-inline-styles }}
+          <AuButton
+            style="background-color: #007A37; border-color: #007A37;"
+            @icon="table-row-end-add"
+            @loadingMessage="Genereren"
+          >
+            Genereer rijen
+          </AuButton>
+        {{/if}}
         {{#if (or (await this.isRMW) (await this.isLidVanVB))}}
           <AuButton
             @skin="secondary"

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -117,7 +117,7 @@
     @closeModal={{(fn (mut this.isGeneratingRows) false)}}
   >
     <div class="au-o-box">
-      <Verkiezingen::GenerateRowsForm
+      <Verkiezingen::GenerateRows
         @bestuursorgaan={{@bestuursorgaan}}
         @onCancel={{(fn (mut this.isGeneratingRows) false)}}
       />

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -58,7 +58,11 @@
 
   {{#if
     (and
-      (or this.mirrorTable.isRunning this.onCreate.isRunning)
+      (or
+        this.mirrorTable.isRunning
+        this.onCreate.isRunning
+        this.onRowsGenerated.isRunning
+      )
       this.skeletonRowsOfMirror
     )
   }}
@@ -120,6 +124,7 @@
       <Verkiezingen::GenerateRows
         @bestuursorgaan={{@bestuursorgaan}}
         @onCancel={{(fn (mut this.isGeneratingRows) false)}}
+        @onCreated={{perform this.onRowsGenerated}}
       />
     </div>
   </AuModal>

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -21,7 +21,9 @@
           </AuButton>
         {{/if}}
         {{#if
-          (or (await @bestuursorgaan.isRMW) (await @bestuursorgaan.isLidVanVB))
+          (or
+            (await @bestuursorgaan.isRMW) (await @bestuursorgaan.isVastBureau)
+          )
         }}
           <AuButton
             @skin="secondary"
@@ -33,7 +35,7 @@
             {{#if (await @bestuursorgaan.isRMW)}}
               Neem over van Gemeenteraad
             {{/if}}
-            {{#if (await @bestuursorgaan.isLidVanVB)}}
+            {{#if (await @bestuursorgaan.isVastBureau)}}
               Neem over van College van Burgemeester en Schepenen
             {{/if}}
           </AuButton>
@@ -59,9 +61,9 @@
   {{#if
     (and
       (or
+        this.initialLoad.isRunning
         this.mirrorTable.isRunning
-        this.onCreate.isRunning
-        this.onRowsGenerated.isRunning
+        this.getMandatarissen.isRunning
       )
       this.skeletonRowsOfMirror
     )
@@ -72,9 +74,8 @@
   {{else}}
     <Verkiezingen::DraftMandatarisList
       @readOnly={{@isBehandeld}}
-      @bestuursorgaan={{@bestuursorgaan}}
-      @page={{0}}
-      @size={{9999}}
+      @mandatarissen={{this.mandatarissen}}
+      @updateMandatarissen={{perform this.getMandatarissen}}
       @title=""
       @showFractie={{true}}
       @showFunctie={{true}}
@@ -124,7 +125,7 @@
       <Verkiezingen::GenerateRows
         @bestuursorgaan={{@bestuursorgaan}}
         @onCancel={{(fn (mut this.isGeneratingRows) false)}}
-        @onCreated={{perform this.onRowsGenerated}}
+        @onCreated={{perform this.getMandatarissen}}
       />
     </div>
   </AuModal>

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -1,4 +1,4 @@
-{{#if (await this.isBurgemeester)}}
+{{#if (await @bestuursorgaan.isBurgemeester)}}
   <Mandaat::BurgemeesterSelector
     @bestuursorgaanInTijd={{@bestuursorgaan}}
     @readOnly={{@isBehandeld}}
@@ -19,7 +19,9 @@
             Genereer rijen
           </AuButton>
         {{/if}}
-        {{#if (or (await this.isRMW) (await this.isLidVanVB))}}
+        {{#if
+          (or (await @bestuursorgaan.isRMW) (await @bestuursorgaan.isLidVanVB))
+        }}
           <AuButton
             @skin="secondary"
             @icon="synchronize"
@@ -27,10 +29,10 @@
             @loadingMessage="Aan het synchroniseren"
             {{on "click" (perform this.mirrorTable)}}
           >
-            {{#if (await this.isRMW)}}
+            {{#if (await @bestuursorgaan.isRMW)}}
               Neem over van Gemeenteraad
             {{/if}}
-            {{#if (await this.isLidVanVB)}}
+            {{#if (await @bestuursorgaan.isLidVanVB)}}
               Neem over van College van Burgemeester en Schepenen
             {{/if}}
           </AuButton>

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -15,6 +15,7 @@
             style="background-color: #007A37; border-color: #007A37;"
             @icon="table-row-end-add"
             @loadingMessage="Genereren"
+            {{on "click" (fn (mut this.isGeneratingRows) true)}}
           >
             Genereer rijen
           </AuButton>
@@ -103,6 +104,20 @@
         @buildSourceTtl={{this.buildSourceTtl}}
         @buildMetaTtl={{this.buildMetaTtl}}
       />
+    </div>
+  </AuModal>
+
+  <AuModalContainer />
+  <AuModal
+    @title={{(concat
+      "Genereer rijen voor " @bestuursorgaan.isTijdsspecialisatieVan.naam
+    )}}
+    @modalOpen={{this.isGeneratingRows}}
+    @closable={{true}}
+    @closeModal={{(fn (mut this.isGeneratingRows) false)}}
+  >
+    <div class="au-o-box">
+      content
     </div>
   </AuModal>
 {{/if}}

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -117,7 +117,10 @@
     @closeModal={{(fn (mut this.isGeneratingRows) false)}}
   >
     <div class="au-o-box">
-      content
+      <Verkiezingen::GenerateRowsForm
+        @bestuursorgaan={{@bestuursorgaan}}
+        @onCancel={{(fn (mut this.isGeneratingRows) false)}}
+      />
     </div>
   </AuModal>
 {{/if}}

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -2,8 +2,10 @@ import Component from '@glimmer/component';
 
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { restartableTask } from 'ember-concurrency';
 import { service } from '@ember/service';
+
+import { restartableTask, timeout, task } from 'ember-concurrency';
+
 import { getBestuursorganenMetaTtl } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';
 import { buildNewMandatarisSourceTtl } from 'frontend-lmb/utils/build-new-mandataris-source-ttl';
 import { syncNewMandatarisMembership } from 'frontend-lmb/utils/sync-new-mandataris-membership';
@@ -236,6 +238,15 @@ export default class PrepareLegislatuurSectionComponent extends Component {
     await syncNewMandatarisMembership(this.store, instanceTtl, instanceId);
     await this.fractieApi.updateCurrentFractie(instanceId);
     await this.mandatarisService.removeDanglingFractiesInPeriod(instanceId);
+  });
+
+  onRowsGenerated = task(async ({ addedMandatarissen }) => {
+    const currentMandatarissen = await this.getBestuursorgaanMandatarissen(
+      this.args.bestuursorgaan
+    );
+    this.skeletonRowsOfMirror =
+      addedMandatarissen + currentMandatarissen.length;
+    await timeout(100);
   });
 
   @action

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -64,10 +64,8 @@ export default class PrepareLegislatuurSectionComponent extends Component {
       this.mandatarissen.removeObjects(removed);
     }
     if (added && added.length >= 1) {
-      console.log(`adding`, added.length);
       if (added.length >= 2) {
         this.skeletonRowsOfMirror = this.mandatarissen.length + added.length;
-        console.log(`skeletonRowsOfMirror`, this.skeletonRowsOfMirror);
       }
       this.mandatarissen.pushObjects(added);
     }

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -35,6 +35,7 @@ export default class PrepareLegislatuurSectionComponent extends Component {
   @service('mandataris') mandatarisService;
 
   @tracked editMode = null;
+  @tracked isGeneratingRows;
   @tracked skeletonRowsOfMirror = null;
 
   @action
@@ -222,6 +223,7 @@ export default class PrepareLegislatuurSectionComponent extends Component {
   @action
   cancel() {
     this.editMode = null;
+    this.isGeneratingRows = false;
   }
 
   onCreate = restartableTask(async ({ instanceTtl, instanceId }) => {

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -8,9 +8,6 @@ import { getBestuursorganenMetaTtl } from 'frontend-lmb/utils/form-context/bestu
 import { buildNewMandatarisSourceTtl } from 'frontend-lmb/utils/build-new-mandataris-source-ttl';
 import { syncNewMandatarisMembership } from 'frontend-lmb/utils/sync-new-mandataris-membership';
 import {
-  BURGEMEESTER_BESTUURSORGAAN_URI,
-  RMW_BESTUURSORGAAN_URI,
-  VAST_BUREAU_BESTUURSORGAAN_URI,
   CBS_BESTUURSORGAAN_URI,
   GEMEENTERAAD_BESTUURSORGAAN_URI,
   MANDAAT_LID_RMW_CODE,
@@ -47,23 +44,6 @@ export default class PrepareLegislatuurSectionComponent extends Component {
 
   get isCreating() {
     return this.editMode === CREATE_MODE;
-  }
-
-  get isBurgemeester() {
-    return this.args.bestuursorgaan.hasBestuursorgaanClassificatie(
-      BURGEMEESTER_BESTUURSORGAAN_URI
-    );
-  }
-
-  get isRMW() {
-    return this.args.bestuursorgaan.hasBestuursorgaanClassificatie(
-      RMW_BESTUURSORGAAN_URI
-    );
-  }
-  get isLidVanVB() {
-    return this.args.bestuursorgaan.hasBestuursorgaanClassificatie(
-      VAST_BUREAU_BESTUURSORGAAN_URI
-    );
   }
 
   get CBSClassification() {

--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -5,6 +5,8 @@ import { service } from '@ember/service';
 import { queryRecord } from 'frontend-lmb/utils/query-record';
 import {
   BCSD_BESTUURSORGAAN_URI,
+  CBS_BESTUURSORGAAN_URI,
+  GEMEENTERAAD_BESTUURSORGAAN_URI,
   RMW_BESTUURSORGAAN_URI,
   VAST_BUREAU_BESTUURSORGAAN_URI,
 } from 'frontend-lmb/utils/well-known-uris';
@@ -127,9 +129,18 @@ export default class BestuursorgaanModel extends Model {
     return this.hasBestuursorgaanClassificatie(BCSD_BESTUURSORGAAN_URI);
   }
 
+  get isGR() {
+    return this.hasBestuursorgaanClassificatie(GEMEENTERAAD_BESTUURSORGAAN_URI);
+  }
+
+  get isCBS() {
+    return this.hasBestuursorgaanClassificatie(CBS_BESTUURSORGAAN_URI);
+  }
+
   get isRMW() {
     return this.hasBestuursorgaanClassificatie(RMW_BESTUURSORGAAN_URI);
   }
+
   get isVastBureau() {
     return this.hasBestuursorgaanClassificatie(VAST_BUREAU_BESTUURSORGAAN_URI);
   }

--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -5,6 +5,7 @@ import { service } from '@ember/service';
 import { queryRecord } from 'frontend-lmb/utils/query-record';
 import {
   BCSD_BESTUURSORGAAN_URI,
+  BURGEMEESTER_BESTUURSORGAAN_URI,
   CBS_BESTUURSORGAAN_URI,
   GEMEENTERAAD_BESTUURSORGAAN_URI,
   RMW_BESTUURSORGAAN_URI,
@@ -143,6 +144,10 @@ export default class BestuursorgaanModel extends Model {
 
   get isVastBureau() {
     return this.hasBestuursorgaanClassificatie(VAST_BUREAU_BESTUURSORGAAN_URI);
+  }
+
+  get isBurgemeester() {
+    return this.hasBestuursorgaanClassificatie(BURGEMEESTER_BESTUURSORGAAN_URI);
   }
 
   async getNbMembers() {

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -12,6 +12,7 @@ export const ACCEPT_HEADER = {
   },
 };
 
+export const INPUT_DEBOUNCE = 250;
 export const SEARCH_TIMEOUT = 500;
 // the resource cache is invalidated because of our form update, but the service doesn't wait for it before returning.
 // this is a temporary hack while we wait for backend driven frontend revalidation

--- a/app/utils/well-known-ids.js
+++ b/app/utils/well-known-ids.js
@@ -8,6 +8,7 @@ export const MANDATARIS_EXTRA_INFO_FORM_ID = 'mandataris-extra-info';
 export const MANDATARIS_NEW_FORM_ID = 'mandataris-new';
 export const MANDATARIS_EXTENDED_FORM = 'mandataris-ext';
 export const CONTACTINFO_FORM_ID = 'contactinfo';
+export const VERKIEZINGEN_GENERATE_ROWS_FORM_ID = 'verkiezingen-generate-rows';
 export const DECRETALE_BESTUURSORGANEN_CONCEPT_SCHEME =
   '2e127dcf-d6c8-4134-ac39-8be1d7fbdfaf';
 export const GEMEENTE_BESTUURSORGANEN_CONCEPT_SCHEME =

--- a/app/utils/well-known-ids.js
+++ b/app/utils/well-known-ids.js
@@ -8,7 +8,6 @@ export const MANDATARIS_EXTRA_INFO_FORM_ID = 'mandataris-extra-info';
 export const MANDATARIS_NEW_FORM_ID = 'mandataris-new';
 export const MANDATARIS_EXTENDED_FORM = 'mandataris-ext';
 export const CONTACTINFO_FORM_ID = 'contactinfo';
-export const VERKIEZINGEN_GENERATE_ROWS_FORM_ID = 'verkiezingen-generate-rows';
 export const DECRETALE_BESTUURSORGANEN_CONCEPT_SCHEME =
   '2e127dcf-d6c8-4134-ac39-8be1d7fbdfaf';
 export const GEMEENTE_BESTUURSORGANEN_CONCEPT_SCHEME =

--- a/tests/integration/components/verkiezingen/generate-rows-form-test.js
+++ b/tests/integration/components/verkiezingen/generate-rows-form-test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | verkiezingen/generate-rows-form',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.set('myAction', function(val) { ... });
+
+      await render(hbs`<Verkiezingen::GenerateRowsForm />`);
+
+      assert.dom(this.element).hasText('');
+
+      // Template block usage:
+      await render(hbs`<Verkiezingen::GenerateRowsForm>
+  template block text
+</Verkiezingen::GenerateRowsForm>`);
+
+      assert.dom(this.element).hasText('template block text');
+    });
+  }
+);

--- a/tests/integration/components/verkiezingen/generate-rows-test.js
+++ b/tests/integration/components/verkiezingen/generate-rows-test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | verkiezingen/generate-rows',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.set('myAction', function(val) { ... });
+
+      await render(hbs`<Verkiezingen::GenerateRows />`);
+
+      assert.dom(this.element).hasText('');
+
+      // Template block usage:
+      await render(hbs`<Verkiezingen::GenerateRows>
+  template block text
+</Verkiezingen::GenerateRows>`);
+
+      assert.dom(this.element).hasText('template block text');
+    });
+  }
+);


### PR DESCRIPTION
## Description

During the legislatuur preparation lokale besturen have to set an amount of mandaten per bestuursorgaan. As this can be 55 gemeenteraadsleden we want the option to generate the with default information for X amount. Add a button next to Toevoegen for generating mandaten.

## How to test

1. Go to the legislatuur page and press the generate button
2. See what happens when you want to create to much or to little mandaten
3. Generate the mandaten by pressing the button
4. The mandataris draft table should be updated with the requested rows of mandaten


## Attachments

![image](https://github.com/user-attachments/assets/f016ad2b-b713-4f1e-a7e3-bc0027d06432)

![image](https://github.com/user-attachments/assets/df2f990d-a37d-4806-9c71-290bec79df14)

