### PR TITLE
make publication status editable again

### DIFF
--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -23,11 +23,32 @@
     <div class="au-o-grid__item au-u-1-2">
       <div class="au-c-description-label">Publicatie status</div>
       <div class="au-c-description-value au-u-margin-top-tiny">
-        <Mandaat::PublicatieStatusPill
-          @mandataris={{@mandataris}}
-          @showInfoText={{true}}
-          @showBekijkBewijs={{true}}
-        />
+        {{#if this.editingStatus}}
+          <Mandatarissen::Mandataris::PublicationStatusSelector
+            @mandataris={{@mandataris}}
+            @onUpdate={{this.stopEditingStatus}}
+          />
+        {{else}}
+          <div class="au-u-flex">
+            <Mandaat::PublicatieStatusPill
+              @mandataris={{@mandataris}}
+              @showInfoText={{true}}
+              @showBekijkBewijs={{true}}
+            />
+            {{#unless this.isBekrachtigd}}
+              <AuButton
+                {{on "click" this.editStatus}}
+                @icon="pencil"
+                @skin="link-secondary"
+                @size="small"
+                class="au-u-maring-left-tiny"
+                @hideText={{true}}
+              >
+                edit
+              </AuButton>
+            {{/unless}}
+          </div>
+        {{/if}}
       </div>
     </div>
     {{#if @mandataris.bekleedt.isSchepen}}

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -1,9 +1,21 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE } from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarisCardComponent extends Component {
+  @tracked
+  editingStatus = false;
+
   get status() {
     return this.args.mandataris.status.get('label');
   }
+
+  get isBekrachtigd() {
+    const statusId = this.args.mandataris.publicationStatus?.get('uri');
+    return !statusId || statusId === MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE;
+  }
+
   get fractie() {
     return this.args.mandataris.heeftLidmaatschap.get('binnenFractie')
       ? this.args.mandataris.heeftLidmaatschap.get('binnenFractie').get('naam')
@@ -28,5 +40,15 @@ export default class MandatarisCardComponent extends Component {
     }
 
     return 'default';
+  }
+
+  @action
+  editStatus() {
+    this.editingStatus = true;
+  }
+
+  @action
+  stopEditingStatus() {
+    this.editingStatus = false;
   }
 }

--- a/app/components/mandatarissen/mandataris/publication-status-selector.hbs
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.hbs
@@ -16,4 +16,11 @@
       Geen statussen
     {{/if}}
   </PowerSelect>
+  <span class="au-u-margin-top-small u-u-margin-right-tiny">Om een bekrachtiging
+    terug te trekken moet je de
+    <AuLinkExternal
+      href="mailto:lokaalmandatenbeheer@vlaanderen.be?subject=Bekrachtiging terugtrekken - Lokaal Mandatenbeheer"
+    >technische dienst contacteren</AuLinkExternal>
+  </span>
+
 </div>

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -52,5 +52,8 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
     }
     this.mandataris.publicationStatus = publicationStatus;
     await this.mandataris.save();
+    if (this.args.onUpdate) {
+      this.args.onUpdate();
+    }
   }
 }


### PR DESCRIPTION
## Description

Makes publication status editable again (the select got removed somehow)
![image](https://github.com/user-attachments/assets/d2b09448-8925-40f2-81f4-612a2ee9f714)

![image](https://github.com/user-attachments/assets/e73d8868-c7ee-498c-bf34-51098a36a30f)

![image](https://github.com/user-attachments/assets/52c8c4f5-0f6b-4151-9669-cfa3b4c97e1e)

