### PR TITLE
lmb-798: aumodalcontainer vcan only be added the the application template

### DIFF
--- a/app/components/bestuursperiode-new-button.hbs
+++ b/app/components/bestuursperiode-new-button.hbs
@@ -2,7 +2,6 @@
   <AuButton {{on "click" this.openModal}}>
     Voeg bestuursperiode toe
   </AuButton>
-  <AuModalContainer />
   <AuModal
     @title={{this.title}}
     @modalOpen={{this.isModalOpen}}

--- a/app/components/form/cancel-with-confirm.hbs
+++ b/app/components/form/cancel-with-confirm.hbs
@@ -1,6 +1,5 @@
 <AuButton @skin="secondary" {{on "click" this.cancel}}>{{yield}}</AuButton>
 
-<AuModalContainer />
 <AuModal
   @id="exit-confirmation"
   @modalOpen={{this.isModalOpen}}

--- a/app/components/form/save-with-history.hbs
+++ b/app/components/form/save-with-history.hbs
@@ -1,4 +1,3 @@
-<AuModalContainer />
 <AuModal
   @id="form-history"
   @closeModal={{fn (mut @isModalOpen) false}}

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -73,7 +73,6 @@
   {{/if}}
 </div>
 
-<AuModalContainer />
 <AuModal
   @title={{"Selecteer een persoon"}}
   @modalOpen={{this.isPersonSelectOpen}}

--- a/app/components/mandatarissen/mandataris-extra-info-card.hbs
+++ b/app/components/mandatarissen/mandataris-extra-info-card.hbs
@@ -35,7 +35,6 @@
   </div>
 </div>
 
-<AuModalContainer />
 <AuModal
   @title="Bewerk bijkomende info mandataris"
   @modalOpen={{this.isModalActive}}

--- a/app/components/mandatarissen/mandataris/publication-status-selector.hbs
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.hbs
@@ -23,7 +23,6 @@
     >technische dienst contacteren</AuLinkExternal>
   </span>
 
-  <AuModalContainer />
   <AuModal
     @title="Link naar besluit"
     @modalOpen={{this.showLinkToDecisionModal}}

--- a/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
+++ b/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
@@ -106,7 +106,6 @@
   {{yield}}
 </div>
 
-<AuModalContainer />
 <AuModal
   @id="create-mandaat"
   @modalOpen={{this.creatingNewMandaat}}

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -96,7 +96,6 @@
   </div>
 </div>
 
-<AuModalContainer />
 <AuModal
   @title={{(concat
     "Editeer mandataris" this.mandataris.bekleedt.bestuursfunctie.label

--- a/app/components/verkiezingen/kieslijst-splitter.hbs
+++ b/app/components/verkiezingen/kieslijst-splitter.hbs
@@ -96,7 +96,6 @@
   </div>
 </div>
 
-<AuModalContainer />
 <AuModal
   @title="Splits kieslijst in fracties"
   @modalOpen={{this.splitKieslijstModalOpen}}

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -93,7 +93,6 @@
     />
   {{/if}}
 
-  <AuModalContainer />
   <AuModal
     @title={{(concat
       "Voeg mandataris toe aan " @bestuursorgaan.isTijdsspecialisatieVan.naam
@@ -112,7 +111,6 @@
     </div>
   </AuModal>
 
-  <AuModalContainer />
   <AuModal
     @title={{(concat
       "Genereer rijen voor " @bestuursorgaan.isTijdsspecialisatieVan.naam

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -142,7 +142,6 @@
   {{/if}}
 </div>
 
-<AuModalContainer />
 <AuModal
   @title="Selecteer bestuursorgaan"
   @modalOpen={{this.isModalOpen}}

--- a/app/templates/organen/fracties.hbs
+++ b/app/templates/organen/fracties.hbs
@@ -36,7 +36,6 @@
   </div>
 </div>
 
-<AuModalContainer />
 <AuModal
   @title="Voeg fractie toe"
   @modalOpen={{eq this.modal this.create}}

--- a/app/templates/organen/index.hbs
+++ b/app/templates/organen/index.hbs
@@ -92,7 +92,6 @@
   </main.content>
 </AuMainContainer>
 
-<AuModalContainer />
 <AuModal
   @title="Voeg orgaan toe"
   @modalOpen={{this.isModalActive}}

--- a/app/templates/organen/orgaan/index.hbs
+++ b/app/templates/organen/orgaan/index.hbs
@@ -59,7 +59,6 @@
   </div>
 </div>
 
-<AuModalContainer />
 <AuModal
   @title="Bewerk bestuursorgaan"
   @modalOpen={{this.isModalActive}}

--- a/app/templates/organen/orgaan/mandatarissen.hbs
+++ b/app/templates/organen/orgaan/mandatarissen.hbs
@@ -54,7 +54,6 @@
 
 {{outlet}}
 
-<AuModalContainer />
 <AuModal
   @title="Voeg nieuwe mandataris toe"
   @modalOpen={{this.isCreatingMandataris}}

--- a/app/templates/verkiezingen/installatievergadering.hbs
+++ b/app/templates/verkiezingen/installatievergadering.hbs
@@ -103,7 +103,6 @@
       </div>
     {{/unless}}
   </div>
-  <AuModalContainer />
   <AuModal
     @title="Volgende status"
     @modalOpen={{this.isModalOpen}}


### PR DESCRIPTION
## Description

We added a `<auModalContainer/>` tag before every modal we add in our application. This is not necessary so they can be removed as we added one to the top of our _application.hbs_ file

## How to test

Open all the modals in the app and see if they do not throw an issue
