### PR TITLE
LMB-743 | Bug form change triggers unnecassary network calls

### DIFF
--- a/app/components/rdf-input-fields/mandataris-fractie-selector.js
+++ b/app/components/rdf-input-fields/mandataris-fractie-selector.js
@@ -11,6 +11,8 @@ import { NamedNode } from 'rdflib';
 import { loadBestuursorgaanUrisFromContext } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';
 import { MANDAAT } from 'frontend-lmb/rdf/namespaces';
 import { restartableTask, timeout } from 'ember-concurrency';
+import { isPredicateInObserverChange } from 'frontend-lmb/utils/is-predicate-in-observer-change';
+import { MANDATARIS_PREDICATE } from 'frontend-lmb/utils/constants';
 
 /**
  * The reason that the FractieSelector is a specific component is that when linking a mandataris
@@ -45,8 +47,15 @@ export default class MandatarisFractieSelector extends InputFieldComponent {
   constructor() {
     super(...arguments);
     this.load();
-    this.storeOptions.store.registerObserver(async () => {
-      await this.findPersonInForm.perform();
+    this.storeOptions.store.registerObserver(async (formChange) => {
+      const mustTrigger = isPredicateInObserverChange(
+        formChange,
+        MANDATARIS_PREDICATE.persoon
+      );
+
+      if (mustTrigger) {
+        await this.findPersonInForm.perform();
+      }
     });
   }
 

--- a/app/components/rdf-input-fields/mandataris-mandaat-selector.js
+++ b/app/components/rdf-input-fields/mandataris-mandaat-selector.js
@@ -12,6 +12,8 @@ import { triplesForPath } from '@lblod/submission-form-helpers';
 import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
 import { loadBestuursorgaanUrisFromContext } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';
 import { MANDAAT } from 'frontend-lmb/rdf/namespaces';
+import { isPredicateInObserverChange } from 'frontend-lmb/utils/is-predicate-in-observer-change';
+import { MANDATARIS_PREDICATE } from 'frontend-lmb/utils/constants';
 
 export default class MandatarisMandaatSelector extends InputFieldComponent {
   inputId = 'input-' + guidFor(this);
@@ -27,8 +29,15 @@ export default class MandatarisMandaatSelector extends InputFieldComponent {
   constructor() {
     super(...arguments);
     this.load();
-    this.storeOptions.store.registerObserver(async () => {
-      await this.findPerson.perform();
+    this.storeOptions.store.registerObserver(async (formChange) => {
+      const mustTrigger = isPredicateInObserverChange(
+        formChange,
+        MANDATARIS_PREDICATE.persoon
+      );
+
+      if (mustTrigger) {
+        await this.findPerson.perform();
+      }
     });
   }
 

--- a/app/components/rdf-input-fields/mandataris-rangorde.js
+++ b/app/components/rdf-input-fields/mandataris-rangorde.js
@@ -12,6 +12,8 @@ import {
   triplesForPath,
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
+import { isPredicateInObserverChange } from 'frontend-lmb/utils/is-predicate-in-observer-change';
+import { MANDATARIS_PREDICATE } from 'frontend-lmb/utils/constants';
 
 export default class RdfMandatarisRangorde extends InputFieldComponent {
   inputId = 'rangorde-' + guidFor(this);
@@ -42,7 +44,16 @@ export default class RdfMandatarisRangorde extends InputFieldComponent {
 
       this.checkIfShouldRender();
     };
-    this.storeOptions.store.registerObserver(onFormUpdate);
+    this.storeOptions.store.registerObserver((formChange) => {
+      const mustTrigger = isPredicateInObserverChange(
+        formChange,
+        MANDATARIS_PREDICATE.mandaat
+      );
+
+      if (mustTrigger) {
+        onFormUpdate();
+      }
+    });
     onFormUpdate();
   }
 

--- a/app/components/rdf-input-fields/mandataris-status-selector.js
+++ b/app/components/rdf-input-fields/mandataris-status-selector.js
@@ -9,6 +9,8 @@ import {
   notBurgemeesterStates,
 } from 'frontend-lmb/utils/well-known-uris';
 import { ORG } from 'frontend-lmb/rdf/namespaces';
+import { isPredicateInObserverChange } from 'frontend-lmb/utils/is-predicate-in-observer-change';
+import { MANDATARIS_PREDICATE } from 'frontend-lmb/utils/constants';
 
 export default class RdfInputFieldsMandatarisStatusSelectorComponent extends RdfInputFieldsConceptSchemeSelectorComponent {
   @service store;
@@ -43,7 +45,16 @@ export default class RdfInputFieldsMandatarisStatusSelectorComponent extends Rdf
 
       await this.loadMandaat();
     };
-    this.storeOptions.store.registerObserver(onFormUpdate);
+    this.storeOptions.store.registerObserver((formChange) => {
+      const mustTrigger = isPredicateInObserverChange(
+        formChange,
+        MANDATARIS_PREDICATE.mandaat
+      );
+
+      if (mustTrigger) {
+        onFormUpdate();
+      }
+    });
     onFormUpdate();
   }
 

--- a/app/components/rdf-input-fields/mandataris-status-selector.js
+++ b/app/components/rdf-input-fields/mandataris-status-selector.js
@@ -45,14 +45,14 @@ export default class RdfInputFieldsMandatarisStatusSelectorComponent extends Rdf
 
       await this.loadMandaat();
     };
-    this.storeOptions.store.registerObserver((formChange) => {
+    this.storeOptions.store.registerObserver(async (formChange) => {
       const mustTrigger = isPredicateInObserverChange(
         formChange,
         MANDATARIS_PREDICATE.mandaat
       );
 
       if (mustTrigger) {
-        onFormUpdate();
+        await onFormUpdate();
       }
     });
     onFormUpdate();

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -30,3 +30,8 @@ export const placeholderOnafhankelijk = {
   id: 'ONAFHANKELIJK-ID',
   naam: 'Onafhankelijk',
 };
+
+export const MANDATARIS_PREDICATE = {
+  persoon: 'http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan',
+  mandaat: 'http://www.w3.org/ns/org#holds',
+};

--- a/app/utils/is-predicate-in-observer-change.js
+++ b/app/utils/is-predicate-in-observer-change.js
@@ -1,0 +1,10 @@
+export function isPredicateInObserverChange(
+  { inserts, deletes },
+  predicateAsString
+) {
+  const predicateArray = [...inserts, ...deletes].map(
+    (triple) => triple.predicate.value
+  );
+
+  return predicateArray.includes(predicateAsString);
+}


### PR DESCRIPTION
## Description

When testing on QA the correct form is not working smoothly. (Cannot edit a date without a refresh of the form)
Updated it that when the form observer is triggered the components used will only execute there logic when a specific predicate is changed (inserted or deleted).

## How to test

Create/wijzig/edit a mandataris and see if it is hard or tough to change a value.
