### PR TITLE
enable search for adding mandates to bestuursorgaan

### DIFF
--- a/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
+++ b/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
@@ -115,7 +115,7 @@
     <PowerSelect
       @allowClear={{false}}
       @renderInPlace={{false}}
-      @searchEnabled={{this.searchEnabled}}
+      @searchEnabled={{true}}
       @noMatchesMessage={{"Geen resultaten gevonden"}}
       @searchMessage={{"Typ om een type mandaat te zoeken"}}
       @options={{@availableBestuursfuncties}}


### PR DESCRIPTION
## Description

Enable search in add mandates to bestuursorganen.

![Screenshot 2024-10-01 at 14 18 43](https://github.com/user-attachments/assets/7fb31a5d-2fb5-4a0a-9f51-1a84c3e325db)

## How to test

Add a new bestuursorgaan and check that you can add mandates and search when adding mandates.

