### PR TITLE
fix form not scrollable

### DIFF
--- a/app/templates/organen/orgaan.hbs
+++ b/app/templates/organen/orgaan.hbs
@@ -26,7 +26,9 @@
   </main.sidebar>
   <main.content>
     <AuBodyContainer id="content">
-      {{outlet}}
+      <div class="au-c-body-container au-c-body-container--scroll">
+        {{outlet}}
+      </div>
     </AuBodyContainer>
   </main.content>
 </AuMainContainer>


### PR DESCRIPTION
## Description

The form was not scrollable in case the screen was small
## How to test

Make your screen small but wide enough to still have a sidebar it should look like this
![image](https://github.com/user-attachments/assets/cb26ca05-156b-46da-ba87-72059f0c2ec5)

example url: http://localhost:4200/organen/15f48ffbd10856140a84e744b82c0835a29970902210f556fa5692b103c7590e/mandataris/new?person=ac7c0cec477cc285a64e2ab49dbf472d72552c43caf849a827ac7766b9894282

(go to a person and add a mandate there)