### PR TITLE
lmb-700 | limit the start and endate input iwhen creating a new mandataris 

### DIFF
--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -25,19 +25,19 @@
     <AuLabel>
       Vanaf
     </AuLabel>
-    <AuDatePicker
+    <AuDateInput
       @value={{this.date}}
       @onChange={{this.updateDate}}
-      @error={{not this.validDate}}
-      @alignment="top"
+      @error={{not this.isValidDate}}
+      @alignment="default"
     />
-    {{#unless this.validDate}}
+    {{#unless this.isValidDate}}
       <AuAlert
         @size="small"
         @closable={{false}}
         @skin="error"
         class="au-u-margin-top"
-      >De gekozen datum moet na de startdatum liggen van het huidige mandaat.</AuAlert>
+      >{{this.invalidDateErrorMessage}}</AuAlert>
     {{/unless}}
   </div>
   <div>

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -111,7 +111,7 @@
         <AuButton
           {{on "click" (perform this.updateState)}}
           @disabled={{this.disabled}}
-          @loading={{this.isSaving}}
+          @loading={{this.updateState.isRunning}}
         >
           {{if this.hasChanges "Pas aan" "Onveranderd"}}
         </AuButton>

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -5,6 +5,8 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
+import moment from 'moment';
+
 import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
 import { getDraftPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
 import {
@@ -55,7 +57,16 @@ export default class MandatarissenUpdateState extends Component {
     this.bestuursperiode =
       await this.bestuursorganenOfMandaat[0]?.heeftBestuursperiode;
     this.statusOptions = await this.getStatusOptions();
+    await this.getBestuursorgaanEndDate();
   });
+
+  async getBestuursorgaanEndDate() {
+    const mandaat = await this.args.mandataris.bekleedt;
+    const bestuursorganen = await mandaat.bevatIn;
+    if (bestuursorganen.length >= 1) {
+      this.bestuursorgaanEndDate = bestuursorganen.at(0).bindingEinde;
+    }
+  }
 
   async getStatusOptions() {
     const isBurgemeester = (
@@ -101,14 +112,41 @@ export default class MandatarissenUpdateState extends Component {
     return this.newStatus === this.mandatarisStatus.endedState;
   }
 
-  get validDate() {
+  get isValidDate() {
     if (!this.date) {
       return false;
     }
     if (!this.args.mandataris.start) {
       return true;
     }
-    return this.date.getTime() >= this.args.mandataris.start.getTime();
+
+    if (
+      this.bestuursorgaanEndDate &&
+      this.date.getTime() > this.bestuursorgaanEndDate.getTime()
+    ) {
+      return false;
+    }
+
+    const referenceDate = new Date(this.args.mandataris.start);
+    referenceDate.setHours(0, 0, 0, 0);
+    return this.date.getTime() >= referenceDate.getTime();
+  }
+
+  get invalidDateErrorMessage() {
+    if (
+      this.bestuursorgaanEndDate &&
+      this.date.getTime() > this.bestuursorgaanEndDate.getTime()
+    ) {
+      const formattedEndDate = moment(this.bestuursorgaanEndDate).format(
+        'DD-MM-YYYY'
+      );
+      return `De gekozen datum moet voor het einde van de bestuursperiode liggen (${formattedEndDate})`;
+    }
+
+    const formattedStartDate = moment(this.args.mandataris.start).format(
+      'DD-MM-YYYY'
+    );
+    return `De gekozen datum moet na de startdatum liggen van het huidige mandaat. (${formattedStartDate})`;
   }
 
   get hasChanges() {
@@ -126,7 +164,7 @@ export default class MandatarissenUpdateState extends Component {
       this.load.isRunning ||
       !this.newStatus ||
       !this.date ||
-      !this.validDate ||
+      !this.isValidDate ||
       !this.hasChanges
     );
   }

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -149,8 +149,18 @@ export default class MandatarissenUpdateState extends Component {
     return `De gekozen datum moet na de startdatum liggen van het huidige mandaat. (${formattedStartDate})`;
   }
 
+  get isInputDateTheSameAsMandatarisStart() {
+    const startDate = new Date(this.args.mandataris.start);
+    startDate.setHours(0, 0, 0, 0);
+    const inputDate = new Date(this.date);
+    inputDate.setHours(0, 0, 0, 0);
+
+    return startDate.getTime() === inputDate.getTime();
+  }
+
   get hasChanges() {
     return (
+      !this.isInputDateTheSameAsMandatarisStart ||
       this.newStatus?.id !== this.args.mandataris.status?.id ||
       this.selectedFractie?.id !==
         this.args.mandataris.get('heeftLidmaatschap.binnenFractie.id') ||

--- a/app/components/rdf-input-fields/mandataris-fractie-selector.js
+++ b/app/components/rdf-input-fields/mandataris-fractie-selector.js
@@ -8,7 +8,7 @@ import { action } from '@ember/object';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
 import { NamedNode } from 'rdflib';
-import { loadBestuursorgaanUrisFromContext } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';
+import { loadBestuursorgaanUrisFromContext } from 'frontend-lmb/utils/form-context/application-context-meta-ttl';
 import { MANDAAT } from 'frontend-lmb/rdf/namespaces';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { isPredicateInObserverChange } from 'frontend-lmb/utils/is-predicate-in-observer-change';

--- a/app/components/rdf-input-fields/mandataris-mandaat-selector.js
+++ b/app/components/rdf-input-fields/mandataris-mandaat-selector.js
@@ -10,7 +10,7 @@ import { restartableTask } from 'ember-concurrency';
 
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
-import { loadBestuursorgaanUrisFromContext } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';
+import { loadBestuursorgaanUrisFromContext } from 'frontend-lmb/utils/form-context/application-context-meta-ttl';
 import { MANDAAT } from 'frontend-lmb/rdf/namespaces';
 import { isPredicateInObserverChange } from 'frontend-lmb/utils/is-predicate-in-observer-change';
 import { MANDATARIS_PREDICATE } from 'frontend-lmb/utils/constants';

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -7,7 +7,7 @@ import { A } from '@ember/array';
 
 import { restartableTask, task } from 'ember-concurrency';
 
-import { getBestuursorganenMetaTtl } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';
+import { getApplicationContextMetaTtl } from 'frontend-lmb/utils/form-context/application-context-meta-ttl';
 import { buildNewMandatarisSourceTtl } from 'frontend-lmb/utils/build-new-mandataris-source-ttl';
 import { syncNewMandatarisMembership } from 'frontend-lmb/utils/sync-new-mandataris-membership';
 import {
@@ -280,6 +280,6 @@ export default class PrepareLegislatuurSectionComponent extends Component {
 
   @action
   buildMetaTtl() {
-    return getBestuursorganenMetaTtl([this.args.bestuursorgaan]);
+    return getApplicationContextMetaTtl([this.args.bestuursorgaan]);
   }
 }

--- a/app/controllers/mandatarissen/persoon/mandataris.js
+++ b/app/controllers/mandatarissen/persoon/mandataris.js
@@ -7,7 +7,7 @@ import { tracked } from '@glimmer/tracking';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
 import { SOURCE_GRAPH } from 'frontend-lmb/utils/constants';
 import { syncMandatarisMembership } from 'frontend-lmb/utils/form-business-rules/mandataris-membership';
-import { getBestuursorganenMetaTtl } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';
+import { getApplicationContextMetaTtl } from 'frontend-lmb/utils/form-context/application-context-meta-ttl';
 import { task } from 'ember-concurrency';
 import { INSTALLATIEVERGADERING_BEHANDELD_STATUS } from 'frontend-lmb/utils/well-known-uris';
 
@@ -78,7 +78,7 @@ export default class MandatarissenPersoonMandatarisController extends Controller
 
   @action
   async buildMetaTtl() {
-    return getBestuursorganenMetaTtl(this.model.bestuursorganen);
+    return getApplicationContextMetaTtl(this.model.bestuursorganen);
   }
 
   checkLegislatuur = task(async () => {

--- a/app/controllers/organen/orgaan/mandataris/new.js
+++ b/app/controllers/organen/orgaan/mandataris/new.js
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
-import { getBestuursorganenMetaTtl } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';
+import { getApplicationContextMetaTtl } from 'frontend-lmb/utils/form-context/application-context-meta-ttl';
 import { buildNewMandatarisSourceTtl } from 'frontend-lmb/utils/build-new-mandataris-source-ttl';
 import { syncNewMandatarisMembership } from 'frontend-lmb/utils/sync-new-mandataris-membership';
 
@@ -42,7 +42,7 @@ export default class OrganenMandatarisNewController extends Controller {
 
   @action
   buildMetaTtl() {
-    return getBestuursorganenMetaTtl([this.model.currentBestuursorgaan]);
+    return getApplicationContextMetaTtl([this.model.currentBestuursorgaan]);
   }
 
   @action

--- a/app/controllers/organen/orgaan/mandatarissen.js
+++ b/app/controllers/organen/orgaan/mandatarissen.js
@@ -4,7 +4,7 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
 import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
-import { getBestuursorganenMetaTtl } from 'frontend-lmb/utils/form-context/bestuursorgaan-meta-ttl';
+import { getApplicationContextMetaTtl } from 'frontend-lmb/utils/form-context/application-context-meta-ttl';
 import { buildNewMandatarisSourceTtl } from 'frontend-lmb/utils/build-new-mandataris-source-ttl';
 import { syncNewMandatarisMembership } from 'frontend-lmb/utils/sync-new-mandataris-membership';
 
@@ -54,7 +54,7 @@ export default class OrganenMandatarissenController extends Controller {
 
   @action
   buildMetaTtl() {
-    return getBestuursorganenMetaTtl([this.model.currentBestuursorgaan]);
+    return getApplicationContextMetaTtl([this.model.currentBestuursorgaan]);
   }
 
   @action

--- a/app/rdf/namespaces.js
+++ b/app/rdf/namespaces.js
@@ -5,3 +5,4 @@ export { MU, FORM, RDF, XSD } from '@lblod/submission-form-helpers';
 export const EXT = new Namespace('http://mu.semte.ch/vocabularies/ext/');
 export const ORG = new Namespace('http://www.w3.org/ns/org#');
 export const MANDAAT = new Namespace('http://data.vlaanderen.be/ns/mandaat#');
+export const LMB = new Namespace('http://lblod.data.gift/vocabularies/lmb/');

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -35,3 +35,5 @@ export const MANDATARIS_PREDICATE = {
   persoon: 'http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan',
   mandaat: 'http://www.w3.org/ns/org#holds',
 };
+
+export const NULL_DATE = new Date(null);

--- a/app/utils/form-context/application-context-meta-ttl.js
+++ b/app/utils/form-context/application-context-meta-ttl.js
@@ -2,18 +2,18 @@ import { EXT, LMB } from 'frontend-lmb/rdf/namespaces';
 import { NULL_DATE } from 'frontend-lmb/utils/constants';
 
 // Expects bestuursorgaan in de tijd
-export const getBestuursorganenMetaTtl = (bestuursorgaan) => {
-  if (!bestuursorgaan) {
+export const getApplicationContextMetaTtl = (bestuursorganen) => {
+  if (!bestuursorganen) {
     return;
   }
   let bestuursorgaanUris;
-  bestuursorgaanUris = bestuursorgaan
+  bestuursorgaanUris = bestuursorganen
     .map((orgaan) => {
       return `<${orgaan.uri}>`;
     })
     .join(', ');
 
-  const period = getBestuursperiodeForBestuursorganen(bestuursorgaan);
+  const period = getBestuursperiodeForBestuursorganen(bestuursorganen);
 
   return `
     @prefix ext: <http://mu.semte.ch/vocabularies/ext/> .

--- a/app/utils/form-context/bestuursorgaan-meta-ttl.js
+++ b/app/utils/form-context/bestuursorgaan-meta-ttl.js
@@ -65,7 +65,7 @@ export const loadBestuursorgaanPeriodFromContext = (storeOptions) => {
 };
 
 const getBestuursperiodeForBestuursorganen = (bestuursorganen) => {
-  if (bestuursorganen.length === 1) {
+  if (bestuursorganen.length >= 1) {
     const bestuursorgaan = bestuursorganen.at(0);
 
     return {
@@ -74,5 +74,5 @@ const getBestuursperiodeForBestuursorganen = (bestuursorganen) => {
     };
   }
 
-  return null;
+  throw new Error('Could not get bestuursorgaan to build up meta ttl');
 };

--- a/app/utils/form-context/bestuursorgaan-meta-ttl.js
+++ b/app/utils/form-context/bestuursorgaan-meta-ttl.js
@@ -1,4 +1,5 @@
-import { EXT } from 'frontend-lmb/rdf/namespaces';
+import { EXT, LMB } from 'frontend-lmb/rdf/namespaces';
+import { NULL_DATE } from 'frontend-lmb/utils/constants';
 
 // Expects bestuursorgaan in de tijd
 export const getBestuursorganenMetaTtl = (bestuursorgaan) => {
@@ -12,10 +13,22 @@ export const getBestuursorganenMetaTtl = (bestuursorgaan) => {
     })
     .join(', ');
 
+  const period = getBestuursperiodeForBestuursorganen(bestuursorgaan);
+
   return `
     @prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+    @prefix lmb: <${LMB.value}> .
 
     ext:applicationContext ext:currentBestuursorgaan ${bestuursorgaanUris} .
+
+    ${
+      period
+        ? `
+        ext:applicationContext lmb:periodStart """${period.startDate}""";
+                               lmb:periodEnd """${period.endDate}""".
+        `
+        : ''
+    }
   `;
 };
 
@@ -29,4 +42,37 @@ export const loadBestuursorgaanUrisFromContext = (storeOptions) => {
   );
 
   return bestuursorgaanUri?.map((node) => node.object.value);
+};
+
+export const loadBestuursorgaanPeriodFromContext = (storeOptions) => {
+  const startDate = storeOptions.store.any(
+    EXT('applicationContext'),
+    LMB('periodStart'),
+    null,
+    storeOptions.metaGraph
+  );
+  const endDate = storeOptions.store.any(
+    EXT('applicationContext'),
+    LMB('periodEnd'),
+    null,
+    storeOptions.metaGraph
+  );
+
+  return {
+    startDate: new Date(startDate.value),
+    endDate: new Date(endDate.value),
+  };
+};
+
+const getBestuursperiodeForBestuursorganen = (bestuursorganen) => {
+  if (bestuursorganen.length === 1) {
+    const bestuursorgaan = bestuursorganen.at(0);
+
+    return {
+      startDate: bestuursorgaan.bindingStart,
+      endDate: bestuursorgaan.bindingEinde ?? NULL_DATE,
+    };
+  }
+
+  return null;
 };

--- a/app/utils/form-context/bestuursorgaan-meta-ttl.js
+++ b/app/utils/form-context/bestuursorgaan-meta-ttl.js
@@ -17,7 +17,7 @@ export const getBestuursorganenMetaTtl = (bestuursorgaan) => {
 
   return `
     @prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
-    @prefix lmb: <${LMB.value}> .
+    @prefix lmb: <http://lblod.data.gift/vocabularies/lmb/> .
 
     ext:applicationContext ext:currentBestuursorgaan ${bestuursorgaanUris} .
 

--- a/app/utils/form-validations/mandataris-date-in-bestuursperiod.js
+++ b/app/utils/form-validations/mandataris-date-in-bestuursperiod.js
@@ -3,7 +3,7 @@ import { loadBestuursorgaanPeriodFromContext } from '../form-context/application
 
 export const isValidMandatarisDate = ([dateLiteral], options) => {
   if (!dateLiteral) {
-    return false;
+    return true;
   }
 
   const date = new Date(dateLiteral.value).getTime();

--- a/app/utils/form-validations/mandataris-date-in-bestuursperiod.js
+++ b/app/utils/form-validations/mandataris-date-in-bestuursperiod.js
@@ -1,0 +1,20 @@
+import { NULL_DATE } from '../constants';
+import { loadBestuursorgaanPeriodFromContext } from '../form-context/bestuursorgaan-meta-ttl';
+
+export const isValidMandatarisDate = ([dateLiteral], options) => {
+  if (!dateLiteral) {
+    return true;
+  }
+
+  const date = new Date(dateLiteral.value).getTime();
+  const period = loadBestuursorgaanPeriodFromContext(options);
+
+  if (period.endDate.getTime() === NULL_DATE.getTime()) {
+    if (period.startDate.getTime() <= date) {
+      return true;
+    }
+    return false;
+  }
+
+  return date >= period.startDate.getTime() && date <= period.endDate.getTime();
+};

--- a/app/utils/form-validations/mandataris-date-in-bestuursperiod.js
+++ b/app/utils/form-validations/mandataris-date-in-bestuursperiod.js
@@ -1,5 +1,5 @@
 import { NULL_DATE } from '../constants';
-import { loadBestuursorgaanPeriodFromContext } from '../form-context/bestuursorgaan-meta-ttl';
+import { loadBestuursorgaanPeriodFromContext } from '../form-context/application-context-meta-ttl';
 
 export const isValidMandatarisDate = ([dateLiteral], options) => {
   if (!dateLiteral) {

--- a/app/utils/form-validations/mandataris-date-in-bestuursperiod.js
+++ b/app/utils/form-validations/mandataris-date-in-bestuursperiod.js
@@ -3,7 +3,7 @@ import { loadBestuursorgaanPeriodFromContext } from '../form-context/bestuursorg
 
 export const isValidMandatarisDate = ([dateLiteral], options) => {
   if (!dateLiteral) {
-    return true;
+    return false;
   }
 
   const date = new Date(dateLiteral.value).getTime();

--- a/app/utils/form-validations/register.js
+++ b/app/utils/form-validations/register.js
@@ -1,6 +1,7 @@
 import { registerCustomValidation } from '@lblod/submission-form-helpers';
 import { rijksregisternummerValidation } from './rijksregisternummer';
 import { isValidRangorde } from './mandataris-rangorde';
+import { isValidMandatarisDate } from './mandataris-date-in-bestuursperiod';
 
 export const registerCustomValidations = () => {
   registerCustomValidation(
@@ -10,5 +11,9 @@ export const registerCustomValidations = () => {
   registerCustomValidation(
     'http://mu.semte.ch/vocabularies/ext/ValidRangorde',
     isValidRangorde
+  );
+  registerCustomValidation(
+    'http://mu.semte.ch/vocabularies/ext/ValidMandatarisDate',
+    isValidMandatarisDate
   );
 };


### PR DESCRIPTION
## Description

When creating a new mandataris the start and end date need to be validated that they are in the bestuursperiode of the bestuursorgaan in tijd. Added a validation for the date field that with the help from our application context can valdiate of the value in the input field is correct.

## How to test

1. Create a mandataris and insert a date that is not in the current bestuursperiode. 
2. Add a date that is exact the start or end date of the bestuursorgaan bindingStart or einde date

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/223
