### PR TITLE
LMB-618 | Filters in dropdown dissapear when filtering on onafhankelijk

### DIFF
--- a/app/controllers/mandatarissen/search.js
+++ b/app/controllers/mandatarissen/search.js
@@ -89,11 +89,11 @@ export default class MandatarissenSearchController extends Controller {
   }
 
   get selectedFracties() {
-    const fractieIds = [...new Set(this.model.selectedFracties?.split(','))];
-    if (fractieIds.length == this.model.fracties.length) {
+    if (!this.model.selectedFracties) {
       return [];
     }
 
+    const fractieIds = [...new Set(this.model.selectedFracties.split(','))];
     const fracties = fractieIds.map((id) =>
       this.model.fracties.find((fractie) => fractie.id == id)
     );

--- a/app/routes/mandatarissen/search.js
+++ b/app/routes/mandatarissen/search.js
@@ -60,10 +60,6 @@ export default class MandatarissenSearchRoute extends Route {
     const samenWerkendFracties = await this.fractieApi.forBestuursperiode(
       selectedPeriod.id
     );
-    let selectedFracties = params.binnenFractie;
-    if (params.onafhankelijkeFractie === 'true') {
-      selectedFracties += `, ${placeholderOnafhankelijk}`;
-    }
 
     return {
       personen,
@@ -72,7 +68,7 @@ export default class MandatarissenSearchRoute extends Route {
       bestuursfuncties: [...new Set(allBestuurfunctieCodes)],
       selectedBestuurfunctieIds: params.bestuursfunctie,
       fracties: [...samenWerkendFracties, placeholderOnafhankelijk],
-      selectedFracties,
+      selectedFracties: params.binnenFractie,
     };
   }
 


### PR DESCRIPTION
## Description

When filtering on onafhankelijke fractie the options dissapear in the dorpdown component itself. There was no issue with showing the filtered data in the table.

## How to test

Go to the mandataris search page and select and unselect the options for filtering on fracties.