### PR TITLE
LMN 698 | Better handling of bekrachtigde mandatarissen

### DIFF
--- a/app/components/mandaat/publicatie-status-pill.hbs
+++ b/app/components/mandaat/publicatie-status-pill.hbs
@@ -14,11 +14,11 @@
   </AuPill>
   {{#if
     (and
-      @showBekijkBewijs @mandataris.linkToBesluit this.isMandatarisBekrachtigd
+      @showBekijkBewijs (await this.linkToDecision) this.isMandatarisBekrachtigd
     )
   }}
     <AuLinkExternal
-      href={{@mandataris.linkToBesluit}}
+      href={{await this.linkToDecision}}
       class="au-u-margin-left-tiny"
     >Bekijk besluit</AuLinkExternal>
   {{/if}}

--- a/app/components/mandaat/publicatie-status-pill.js
+++ b/app/components/mandaat/publicatie-status-pill.js
@@ -4,8 +4,8 @@ import { getLinkToDecision } from 'frontend-lmb/models/mandataris';
 export default class MandaatPublicatieStatusPillComponent extends Component {
   constructor() {
     super(...arguments);
-    console.log(`sadsad`, this.args.mandataris.getLinkToDecision);
   }
+
   get isMandatarisBekrachtigd() {
     return this.args.mandataris.get('publicationStatus')
       ? this.args.mandataris.get('publicationStatus').get('isBekrachtigd')

--- a/app/components/mandaat/publicatie-status-pill.js
+++ b/app/components/mandaat/publicatie-status-pill.js
@@ -1,11 +1,8 @@
 import Component from '@glimmer/component';
+
 import { getLinkToDecision } from 'frontend-lmb/models/mandataris';
 
 export default class MandaatPublicatieStatusPillComponent extends Component {
-  constructor() {
-    super(...arguments);
-  }
-
   get isMandatarisBekrachtigd() {
     return this.args.mandataris.get('publicationStatus')
       ? this.args.mandataris.get('publicationStatus').get('isBekrachtigd')

--- a/app/components/mandaat/publicatie-status-pill.js
+++ b/app/components/mandaat/publicatie-status-pill.js
@@ -1,9 +1,18 @@
 import Component from '@glimmer/component';
+import { getLinkToDecision } from 'frontend-lmb/models/mandataris';
 
 export default class MandaatPublicatieStatusPillComponent extends Component {
+  constructor() {
+    super(...arguments);
+    console.log(`sadsad`, this.args.mandataris.getLinkToDecision);
+  }
   get isMandatarisBekrachtigd() {
     return this.args.mandataris.get('publicationStatus')
       ? this.args.mandataris.get('publicationStatus').get('isBekrachtigd')
       : true;
+  }
+
+  get linkToDecision() {
+    return getLinkToDecision(this.args.mandataris);
   }
 }

--- a/app/components/mandaat/publicatie-status-pill.js
+++ b/app/components/mandaat/publicatie-status-pill.js
@@ -1,8 +1,10 @@
 import Component from '@glimmer/component';
 
-import { getLinkToDecision } from 'frontend-lmb/models/mandataris';
+import { service } from '@ember/service';
 
 export default class MandaatPublicatieStatusPillComponent extends Component {
+  @service('mandataris-api') mandatarisApi;
+
   get isMandatarisBekrachtigd() {
     return this.args.mandataris.get('publicationStatus')
       ? this.args.mandataris.get('publicationStatus').get('isBekrachtigd')
@@ -10,6 +12,14 @@ export default class MandaatPublicatieStatusPillComponent extends Component {
   }
 
   get linkToDecision() {
-    return getLinkToDecision(this.args.mandataris);
+    return this.getLink();
+  }
+
+  async getLink() {
+    const link = await this.mandatarisApi.findDecisionUri(
+      this.args.mandataris.id
+    );
+
+    return link ?? this.args.mandataris.linkToBesluit;
   }
 }

--- a/app/components/mandatarissen/mandataris/publication-status-selector.hbs
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.hbs
@@ -52,11 +52,13 @@
           {{#if this.isLinkToPage}}
             <AuLabel for="link-to-page">Link naar pagina</AuLabel>
             <AuInput
+              @error={{(and (not this.isInputLinkValid) this.linkToDecision)}}
               @width="block"
               @iconAlignment="left"
               value={{this.linkToDecision}}
               id="link-to-page"
               placeholder="Link naar besluit pagina"
+              {{on "keyup" (perform this.setLinkTodecision)}}
             />
           {{else}}
             <AuButtonGroup>
@@ -74,6 +76,7 @@
                 {{predicate.label}}
               </PowerSelect>
               <AuInput
+                @error={{(and (not this.isInputLinkValid) this.linkToDecision)}}
                 @iconAlignment="left"
                 value={{this.linkToDecision}}
                 id="link-to-decision"
@@ -82,12 +85,19 @@
               />
             </AuButtonGroup>
           {{/if}}
+          <AuHelpText
+            @skin={{this.skin}}
+            @size={{this.size}}
+            @error={{this.error}}
+            @warning={{this.warning}}
+          >
+            Geef een correct uri in om te linken naar een besluit.
+          </AuHelpText>
         </span>
       {{else}}
         <div class="au-u-padding-large"></div>
       {{/if}}
       <span class="au-u-padding">
-
         <AuButtonGroup>
           <AuButton
             @disabled={{not this.canSaveLinkToDecision}}

--- a/app/components/mandatarissen/mandataris/publication-status-selector.hbs
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.hbs
@@ -101,11 +101,16 @@
         <AuButtonGroup>
           <AuButton
             @disabled={{not this.canSaveLinkToDecision}}
+            @loading={{this.addDecisionToMandataris.isRunning}}
             {{on "click" (perform this.addDecisionToMandataris)}}
           >
             Bewaar
           </AuButton>
-          <AuButton @skin="secondary" {{on "click" this.cancelAddDecision}}>
+          <AuButton
+            @skin="secondary"
+            @disabled={{this.addDecisionToMandataris.isRunning}}
+            {{on "click" this.cancelAddDecision}}
+          >
             Annuleer
           </AuButton>
         </AuButtonGroup>

--- a/app/components/mandatarissen/mandataris/publication-status-selector.hbs
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.hbs
@@ -32,6 +32,17 @@
     as |Modal|
   >
     <Modal.Body>
+      <AuAlert
+        @title="Opgelet"
+        @skin="warning"
+        @icon="alert-triangle"
+        @size={{this.size}}
+        @closable={{false}}
+      >
+        <p>Na het toevoegen van een link naar een besluit kan deze niet meer
+          aangepast worden zonder de technische dienst te contacteren.
+        </p>
+      </AuAlert>
       <AuLabel for="decision-type">Type</AuLabel>
       <PowerSelect
         id="decision-type"

--- a/app/components/mandatarissen/mandataris/publication-status-selector.hbs
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.hbs
@@ -43,58 +43,17 @@
           aangepast worden zonder de technische dienst te contacteren.
         </p>
       </AuAlert>
-      <AuLabel for="decision-type">Type</AuLabel>
-      <PowerSelect
-        id="decision-type"
-        @allowClear={{false}}
-        @placeholder="Selecteer het type artikel/besluit"
-        @selected={{this.selectedType}}
-        @options={{this.typeOptions}}
-        @onChange={{this.setType}}
-        @searchEnabled={{true}}
-        @loadingMessage="Aan het laden..."
-        @noMatchesMessage="Geen resultaten"
-        as |type|
-      >
-        {{type.label}}
-      </PowerSelect>
       <span class="au-u-padding">
-        {{#if this.isLinkToPage}}
-          <AuLabel for="link-to-page">Link naar pagina</AuLabel>
-          <AuInput
-            @error={{(and (not this.isInputLinkValid) this.linkToDecision)}}
-            @width="block"
-            @iconAlignment="left"
-            value={{this.linkToDecision}}
-            id="link-to-page"
-            placeholder="Link naar besluit pagina"
-            {{on "keyup" (perform this.setLinkTodecision)}}
-          />
-        {{else}}
-          <AuButtonGroup>
-            <PowerSelect
-              @allowClear={{false}}
-              @placeholder="Bekrachtiging/ontslag"
-              @selected={{this.selectedDecisionPredicate}}
-              @options={{this.predicateOptions}}
-              @onChange={{this.setDecisionPredicate}}
-              @searchEnabled={{true}}
-              @loadingMessage="Aan het laden..."
-              @noMatchesMessage="Geen resultaten"
-              as |predicate|
-            >
-              {{predicate.label}}
-            </PowerSelect>
-            <AuInput
-              @error={{(and (not this.isInputLinkValid) this.linkToDecision)}}
-              @iconAlignment="left"
-              value={{this.linkToDecision}}
-              id="link-to-decision"
-              placeholder="Link naar besluit"
-              {{on "keyup" (perform this.setLinkTodecision)}}
-            />
-          </AuButtonGroup>
-        {{/if}}
+        <AuLabel for="link-to-page">Link naar pagina</AuLabel>
+        <AuInput
+          @error={{(and (not this.isInputLinkValid) this.linkToDecision)}}
+          @width="block"
+          @iconAlignment="left"
+          value={{this.linkToDecision}}
+          id="link-to-page"
+          placeholder="Link naar besluit pagina"
+          {{on "keyup" (perform this.setLinkTodecision)}}
+        />
         <AuHelpText
           @skin={{this.skin}}
           @size={{this.size}}
@@ -107,7 +66,7 @@
       <span class="au-u-padding">
         <AuButtonGroup>
           <AuButton
-            @disabled={{not this.canSaveLinkToDecision}}
+            @disabled={{not this.isInputLinkValid}}
             @loading={{this.addDecisionToMandataris.isRunning}}
             {{on "click" (perform this.addDecisionToMandataris)}}
           >

--- a/app/components/mandatarissen/mandataris/publication-status-selector.hbs
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.hbs
@@ -29,16 +29,77 @@
     @modalOpen={{this.showLinkToDecisionModal}}
     @closable={{true}}
     @closeModal={{(fn (mut this.showLinkToDecisionModal) false)}}
+    as |Modal|
   >
-    <div>
-      <AuLabel for="decision-link">Link naar besluit</AuLabel>
-      <AuInput
-        @icon="search"
-        @iconAlignment="left"
-        value={{this.voornaam}}
-        id="decision-link"
-        placeholder="Link naar besluit"
-      />
-    </div>
+    <Modal.Body>
+      <AuLabel for="decision-type">Type</AuLabel>
+      <PowerSelect
+        id="decision-type"
+        @allowClear={{false}}
+        @placeholder="Selecteer het type artikel/besluit"
+        @selected={{this.selectedType}}
+        @options={{this.typeOptions}}
+        @onChange={{this.setType}}
+        @searchEnabled={{true}}
+        @loadingMessage="Aan het laden..."
+        @noMatchesMessage="Geen resultaten"
+        as |type|
+      >
+        {{type.label}}
+      </PowerSelect>
+      {{#if this.selectedType}}
+        <span class="au-u-padding">
+          {{#if this.isLinkToPage}}
+            <AuLabel for="link-to-page">Link naar pagina</AuLabel>
+            <AuInput
+              @width="block"
+              @iconAlignment="left"
+              value={{this.linkToDecision}}
+              id="link-to-page"
+              placeholder="Link naar besluit pagina"
+            />
+          {{else}}
+            <AuButtonGroup>
+              <PowerSelect
+                @allowClear={{false}}
+                @placeholder="Bekrachtiging/ontslag"
+                @selected={{this.selectedDecisionPredicate}}
+                @options={{this.predicateOptions}}
+                @onChange={{this.setDecisionPredicate}}
+                @searchEnabled={{true}}
+                @loadingMessage="Aan het laden..."
+                @noMatchesMessage="Geen resultaten"
+                as |predicate|
+              >
+                {{predicate.label}}
+              </PowerSelect>
+              <AuInput
+                @iconAlignment="left"
+                value={{this.linkToDecision}}
+                id="link-to-decision"
+                placeholder="Link naar besluit"
+                {{on "keyup" (perform this.setLinkTodecision)}}
+              />
+            </AuButtonGroup>
+          {{/if}}
+        </span>
+      {{else}}
+        <div class="au-u-padding-large"></div>
+      {{/if}}
+      <span class="au-u-padding">
+
+        <AuButtonGroup>
+          <AuButton
+            @disabled={{not this.canSaveLinkToDecision}}
+            {{on "click" (perform this.addDecisionToMandataris)}}
+          >
+            Bewaar
+          </AuButton>
+          <AuButton @skin="secondary" {{on "click" this.cancelAddDecision}}>
+            Annuleer
+          </AuButton>
+        </AuButtonGroup>
+      </span>
+    </Modal.Body>
   </AuModal>
 </div>

--- a/app/components/mandatarissen/mandataris/publication-status-selector.hbs
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.hbs
@@ -47,56 +47,52 @@
       >
         {{type.label}}
       </PowerSelect>
-      {{#if this.selectedType}}
-        <span class="au-u-padding">
-          {{#if this.isLinkToPage}}
-            <AuLabel for="link-to-page">Link naar pagina</AuLabel>
+      <span class="au-u-padding">
+        {{#if this.isLinkToPage}}
+          <AuLabel for="link-to-page">Link naar pagina</AuLabel>
+          <AuInput
+            @error={{(and (not this.isInputLinkValid) this.linkToDecision)}}
+            @width="block"
+            @iconAlignment="left"
+            value={{this.linkToDecision}}
+            id="link-to-page"
+            placeholder="Link naar besluit pagina"
+            {{on "keyup" (perform this.setLinkTodecision)}}
+          />
+        {{else}}
+          <AuButtonGroup>
+            <PowerSelect
+              @allowClear={{false}}
+              @placeholder="Bekrachtiging/ontslag"
+              @selected={{this.selectedDecisionPredicate}}
+              @options={{this.predicateOptions}}
+              @onChange={{this.setDecisionPredicate}}
+              @searchEnabled={{true}}
+              @loadingMessage="Aan het laden..."
+              @noMatchesMessage="Geen resultaten"
+              as |predicate|
+            >
+              {{predicate.label}}
+            </PowerSelect>
             <AuInput
               @error={{(and (not this.isInputLinkValid) this.linkToDecision)}}
-              @width="block"
               @iconAlignment="left"
               value={{this.linkToDecision}}
-              id="link-to-page"
-              placeholder="Link naar besluit pagina"
+              id="link-to-decision"
+              placeholder="Link naar besluit"
               {{on "keyup" (perform this.setLinkTodecision)}}
             />
-          {{else}}
-            <AuButtonGroup>
-              <PowerSelect
-                @allowClear={{false}}
-                @placeholder="Bekrachtiging/ontslag"
-                @selected={{this.selectedDecisionPredicate}}
-                @options={{this.predicateOptions}}
-                @onChange={{this.setDecisionPredicate}}
-                @searchEnabled={{true}}
-                @loadingMessage="Aan het laden..."
-                @noMatchesMessage="Geen resultaten"
-                as |predicate|
-              >
-                {{predicate.label}}
-              </PowerSelect>
-              <AuInput
-                @error={{(and (not this.isInputLinkValid) this.linkToDecision)}}
-                @iconAlignment="left"
-                value={{this.linkToDecision}}
-                id="link-to-decision"
-                placeholder="Link naar besluit"
-                {{on "keyup" (perform this.setLinkTodecision)}}
-              />
-            </AuButtonGroup>
-          {{/if}}
-          <AuHelpText
-            @skin={{this.skin}}
-            @size={{this.size}}
-            @error={{this.error}}
-            @warning={{this.warning}}
-          >
-            Geef een correct uri in om te linken naar een besluit.
-          </AuHelpText>
-        </span>
-      {{else}}
-        <div class="au-u-padding-large"></div>
-      {{/if}}
+          </AuButtonGroup>
+        {{/if}}
+        <AuHelpText
+          @skin={{this.skin}}
+          @size={{this.size}}
+          @error={{this.error}}
+          @warning={{this.warning}}
+        >
+          Geef een correct uri in om te linken naar een besluit.
+        </AuHelpText>
+      </span>
       <span class="au-u-padding">
         <AuButtonGroup>
           <AuButton

--- a/app/components/mandatarissen/mandataris/publication-status-selector.hbs
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.hbs
@@ -25,10 +25,10 @@
 
   <AuModalContainer />
   <AuModal
-    @title={{this.title}}
+    @title="Link naar besluit"
     @modalOpen={{this.showLinkToDecisionModal}}
     @closable={{true}}
-    @closeModal={{(fn (mut this.showLinkToDecisionModal) false)}}
+    @closeModal={{this.cancelAddDecision}}
     as |Modal|
   >
     <Modal.Body>

--- a/app/components/mandatarissen/mandataris/publication-status-selector.hbs
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.hbs
@@ -54,14 +54,12 @@
           placeholder="Link naar besluit pagina"
           {{on "keyup" (perform this.setLinkTodecision)}}
         />
-        <AuHelpText
-          @skin={{this.skin}}
-          @size={{this.size}}
-          @error={{this.error}}
-          @warning={{this.warning}}
-        >
-          Geef een correct uri in om te linken naar een besluit.
-        </AuHelpText>
+        {{#if (and (not this.isInputLinkValid) this.linkToDecision)}}
+          <AuHelpText @skin="secondary" @error={{true}}>
+            Start de url met http://, https:// of www. om te linken naar de
+            besluit pagina.
+          </AuHelpText>
+        {{/if}}
       </span>
       <span class="au-u-padding">
         <AuButtonGroup>

--- a/app/components/mandatarissen/mandataris/publication-status-selector.hbs
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.hbs
@@ -23,4 +23,22 @@
     >technische dienst contacteren</AuLinkExternal>
   </span>
 
+  <AuModalContainer />
+  <AuModal
+    @title={{this.title}}
+    @modalOpen={{this.showLinkToDecisionModal}}
+    @closable={{true}}
+    @closeModal={{(fn (mut this.showLinkToDecisionModal) false)}}
+  >
+    <div>
+      <AuLabel for="decision-link">Link naar besluit</AuLabel>
+      <AuInput
+        @icon="search"
+        @iconAlignment="left"
+        value={{this.voornaam}}
+        id="decision-link"
+        placeholder="Link naar besluit"
+      />
+    </div>
+  </AuModal>
 </div>

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
 import { restartableTask, task, timeout } from 'ember-concurrency';
+
 import { INPUT_DEBOUNCE } from 'frontend-lmb/utils/constants';
 import { showWarningToast } from 'frontend-lmb/utils/toasts';
 import { queryRecord } from 'frontend-lmb/utils/query-record';

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -133,7 +133,7 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
           this.selectedDecisionPredicate.id === 1
             ? 'bekrachtigtAanstellingVan'
             : 'bekrachtigtOntslagVan';
-        rechtsgrondenWithUri[rechtsgrondPropertie] = this.mandataris.uri;
+        rechtsgrondenWithUri[rechtsgrondPropertie] = this.mandataris;
         await rechtsgrondenWithUri.save();
         this.showLinkToDecisionModal = false;
         await this.setStatus(this.selectedPublicationStatus);

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -17,6 +17,7 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
   @tracked linkToDecision;
   @tracked isLinkToPage;
   @tracked selectedPublicationStatus;
+  @tracked isInputLinkValid;
 
   get mandataris() {
     return this.args.mandataris;
@@ -91,15 +92,16 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
   }
 
   isValidUri(inputValue) {
-    if (!inputValue) {
-      return false;
-    }
-
-    return inputValue.trim() !== '';
+    // eslint-disable-next-line no-useless-escape, prettier/prettier
+    const uriRegex = new RegExp(
+      '^https?://[a-zA-Z0-9-]+(.[a-zA-Z0-9-]+)*(/.*)?$'
+    );
+    return uriRegex.test(inputValue);
   }
 
   setLinkTodecision = restartableTask(async (event) => {
     this.linkToDecision = event.target?.value;
+    this.isInputLinkValid = this.isValidUri(this.linkToDecision);
   });
 
   addDecisionToMandataris = task(async () => {
@@ -107,7 +109,11 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
   });
 
   get canSaveLinkToDecision() {
-    return this.isValidUri(this.linkToDecision);
+    return (
+      this.isInputLinkValid &&
+      this.selectedDecisionPredicate &&
+      this.selectedType
+    );
   }
 
   get typeOptions() {

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -43,6 +43,9 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
     this.options = await this.store.findAll(
       'mandataris-publication-status-code'
     );
+
+    this.selectedType = this.typeOptions[1];
+    this.selectedDecisionPredicate = this.predicateOptions[0];
   }
 
   constructor() {

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -5,9 +5,11 @@ import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
 export default class MandatarissenMandatarisPublicationStatusSelectorComponent extends Component {
+  @service store;
+
   @tracked options = [];
   @tracked isDisabled = false;
-  @service store;
+  @tracked showLinkToDecisionModal;
 
   get mandataris() {
     return this.args.mandataris;
@@ -43,9 +45,17 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
 
   @action
   async onUpdate(publicationStatus) {
+    console.log(`publicationStatus`, publicationStatus);
     if (publicationStatus.isBekrachtigd) {
+      this.showLinkToDecisionModal = true;
       this.isDisabled = true;
+    } else {
+      await this.setStatus(publicationStatus);
     }
+  }
+
+  @action
+  async setStatus(publicationStatus) {
     this.mandataris.publicationStatus = publicationStatus;
     await this.mandataris.save();
     if (this.args.onUpdate) {

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -83,9 +83,8 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
 
   isValidUri(inputValue) {
     // eslint-disable-next-line no-useless-escape, prettier/prettier
-    const uriRegex = new RegExp(
-      '^https?://[a-zA-Z0-9-]+(.[a-zA-Z0-9-]+)*(/.*)?$'
-    );
+    const regex = '^(https?://|www\.)[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*(/.*)?$';
+    const uriRegex = new RegExp(regex);
     return uriRegex.test(inputValue);
   }
 

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -38,9 +38,6 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
     this.options = await this.store.findAll(
       'mandataris-publication-status-code'
     );
-
-    this.selectedType = this.typeOptions[1];
-    this.selectedDecisionPredicate = this.predicateOptions[0];
   }
 
   constructor() {
@@ -79,7 +76,9 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
   async cancelAddDecision() {
     this.selectedPublicationStatus = await this.mandataris.publicationStatus;
     this.showLinkToDecisionModal = false;
-    this.args.onUpdate();
+    if (this.args.onUpdate) {
+      this.args.onUpdate();
+    }
   }
 
   isValidUri(inputValue) {

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -21,10 +21,6 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
     return [...this.options].sort((a, b) => a.order - b.order);
   }
 
-  isBekrachtigd(publicationStatus) {
-    return !publicationStatus || publicationStatus.isBekrachtigd;
-  }
-
   async loadOptions() {
     await this.checkPublicationStatus();
 
@@ -42,7 +38,7 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
   @action
   async checkPublicationStatus() {
     const publicationStatus = await this.mandataris.publicationStatus;
-    this.isDisabled = this.isBekrachtigd(publicationStatus);
+    this.isDisabled = publicationStatus.isBekrachtigd;
   }
 
   @action

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -119,8 +119,7 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
       const searchModel = this.selectedType.id === 1 ? 'artikel' : 'besluit';
       const rechtsgrondenWithUri = await queryRecord(this.store, searchModel, {
         filter: {
-          ':uri:':
-            'http://data.lblod.info/id/besluiten/66E955D2FD74B81251EBA605',
+          ':uri:': this.linkToDecision,
         },
       });
       if (!rechtsgrondenWithUri) {
@@ -129,8 +128,16 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
           'Geen besluit of artikel gevonden voor deze uri',
           'Geen resultaat'
         );
+      } else {
+        const rechtsgrondPropertie =
+          this.selectedDecisionPredicate.id === 1
+            ? 'bekrachtigtAanstellingVan'
+            : 'bekrachtigtOntslagVan';
+        rechtsgrondenWithUri[rechtsgrondPropertie] = this.mandataris.uri;
+        await rechtsgrondenWithUri.save();
+        this.showLinkToDecisionModal = false;
+        await this.setStatus(this.selectedPublicationStatus);
       }
-      alert('We did nothing with the link to besluit/artikel');
     }
   });
 

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -116,13 +116,13 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
       this.showLinkToDecisionModal = false;
       await this.setStatus(this.selectedPublicationStatus);
     } else {
-      const rechtsgrondenWithUri = await queryRecord(
-        this.store,
-        'rechtsgrond',
-        {
-          filter: { ':uri:': this.linkToDecision },
-        }
-      );
+      const searchModel = this.selectedType.id === 1 ? 'artikel' : 'besluit';
+      const rechtsgrondenWithUri = await queryRecord(this.store, searchModel, {
+        filter: {
+          ':uri:':
+            'http://data.lblod.info/id/besluiten/66E955D2FD74B81251EBA605',
+        },
+      });
       if (!rechtsgrondenWithUri) {
         showWarningToast(
           this.toaster,

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -4,19 +4,28 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
+import { restartableTask, task } from 'ember-concurrency';
+
 export default class MandatarissenMandatarisPublicationStatusSelectorComponent extends Component {
   @service store;
 
   @tracked options = [];
   @tracked isDisabled = false;
   @tracked showLinkToDecisionModal;
+  @tracked selectedType;
+  @tracked selectedDecisionPredicate;
+  @tracked linkToDecision;
+  @tracked isLinkToPage;
+  @tracked selectedPublicationStatus;
 
   get mandataris() {
     return this.args.mandataris;
   }
 
   get publicationStatus() {
-    return this.mandataris.publicationStatus;
+    return this.selectedPublicationStatus
+      ? this.selectedPublicationStatus
+      : this.mandataris.publicationStatus;
   }
 
   get sortedOptions() {
@@ -45,10 +54,10 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
 
   @action
   async onUpdate(publicationStatus) {
-    console.log(`publicationStatus`, publicationStatus);
+    this.selectedPublicationStatus = publicationStatus;
     if (publicationStatus.isBekrachtigd) {
-      this.showLinkToDecisionModal = true;
       this.isDisabled = true;
+      this.showLinkToDecisionModal = true;
     } else {
       await this.setStatus(publicationStatus);
     }
@@ -61,5 +70,58 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
     if (this.args.onUpdate) {
       this.args.onUpdate();
     }
+  }
+
+  @action
+  setType(selectedType) {
+    this.selectedType = selectedType;
+    this.isLinkToPage = selectedType.id === 3;
+  }
+
+  @action
+  setDecisionPredicate(predicate) {
+    this.selectedDecisionPredicate = predicate;
+  }
+
+  @action
+  async cancelAddDecision() {
+    this.selectedPublicationStatus = await this.mandataris.publicationStatus;
+    this.showLinkToDecisionModal = false;
+    this.args.onUpdate();
+  }
+
+  isValidUri(inputValue) {
+    if (!inputValue) {
+      return false;
+    }
+
+    return inputValue.trim() !== '';
+  }
+
+  setLinkTodecision = restartableTask(async (event) => {
+    this.linkToDecision = event.target?.value;
+  });
+
+  addDecisionToMandataris = task(async () => {
+    // Todo: look for decision URI if it exists and link it to the mandataris
+  });
+
+  get canSaveLinkToDecision() {
+    return this.isValidUri(this.linkToDecision);
+  }
+
+  get typeOptions() {
+    return [
+      { id: 1, label: 'Artikel' },
+      { id: 2, label: 'Besluit' },
+      { id: 3, label: 'Link naar pagina' },
+    ];
+  }
+
+  get predicateOptions() {
+    return [
+      { id: 1, label: 'bekrachtigtAanstellingVan' },
+      { id: 2, label: 'bekrachtigtOntslagVan' },
+    ];
   }
 }

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -145,17 +145,3 @@ export default class MandatarisModel extends Model {
     return result;
   }
 }
-
-export async function getLinkToDecision(mandataris) {
-  const aanstelling = (await mandataris.aanstellingBekrachtigdDoor)?.uri;
-  if (aanstelling) {
-    return aanstelling;
-  }
-
-  const ontslag = (await mandataris.ontslagBekrachtigdDoor)?.uri;
-  if (ontslag) {
-    return ontslag;
-  }
-
-  return mandataris.linkToBesluit;
-}

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -157,12 +157,12 @@ export default class MandatarisModel extends Model {
 }
 
 export async function getLinkToDecision(mandataris) {
-  const aanstelling = (await mandataris.aanstellingBekrachtigdDoor).uri;
+  const aanstelling = (await mandataris.aanstellingBekrachtigdDoor)?.uri;
   if (aanstelling) {
     return aanstelling;
   }
 
-  const ontslag = (await mandataris.ontslagBekrachtigdDoor).uri;
+  const ontslag = (await mandataris.ontslagBekrachtigdDoor)?.uri;
   if (ontslag) {
     return ontslag;
   }

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -144,3 +144,17 @@ export default class MandatarisModel extends Model {
     return result;
   }
 }
+
+export async function getLinkToDecision(mandataris) {
+  const aanstelling = await mandataris.aanstellingBekrachtigdDoor;
+  if (aanstelling) {
+    return aanstelling;
+  }
+
+  const ontslag = await mandataris.ontslagBekrachtigdDoor;
+  if (ontslag) {
+    return ontslag;
+  }
+
+  return mandataris.linkToBesluit;
+}

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -70,9 +70,20 @@ export default class MandatarisModel extends Model {
   })
   contactPoints;
 
-  @belongsTo('rechtsgrond', { async: true, inverse: null, polymorphic: true })
+  @belongsTo('rechtsgrond', {
+    async: true,
+    inverse: 'bekrachtigtAanstellingVan',
+    polymorphic: true,
+    as: 'mandataris',
+  })
   aanstellingBekrachtigdDoor;
-  @belongsTo('rechtsgrond', { async: true, inverse: null, polymorphic: true })
+
+  @belongsTo('rechtsgrond', {
+    async: true,
+    inverse: 'bekrachtigtOntslagVan',
+    polymorphic: true,
+    as: 'mandataris',
+  })
   ontslagBekrachtigdDoor;
 
   get generatedFromGelinktNotuleren() {
@@ -146,12 +157,12 @@ export default class MandatarisModel extends Model {
 }
 
 export async function getLinkToDecision(mandataris) {
-  const aanstelling = await mandataris.aanstellingBekrachtigdDoor;
+  const aanstelling = (await mandataris.aanstellingBekrachtigdDoor).uri;
   if (aanstelling) {
     return aanstelling;
   }
 
-  const ontslag = await mandataris.ontslagBekrachtigdDoor;
+  const ontslag = (await mandataris.ontslagBekrachtigdDoor).uri;
   if (ontslag) {
     return ontslag;
   }

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -70,20 +70,10 @@ export default class MandatarisModel extends Model {
   })
   contactPoints;
 
-  @belongsTo('rechtsgrond', {
-    async: true,
-    inverse: 'bekrachtigtAanstellingVan',
-    polymorphic: true,
-    as: 'mandataris',
-  })
+  @belongsTo('rechtsgrond', { async: true, inverse: null, polymorphic: true })
   aanstellingBekrachtigdDoor;
 
-  @belongsTo('rechtsgrond', {
-    async: true,
-    inverse: 'bekrachtigtOntslagVan',
-    polymorphic: true,
-    as: 'mandataris',
-  })
+  @belongsTo('rechtsgrond', { async: true, inverse: null, polymorphic: true })
   ontslagBekrachtigdDoor;
 
   get generatedFromGelinktNotuleren() {

--- a/app/models/rechtsgrond.js
+++ b/app/models/rechtsgrond.js
@@ -1,7 +1,21 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class RechtsgrondModel extends Model {
   @attr uri;
-  @attr bekrachtigtAanstellingVan;
-  @attr bekrachtigtOntslagVan;
+
+  @belongsTo('mandataris', {
+    async: true,
+    inverse: 'aanstellingBekrachtigdDoor',
+    polymorphic: true,
+    as: 'rechtsgrond',
+  })
+  bekrachtigtAanstellingVan;
+
+  @belongsTo('mandataris', {
+    async: true,
+    inverse: 'aanstellingOntslagDoor',
+    polymorphic: true,
+    as: 'rechtsgrond',
+  })
+  bekrachtigtOntslagVan;
 }

--- a/app/models/rechtsgrond.js
+++ b/app/models/rechtsgrond.js
@@ -1,21 +1,8 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
 export default class RechtsgrondModel extends Model {
   @attr uri;
 
-  @belongsTo('mandataris', {
-    async: true,
-    inverse: 'aanstellingBekrachtigdDoor',
-    polymorphic: true,
-    as: 'rechtsgrond',
-  })
-  bekrachtigtAanstellingVan;
-
-  @belongsTo('mandataris', {
-    async: true,
-    inverse: 'ontslagBekrachtigdDoor',
-    polymorphic: true,
-    as: 'rechtsgrond',
-  })
-  bekrachtigtOntslagVan;
+  @attr bekrachtigtAanstellingVan;
+  @attr bekrachtigtOntslagVan;
 }

--- a/app/models/rechtsgrond.js
+++ b/app/models/rechtsgrond.js
@@ -13,7 +13,7 @@ export default class RechtsgrondModel extends Model {
 
   @belongsTo('mandataris', {
     async: true,
-    inverse: 'aanstellingOntslagDoor',
+    inverse: 'ontslagBekrachtigdDoor',
     polymorphic: true,
     as: 'rechtsgrond',
   })

--- a/app/services/mandataris-api.js
+++ b/app/services/mandataris-api.js
@@ -42,8 +42,6 @@ export default class MandatarisApiService extends Service {
       };
     }
 
-    await timeout(RESOURCE_CACHE_TIMEOUT);
-
     return jsonReponse.decisionUri;
   }
 }

--- a/app/services/mandataris-api.js
+++ b/app/services/mandataris-api.js
@@ -27,4 +27,23 @@ export default class MandatarisApiService extends Service {
 
     await timeout(RESOURCE_CACHE_TIMEOUT);
   }
+
+  async findDecisionUri(mandatarisId) {
+    const response = await fetch(
+      `${API.MANDATARIS_SERVICE}/mandatarissen/${mandatarisId}/decision`
+    );
+    const jsonReponse = await response.json();
+
+    if (response.status !== STATUS_CODE.OK) {
+      console.error(jsonReponse.message);
+      throw {
+        status: response.status,
+        message: jsonReponse.message,
+      };
+    }
+
+    await timeout(RESOURCE_CACHE_TIMEOUT);
+
+    return jsonReponse.decisionUri;
+  }
 }


### PR DESCRIPTION
## Description

When the status of mandataris is set to bekrachtigd the mandataris must be linked to a besluit

## How to test

1. Create a besluit model
2. Go to a mandataris and change the publication status to bekrachtigd
3. A modal will show where you can add the besluit link to the mandataris
4. The besluit model can be viewed behind "Bekijk bewijs"

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/216
- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/221
- https://github.com/lblod/mandataris-service/pull/48

## Attachments

![image](https://github.com/user-attachments/assets/612642f4-36ef-4ef3-9515-0b1e7772a932)

![image](https://github.com/user-attachments/assets/f1517d78-f796-4ee1-a73f-6181a6c18e50)


https://data.lblod.info/id/besluiten/66EA96F2AA4844A4541D0F1E

![image](https://github.com/user-attachments/assets/cbd24286-64c9-405d-bc63-4f6fc8b3b7c3)

