### PR TITLE
Lmb 823 placeholder text for schepenen rangorde

### DIFF
--- a/app/components/rdf-input-fields/mandataris-rangorde.hbs
+++ b/app/components/rdf-input-fields/mandataris-rangorde.hbs
@@ -13,7 +13,7 @@
     @width="block"
     id={{this.inputId}}
     value={{this.rangorde}}
-    placeholder="Eerste schepen"
+    placeholder="Vul de rangorde in, bvb “eerste schepen”"
     {{on "blur" this.updateValue}}
   />
 


### PR DESCRIPTION
## Description

The placeholder text for rangorde of a schepenen is is not "Eerste schepenen" change this to `Vul de rangorde in, bvb “eerste schepen”`

## How to test

Create a new mandataris

## NOTE

Rangorde can also be set in the IV page. Did not change it here as it looks good 👌🏻 
