### PR TITLE
add beleidsdomeinen to deputatie

### DIFF
--- a/app/models/mandaat.js
+++ b/app/models/mandaat.js
@@ -7,6 +7,7 @@ import {
   MANDAAT_DISTRICT_SCHEPEN_CODE,
   MANDAAT_SCHEPEN_CODE,
   MANDAAT_TOEGEVOEGDE_SCHEPEN_CODE,
+  MANDAAT_GEDEPUTEERDE_CODE,
 } from 'frontend-lmb/utils/well-known-uris';
 
 const identity = Boolean;
@@ -62,6 +63,7 @@ export default class MandaatModel extends Model {
       MANDAAT_SCHEPEN_CODE,
       MANDAAT_DISTRICT_SCHEPEN_CODE,
       MANDAAT_TOEGEVOEGDE_SCHEPEN_CODE,
+      MANDAAT_GEDEPUTEERDE_CODE,
     ].includes(this.bestuursfunctie.get('uri'));
   }
 

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -61,6 +61,8 @@ export const MANDAAT_TOEGEVOEGDE_SCHEPEN_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/59a90e03-4f22-4bb9-8c91-132618db4b38';
 export const MANDAAT_DISTRICT_SCHEPEN_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001e';
+export const MANDAAT_GEDEPUTEERDE_CODE =
+  'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000020';
 
 export const burgemeesterOnlyStates = [MANDATARIS_TITELVOEREND_STATE];
 export const notBurgemeesterStates = [MANDATARIS_VERHINDERD_STATE];


### PR DESCRIPTION
## Description
add beleidsdomeinen to deputatie
## How to test

Log in as vlaams brabant (provincie) 

Open deputatie 
See that you can modify beleidsdomeinen

![image](https://github.com/user-attachments/assets/d1b0d151-9c5d-42c7-8e8a-2cf50347aaa9)


## Links to other PR's
Requires a rebuild of you db using this pr
- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/209
