### PR TITLE
fix bestuurseenheid contact created in wrong direction, triggering mu-auth issue

### DIFF
--- a/app/models/bestuurseenheid-contact.js
+++ b/app/models/bestuurseenheid-contact.js
@@ -1,6 +1,12 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class BestuurseenheidContactModel extends Model {
   @attr('string') uri;
   @attr('string') email;
+
+  @belongsTo('bestuurseenheid', {
+    async: true,
+    inverse: null,
+  })
+  bestuurseenheid;
 }

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -24,12 +24,10 @@ export default class SettingsRoute extends Route {
     if (!contact) {
       const newContact = this.store.createRecord('bestuurseenheid-contact', {
         email: null,
+        bestuurseenheid: bestuurseenheid,
       });
       await newContact.save();
       contact = newContact;
-
-      bestuurseenheid.contact = newContact;
-      await bestuurseenheid.save();
     }
 
     return {


### PR DESCRIPTION
## Description

we're not allowed to modify bestuurseenheden! So we need to create the contact instance and link from it to bestuurseenheid to be allowed by mu-auth

## How to test

open the settings page and set the email for a bestuurseenheid

## Links to other PR's

- requires app change: https://github.com/lblod/app-lokaal-mandatenbeheer/pull/236
