### PR TITLE
fix selecting persons: filter in backend, not afterwards in frontend

### DIFF
--- a/app/components/mandatenbeheer/mandaat-bestuursorganen-selector.js
+++ b/app/components/mandatenbeheer/mandaat-bestuursorganen-selector.js
@@ -36,11 +36,10 @@ export default class MandaatBestuursorganenSelector extends Component {
     ) {
       const bestuursperiode =
         await this.args.bestuursorganen.at(0).heeftBestuursperiode;
-      const electedPeople =
-        await this.verkiezingService.getPeopleThatAreElected(
-          [this.args.person],
-          bestuursperiode
-        );
+      const electedPeople = await this.verkiezingService.checkIfPersonIsElected(
+        this.args.person.id,
+        bestuursperiode
+      );
       if (electedPeople.length === 0) {
         const burgemeesterMandaten = await Promise.all(
           this.mandaatOptions.map(async (m) => {

--- a/app/components/mandatenbeheer/mandaat-bestuursorganen-selector.js
+++ b/app/components/mandatenbeheer/mandaat-bestuursorganen-selector.js
@@ -36,11 +36,11 @@ export default class MandaatBestuursorganenSelector extends Component {
     ) {
       const bestuursperiode =
         await this.args.bestuursorganen.at(0).heeftBestuursperiode;
-      const electedPeople = await this.verkiezingService.checkIfPersonIsElected(
+      const isElected = await this.verkiezingService.checkIfPersonIsElected(
         this.args.person.id,
         bestuursperiode
       );
-      if (electedPeople.length === 0) {
+      if (!isElected) {
         const burgemeesterMandaten = await Promise.all(
           this.mandaatOptions.map(async (m) => {
             const isBurgemeester = await m.isBurgemeester;

--- a/app/components/person/search-form.js
+++ b/app/components/person/search-form.js
@@ -80,6 +80,21 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
       return;
     }
 
+    const extraFilter = {};
+    if (this.args.searchElected && this.args.bestuursperiode) {
+      extraFilter.verkiezingsresultaten = {
+        kandidatenlijst: {
+          verkiezing: {
+            'bestuursorgaan-in-tijd': {
+              'heeft-bestuursperiode': {
+                ':id:': this.args.bestuursperiode.id,
+              },
+            },
+          },
+        },
+      };
+    }
+
     let queryParams = {
       sort: 'achternaam',
       include: ['geboorte', 'identificator'].join(','),
@@ -90,6 +105,7 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
           (this.rijksregisternummer &&
             this.rijksregisternummer.replace(/\D+/g, '')) ||
           undefined,
+        ...extraFilter,
       },
       page: {
         size: this.pageSize,
@@ -109,12 +125,6 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
       personen = await this.store.query('persoon', queryParams);
     } catch (e) {
       this.error = true;
-    }
-    if (this.args.searchElected && this.args.bestuursperiode) {
-      return this.verkiezingService.getPeopleThatAreElected(
-        personen,
-        this.args.bestuursperiode
-      );
     }
     return personen;
   });

--- a/app/components/rdf-input-fields/person-selector.js
+++ b/app/components/rdf-input-fields/person-selector.js
@@ -72,8 +72,8 @@ export default class PersonSelectorComponent extends InputFieldComponent {
     super.updateValidations();
     this.person = person;
     if (this.person && this.searchElected) {
-      const isElected = await this.verkiezingService.getPeopleThatAreElected(
-        [this.person],
+      const isElected = await this.verkiezingService.checkIfPersonIsElected(
+        this.person.id,
         this.currentBestuursperiode
       );
 

--- a/app/components/rdf-input-fields/person-selector.js
+++ b/app/components/rdf-input-fields/person-selector.js
@@ -77,7 +77,7 @@ export default class PersonSelectorComponent extends InputFieldComponent {
         this.currentBestuursperiode
       );
 
-      if (isElected.length === 0) {
+      if (!isElected) {
         this.person = null;
         replaceSingleFormValue(this.storeOptions, null);
         showWarningToast(

--- a/app/services/verkiezing.js
+++ b/app/services/verkiezing.js
@@ -5,7 +5,7 @@ import { service } from '@ember/service';
 export default class VerkiezingService extends Service {
   @service store;
 
-  async getPeopleThatAreElected(personModels, bestuursperiode) {
+  async checkIfPersonIsElected(personId, bestuursperiode) {
     return await this.store.query('persoon', {
       include: [
         'verkiezingsresultaten',
@@ -16,9 +16,7 @@ export default class VerkiezingService extends Service {
       ].join(','),
       'filter[verkiezingsresultaten][kandidatenlijst][verkiezing][bestuursorgaan-in-tijd][heeft-bestuursperiode][:id:]':
         bestuursperiode.id,
-      'filter[verkiezingsresultaten][persoon][:id:]': personModels
-        .map((p) => p.id)
-        .join(','),
+      'filter[verkiezingsresultaten][persoon][:id:]': personId,
     });
   }
 }

--- a/app/services/verkiezing.js
+++ b/app/services/verkiezing.js
@@ -6,7 +6,7 @@ export default class VerkiezingService extends Service {
   @service store;
 
   async checkIfPersonIsElected(personId, bestuursperiode) {
-    return await this.store.query('persoon', {
+    const matches = await this.store.query('persoon', {
       include: [
         'verkiezingsresultaten',
         'verkiezingsresultaten.kandidatenlijst',
@@ -18,5 +18,6 @@ export default class VerkiezingService extends Service {
         bestuursperiode.id,
       'filter[verkiezingsresultaten][persoon][:id:]': personId,
     });
+    return matches.length > 0;
   }
 }


### PR DESCRIPTION
## Description

fix selecting persons: filter in backend, not afterwards in frontend. Doing this breaks pagination and may give the impression that there are no matches when there are only non-elected persons on the first page.

## How to test

Add a gemeenteraadslid to a current bestuursorgaan of type gemeenteraad. Search for the character "a". It should give you a full page of results.

## Links to other PR's
Needs this backend PR and a rebuild from a toLoad folder in the backend to work
- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/193