### PR TITLE
lmb-801: publication status is Bekrachtigd when generating mandatees

### DIFF
--- a/app/components/verkiezingen/generate-rows.js
+++ b/app/components/verkiezingen/generate-rows.js
@@ -57,7 +57,7 @@ export default class GenerateRowsFormComponent extends Component {
       isBestuurlijkeAliasVan: null,
       beleidsdomein: [],
       status: this.effectiefStatus,
-      publicationStatus: this.publicationStatus,
+      publicationStatus: this.draftPublicationStatus,
     };
 
     for (let index = 0; index < rows; index++) {


### PR DESCRIPTION
## Description

Before the fallback of publication status was **Bekrachtigd** this is not changed to **niet beschikbaar** when generating a mandataris with the generate button on the IV page the status is incorrect.

## How to test

Generate x amount of mandatees for a bestuursorgaan on the IV page
