### PR TITLE
Fix comparing dates in update state form

### DIFF
--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -152,7 +152,7 @@ export default class MandatarissenUpdateState extends Component {
   get isInputDateTheSameAsMandatarisStart() {
     const startDate = new Date();
     const inputDate = new Date(this.date);
-    return startDate.getTime() === inputDate.getTime();
+    return moment(startDate).isSame(moment(inputDate), 'day');
   }
 
   get hasChanges() {

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -150,11 +150,8 @@ export default class MandatarissenUpdateState extends Component {
   }
 
   get isInputDateTheSameAsMandatarisStart() {
-    const startDate = new Date(this.args.mandataris.start);
-    startDate.setHours(0, 0, 0, 0);
+    const startDate = new Date();
     const inputDate = new Date(this.date);
-    inputDate.setHours(0, 0, 0, 0);
-
     return startDate.getTime() === inputDate.getTime();
   }
 


### PR DESCRIPTION
## Description

Update state form could always be saved because of an issue with comparing wrong dates.

## How to test

Go to the update state form and check if the form is disabled and gets enabled when you update the date.