### PR TITLE
fix broken page installatievergadering ocmw

### DIFF
--- a/app/templates/verkiezingen/installatievergadering.hbs
+++ b/app/templates/verkiezingen/installatievergadering.hbs
@@ -6,7 +6,7 @@
 {{#if (or (not @model.isRelevant) (not @model.installatievergadering))}}
   <div class="au-o-box">
     <div class="au-o-flow">
-      <AuHeading @skin="2">{{this.title}}</AuHeading>
+      <AuHeading @skin="2">Voorbereiding legislatuur</AuHeading>
     </div>
   </div>
   <div class="au-o-box">


### PR DESCRIPTION
## Description

Fix broken page installatievergadering OCMW. This page did error because it tried to read some model info, the page did not have in the case the bestuurseenheid was an OCMW.

## How to test

Go to an installatievergadering page of an OCMW and check it does not error anymore.
