### PR TITLE
keep track on when to update bcsd alert

### DIFF
--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -20,6 +20,7 @@ import { getFormFrom } from 'frontend-lmb/utils/get-form';
 
 export default class MandaatBurgemeesterSelectorComponent extends Component {
   @service store;
+  @service bcsd;
 
   @tracked persoon = null;
   @tracked mandataris = null;
@@ -167,6 +168,7 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
       })
     );
     this.setup.perform();
+    this.bcsd.forceRecomputeBCSD();
   });
 
   @action

--- a/app/components/verkiezingen/bcsd-voorzitter-alert.js
+++ b/app/components/verkiezingen/bcsd-voorzitter-alert.js
@@ -12,8 +12,15 @@ import {
 
 export default class VerkiezingenBcsdVoorzitterAlertComponent extends Component {
   @service store;
+  @service bcsd;
 
   @tracked errorMessage = '';
+  @tracked lastRecomputeTime = null;
+
+  constructor() {
+    super(...arguments);
+    this.bcsd.forceRecomputeBCSD();
+  }
 
   get bcsdBestuursorgaanInTijd() {
     return this.args.bcsdBestuursorgaanInTijd;
@@ -28,6 +35,17 @@ export default class VerkiezingenBcsdVoorzitterAlertComponent extends Component 
     if (this.isDestroyed) {
       return;
     }
+    if (
+      this.lastRecomputeTime &&
+      this.lastRecomputeTime === this.bcsd.recomputeBCSDNeededTime
+    ) {
+      await timeout(10000);
+      // nothing for now let's try again later
+      this.handleErrorMessage.perform();
+      return;
+    }
+
+    this.lastRecomputeTime = this.bcsd.recomputeBCSDNeededTime;
 
     const voorzitter = await this.getVoorzitterBCSD();
     const isMemberOfRMW = await this.isMemberOfRMW(voorzitter);

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -10,6 +10,7 @@ export default class DraftMandatarisListComponent extends Component {
   @service toaster;
   @service store;
   @service fractieApi;
+  @service bcsd;
 
   @tracked isEditing;
   @tracked isEditFormInitialized;
@@ -35,6 +36,7 @@ export default class DraftMandatarisListComponent extends Component {
       .then(() => {
         const succesMessage = 'Mandataris succesvol verwijderd.';
         this.toaster.success(succesMessage, 'Succes', { timeOut: 5000 });
+        this.bcsd.forceRecomputeBCSD();
       })
       .catch(() => {
         const errorMessage =
@@ -65,5 +67,6 @@ export default class DraftMandatarisListComponent extends Component {
     );
     this.args.updateMandatarissen({ updated: updatedMandataris });
     this.closeEditMandataris();
+    this.bcsd.forceRecomputeBCSD();
   }
 }

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -32,6 +32,7 @@ const CREATE_MODE = 'create';
 
 export default class PrepareLegislatuurSectionComponent extends Component {
   @service toaster;
+  @service bcsd;
   @service store;
   @service router;
   @service fractieApi;
@@ -210,6 +211,8 @@ export default class PrepareLegislatuurSectionComponent extends Component {
       added: newMandatarissen,
       removed: this.mandatarissen,
     });
+
+    this.bcsd.forceRecomputeBCSD();
   });
 
   async createMandatarisFromMandataris(mandataris, mandaat, lidmaatschap) {
@@ -271,6 +274,7 @@ export default class PrepareLegislatuurSectionComponent extends Component {
     await syncNewMandatarisMembership(this.store, instanceTtl, instanceId);
     await this.fractieApi.updateCurrentFractie(instanceId);
     await this.mandatarisService.removeDanglingFractiesInPeriod(instanceId);
+    this.bcsd.forceRecomputeBCSD();
   });
 
   @action

--- a/app/services/bcsd.js
+++ b/app/services/bcsd.js
@@ -1,0 +1,15 @@
+import Service from '@ember/service';
+
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+
+export default class bcsdService extends Service {
+  @service store;
+
+  @tracked
+  recomputeBCSDNeededTime = null;
+
+  forceRecomputeBCSD() {
+    this.recomputeBCSDNeededTime = new Date();
+  }
+}


### PR DESCRIPTION
## Description

This feels a bit like premature optimization BUT i added a service that tracks whether we should refresh our calls to the backend to determine whether the voorzitter of the BCSD should be updated. 
The task with a timeout is in fact a pretty understanable and straight forward way of handling this that avoids passing all kinds of data around. 
The optimization I did was keeping a Date in a service so that you know if your data should still be up to date.
## How to test

Add a voorzitter to the BCSD, see the alert pop up.
Add a person to the gemeenteraad, no change to the alert.
Add the voorzitter to the ocwm, see the alert be removed.
remove the voorzitter from the ocwm, see the alert pop up again
Add the voorzitter as a member of the college of burgemeesters and schepenen, alert is still there.
Copy the college to the vast bureau, the alert should be removed.

Always git it 10 seconds for the alert to update its state.