### PR TITLE
LMB-724: when no publication status set to "Niet beschikbaar"

### DIFF
--- a/app/components/mandaat/publicatie-status-pill.hbs
+++ b/app/components/mandaat/publicatie-status-pill.hbs
@@ -1,10 +1,7 @@
 <div>
   <AuPill
     @skin={{if
-      (or
-        (not @mandataris.publicationStatus.label)
-        (eq @mandataris.publicationStatus.label "Bekrachtigd")
-      )
+      (eq @mandataris.publicationStatus.label "Bekrachtigd")
       "success"
       "default"
     }}
@@ -13,7 +10,7 @@
     @iconAlignment="left"
     @hideText={{false}}
   >
-    {{or @mandataris.publicationStatus.label "Bekrachtigd"}}
+    {{or @mandataris.publicationStatus.label "Niet beschikbaar"}}
   </AuPill>
   {{#if
     (and


### PR DESCRIPTION
## Description

Old mandatarissen that have no publciatie status need to be set to "Niet beschikbaar" instead of "Bekrachtigd"

## How to test

1. Look at a mandataris in bestuursperiode 2012 - 2019 => iet beschikbaar
2. Create a new mandataris => status should be draft
3. Change status to bekrachtigd => pill turns green

