### PR TITLE
publication status is now in the lmb namespace

### DIFF
--- a/app/utils/build-new-mandataris-source-ttl.js
+++ b/app/utils/build-new-mandataris-source-ttl.js
@@ -5,7 +5,7 @@ export const buildNewMandatarisSourceTtl = async (
   instanceUri,
   personId
 ) => {
-  const draftTriple = `<${instanceUri}> <http://mu.semte.ch/vocabularies/ext/lmb/hasPublicationStatus> <${MANDATARIS_DRAFT_PUBLICATION_STATE}>.`;
+  const draftTriple = `<${instanceUri}> <http://lblod.data.gift/vocabularies/lmb/hasPublicationStatus> <${MANDATARIS_DRAFT_PUBLICATION_STATE}>.`;
   if (!personId) {
     return draftTriple;
   }


### PR DESCRIPTION
## Description

publication status is now in the lmb namespace

## How to test

create a new mandataris, it should still have a draft publication status

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/190
