### PR TITLE
LMB-552 | Only allow non elected person to bcsd or burgemeester

### DIFF
--- a/app/components/person/search-form.js
+++ b/app/components/person/search-form.js
@@ -78,7 +78,6 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
       this.personen = [];
       return;
     }
-    console.log(`search | searchElected`, this.args.searchElected);
 
     let queryParams = {
       sort: 'achternaam',
@@ -104,11 +103,22 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
   });
 
   getPersoon = task(async (queryParams) => {
+    let personen = null;
     try {
-      return await this.store.query('persoon', queryParams);
+      personen = await this.store.query('persoon', queryParams);
     } catch (e) {
       this.error = true;
     }
+    if (this.args.searchElected) {
+      const elected = await this.store.query('persoon', {
+        include: ['verkiezingsresultaten'],
+        'filter[verkiezingsresultaten][persoon][:id:]': personen
+          .map((p) => p.id)
+          .join(','),
+      });
+      return elected;
+    }
+    return personen;
   });
 
   resetAfterError() {

--- a/app/components/person/search-form.js
+++ b/app/components/person/search-form.js
@@ -109,9 +109,17 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
     } catch (e) {
       this.error = true;
     }
-    if (this.args.searchElected) {
+    if (this.args.searchElected && this.args.bestuursperiode) {
       const elected = await this.store.query('persoon', {
-        include: ['verkiezingsresultaten'],
+        include: [
+          'verkiezingsresultaten',
+          'verkiezingsresultaten.kandidatenlijst',
+          'verkiezingsresultaten.kandidatenlijst.verkiezing',
+          'verkiezingsresultaten.kandidatenlijst.verkiezing.bestuursorgaan-in-tijd',
+          'verkiezingsresultaten.kandidatenlijst.verkiezing.bestuursorgaan-in-tijd.heeft-bestuursperiode',
+        ].join(','),
+        'filter[verkiezingsresultaten][kandidatenlijst][verkiezing][bestuursorgaan-in-tijd][heeft-bestuursperiode][:id:]':
+          this.args.bestuursperiode.id,
         'filter[verkiezingsresultaten][persoon][:id:]': personen
           .map((p) => p.id)
           .join(','),

--- a/app/components/person/search-form.js
+++ b/app/components/person/search-form.js
@@ -78,6 +78,7 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
       this.personen = [];
       return;
     }
+    console.log(`search | searchElected`, this.args.searchElected);
 
     let queryParams = {
       sort: 'achternaam',
@@ -149,5 +150,9 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
         rijksregisternummer: this.rijksregisternummer,
       });
     }
+  }
+
+  get searchElectedPerson() {
+    return this.args.searchElected;
   }
 }

--- a/app/components/person/selector.hbs
+++ b/app/components/person/selector.hbs
@@ -69,6 +69,7 @@
           @onCreateNewPerson={{this.onCreateNewPerson}}
           @onCancel={{this.cancelEdit}}
           @searchElected={{@searchElected}}
+          @bestuursperiode={{@bestuursperiode}}
         />
       {{/if}}
     </div>

--- a/app/components/person/selector.hbs
+++ b/app/components/person/selector.hbs
@@ -68,6 +68,7 @@
           @onSelect={{this.onSelectPerson}}
           @onCreateNewPerson={{this.onCreateNewPerson}}
           @onCancel={{this.cancelEdit}}
+          @searchElected={{@searchElected}}
         />
       {{/if}}
     </div>

--- a/app/components/rdf-input-fields/person-selector.hbs
+++ b/app/components/rdf-input-fields/person-selector.hbs
@@ -11,6 +11,7 @@
         @person={{this.person}}
         @onUpdate={{this.onUpdate}}
         @searchElected={{this.searchElected}}
