### PR TITLE
LMB-212: call the endpoint of mandataris service for copying no domain

### DIFF
--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -32,6 +32,7 @@ export default class MandatarissenUpdateState extends Component {
   @service toaster;
   @service('mandataris') mandatarisService;
   @service fractieApi;
+  @service mandatarisApi;
 
   constructor() {
     super(...arguments);
@@ -139,7 +140,6 @@ export default class MandatarissenUpdateState extends Component {
 
   async changeMandatarisState() {
     await this.mandatarisService.updateOldLidmaatschap(this.args.mandataris);
-
     const endDate = this.args.mandataris.einde;
 
     const newMandatarisProps = await this.mandatarisService.createNewProps(
@@ -185,6 +185,11 @@ export default class MandatarissenUpdateState extends Component {
     );
     await this.fractieApi.updateCurrentFractie(newMandataris.id);
     await this.mandatarisService.removeDanglingFractiesInPeriod(
+      newMandataris.id
+    );
+
+    await this.mandatarisApi.copyOverNonDomainResourceProperties(
+      this.args.mandataris.id,
       newMandataris.id
     );
 

--- a/app/services/mandataris-api.js
+++ b/app/services/mandataris-api.js
@@ -1,0 +1,30 @@
+import Service from '@ember/service';
+
+import { timeout } from 'ember-concurrency';
+import {
+  API,
+  RESOURCE_CACHE_TIMEOUT,
+  STATUS_CODE,
+} from 'frontend-lmb/utils/constants';
+
+export default class MandatarisApiService extends Service {
+  async copyOverNonDomainResourceProperties(oldMandatarisId, newMandatarisId) {
+    const response = await fetch(
+      `${API.MANDATARIS_SERVICE}/mandatarissen/${oldMandatarisId}/copy/${newMandatarisId}`,
+      {
+        method: 'PUT',
+      }
+    );
+    const jsonReponse = await response.json();
+
+    if (response.status !== STATUS_CODE.OK) {
+      console.error(jsonReponse.message);
+      throw {
+        status: response.status,
+        message: jsonReponse.message,
+      };
+    }
+
+    await timeout(RESOURCE_CACHE_TIMEOUT);
+  }
+}

--- a/tests/unit/services/mandataris-api-test.js
+++ b/tests/unit/services/mandataris-api-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-lmb/tests/helpers';
+
+module('Unit | Service | mandataris-api', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:mandataris-api');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
## Description

Call the mandataris service for copying over the non domain predicates of a mandataris.

## How to test

1. Add a predicate to the mandataris that is not in our domain
2. Change the mandataris state. 

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/38
