### PR TITLE
LMB-601 | update link at bekijk handleiding

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -82,7 +82,7 @@
                 Meer info
               </AuLinkExternal>
               <AuLinkExternal
-                href="https://abb-vlaanderen.gitbook.io/handleiding-loket/"
+                href="https://abb-vlaanderen.gitbook.io/handleiding-lokaal-mandatenbeheer/"
                 @skin="secondary"
               >
                 <AuIcon @icon="documents" @alignment="left" />


### PR DESCRIPTION
## Description

The link behind "Bekijk handleiding" was refering to Loket manual. Update the link to point to https://abb-vlaanderen.gitbook.io/handleiding-lokaal-mandatenbeheer/

## How to test

Go to the app module overview and at the bottom right you find the link.
