### PR TITLE
LMB-474 | Remove comment that it uses the getter (using await now)

### DIFF
--- a/app/components/mandaat/folded-fracties.js
+++ b/app/components/mandaat/folded-fracties.js
@@ -66,7 +66,6 @@ export default class MandaatFoldedFractiesComponent extends Component {
     return await this.store.query('mandataris', options);
   }
 
-  // Using EmberData get returns undefined even if the relation is loaded
   async fractieOrNull(mandataris) {
     const lidmaatschap = await mandataris.heeftLidmaatschap;
     if (!lidmaatschap) {


### PR DESCRIPTION
## Description

Just removed the comment as it is not using the getter anymore