+        @bestuursperiode={{this.currentBestuursperiode}}
       />
     </div>
     {{#each this.errors as |error|}}

--- a/app/components/rdf-input-fields/person-selector.hbs
+++ b/app/components/rdf-input-fields/person-selector.hbs
@@ -5,16 +5,20 @@
   @required={{this.isRequired}}
 >{{this.title}}</AuLabel>
 {{#if this.initialized}}
-  <div class={{if this.hasErrors "ember-power-select--error"}}>
-    <Person::Selector @person={{this.person}} @onUpdate={{this.onUpdate}} />
-  </div>
-  {{#each this.errors as |error|}}
-    <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
-  {{/each}}
+  {{#if this.isMandaatInForm}}
+    <div class={{if this.hasErrors "ember-power-select--error"}}>
+      <Person::Selector @person={{this.person}} @onUpdate={{this.onUpdate}} />
+    </div>
+    {{#each this.errors as |error|}}
+      <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
+    {{/each}}
 
-  {{#each this.warnings as |warning|}}
-    <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
-  {{/each}}
+    {{#each this.warnings as |warning|}}
+      <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
+    {{/each}}
+  {{else}}
+    <p>Selecteer eerst een mandaat</p>
+  {{/if}}
 {{else}}
   <p class="skeleton-input-full au-u-margin-top"></p>
 {{/if}}

--- a/app/components/rdf-input-fields/person-selector.hbs
+++ b/app/components/rdf-input-fields/person-selector.hbs
@@ -7,7 +7,11 @@
 {{#if this.initialized}}
   {{#if this.isMandaatInForm}}
     <div class={{if this.hasErrors "ember-power-select--error"}}>
-      <Person::Selector @person={{this.person}} @onUpdate={{this.onUpdate}} />
+      <Person::Selector
+        @person={{this.person}}
+        @onUpdate={{this.onUpdate}}
+        @searchElected={{this.searchElected}}
+      />
     </div>
     {{#each this.errors as |error|}}
       <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>

--- a/app/components/rdf-input-fields/person-selector.js
+++ b/app/components/rdf-input-fields/person-selector.js
@@ -83,6 +83,12 @@ export default class PersonSelectorComponent extends InputFieldComponent {
     const mandaatModel = await queryRecord(this.store, 'mandaat', {
       'filter[:uri:]': mandaatNode.value,
     });
+
+    if (mandaatModel.isBurgemeester) {
+      this.searchElected = false;
+      return;
+    }
+
     this.searchElected = !(await mandaatModel.isInBCSD());
   });
 }

--- a/app/components/rdf-input-fields/person-selector.js
+++ b/app/components/rdf-input-fields/person-selector.js
@@ -11,6 +11,7 @@ import { restartableTask } from 'ember-concurrency';
 
 import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
 import { ORG } from 'frontend-lmb/rdf/namespaces';
+import { queryRecord } from 'frontend-lmb/utils/query-record';
 
 export default class PersonSelectorComponent extends InputFieldComponent {
   inputId = 'input-' + guidFor(this);
@@ -19,6 +20,7 @@ export default class PersonSelectorComponent extends InputFieldComponent {
 
   @tracked initialized = false;
   @tracked isMandaatInForm = false;
+  @tracked searchElected = true;
 
   constructor() {
     super(...arguments);
@@ -78,5 +80,9 @@ export default class PersonSelectorComponent extends InputFieldComponent {
       return;
     }
     this.isMandaatInForm = true;
+    const mandaatModel = await queryRecord(this.store, 'mandaat', {
+      'filter[:uri:]': mandaatNode.value,
+    });
+    this.searchElected = !(await mandaatModel.isInBCSD());
   });
 }

--- a/app/components/rdf-input-fields/person-selector.js
+++ b/app/components/rdf-input-fields/person-selector.js
@@ -21,6 +21,7 @@ export default class PersonSelectorComponent extends InputFieldComponent {
   @tracked initialized = false;
   @tracked isMandaatInForm = false;
   @tracked searchElected = true;
+  @tracked currentBestuursperiode = null;
 
   constructor() {
     super(...arguments);
@@ -90,5 +91,11 @@ export default class PersonSelectorComponent extends InputFieldComponent {
     }
 
     this.searchElected = !(await mandaatModel.isInBCSD());
+
+    if (this.searchElected) {
+      this.currentBestuursperiode = await (
+        await mandaatModel.bevatIn
+      )[0].heeftBestuursperiode;
+    }
   });
 }

--- a/app/models/mandaat.js
+++ b/app/models/mandaat.js
@@ -64,4 +64,12 @@ export default class MandaatModel extends Model {
       MANDAAT_TOEGEVOEGDE_SCHEPEN_CODE,
     ].includes(this.bestuursfunctie.get('uri'));
   }
+
+  async isInBCSD() {
+    const bestuursorganen = await this.bevatIn;
+    const booleans = await Promise.all(
+      bestuursorganen.map(async (bo) => await bo.isBCSD)
+    );
+    return booleans.includes(true);
+  }
 }

--- a/app/models/persoon.js
+++ b/app/models/persoon.js
@@ -45,6 +45,12 @@ export default class PersoonModel extends Model {
   })
   isAangesteldAls;
 
+  @hasMany('verkiezingsresultaat', {
+    async: true,
+    inverse: 'persoon',
+  })
+  verkiezingsresultaten;
+
   get naam() {
     return `${this.gebruikteVoornaam} ${this.achternaam}`;
   }

--- a/app/models/verkiezingsresultaat.js
+++ b/app/models/verkiezingsresultaat.js
@@ -4,7 +4,7 @@ export default class VerkiezingsresultaatModel extends Model {
   @attr('number') aantalNaamstemmen;
   @attr('number') plaatsRangorde;
 
-  @belongsTo('persoon', { async: true, inverse: null })
+  @belongsTo('persoon', { async: true, inverse: 'verkiezingsresultaten' })
   persoon;
 
   @belongsTo('kandidatenlijst', { async: true, inverse: 'resultaten' })


### PR DESCRIPTION
## Description

We only want the user to select people that are elected when the bestuursorgaan is not BCSD or the mandaat is a burgemeester. 

## How to test

1. Go to the curren bestuursperiod 2019 - 2025, create a mandataris with a non burgemeester and with a burgemeester
2. Create a new person in the legislatuur page, when slected remove it and search for that person, it should not show in in the results

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/180
