### PR TITLE
lmb-846: put the IV module behind a feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ Or in template files by using the `is-feature-enabled` helper:
 
 ### List of feature flags
 
-| Name                | Description                                                                                        |
-| ------------------- | -------------------------------------------------------------------------------------------------- |
-| `show-forms-module` | Show the forms module in overview and navigation, the route remains functional, defaults to false. |
+| Name                | Description                                                                                                               |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `show-forms-module` | Show the forms module in overview and navigation, the route remains functional, defaults to false.                        |
+| `show-iv-module`    | Show the `Opstart nieuwe legislatuur` module in overview and navigation, the route remains functional, defaults to false. |
 
 ## Environment variables
 

--- a/app/components/shared/compact-menu.hbs
+++ b/app/components/shared/compact-menu.hbs
@@ -13,10 +13,12 @@
     <AuIcon @icon="user-fill" @alignment="left" />
     Mandatarissen
   </AuLink>
-  <AuLink @route="verkiezingen.installatievergadering" role="menuitem">
-    <AuIcon @icon="vote" @alignment="left" />
-    Opstart nieuwe legislatuur
-  </AuLink>
+  {{#if (is-feature-enabled "show-iv-module")}}
+    <AuLink @route="verkiezingen.installatievergadering" role="menuitem">
+      <AuIcon @icon="vote" @alignment="left" />
+      Opstart nieuwe legislatuur
+    </AuLink>
+  {{/if}}
   {{#if (is-feature-enabled "show-forms-module")}}
     <AuLink @route="forms" role="menuitem">
       <AuIcon @icon="draft" @alignment="left" />

--- a/app/components/shared/main-menu.hbs
+++ b/app/components/shared/main-menu.hbs
@@ -15,12 +15,14 @@
         Mandatarissen
       </AuNavigationLink>
     </li>
-    <li class="au-c-list-navigation__item">
-      <AuNavigationLink @route="verkiezingen.installatievergadering">
-        <AuIcon @icon="vote" @alignment="left" />
-        Opstart nieuwe legislatuur
-      </AuNavigationLink>
-    </li>
+    {{#if (is-feature-enabled "show-iv-module")}}
+      <li class="au-c-list-navigation__item">
+        <AuNavigationLink @route="verkiezingen.installatievergadering">
+          <AuIcon @icon="vote" @alignment="left" />
+          Opstart nieuwe legislatuur
+        </AuNavigationLink>
+      </li>
+    {{/if}}
     {{#if (is-feature-enabled "show-forms-module")}}
       <li class="au-c-list-navigation__item">
         <AuNavigationLink @route="forms">

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -41,18 +41,20 @@
           </:link>
         </LoketModuleCard>
       </li>
-      <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
-        <LoketModuleCard @icon="vote">
-          <:title>Opstart nieuwe legislatuur</:title>
-          <:description>Hier vind je een overzicht van de legislaturen.</:description>
-          <:link>
-            <AuLink
-              @route="verkiezingen.installatievergadering"
-              @skin="button"
-            >Ga naar opstart nieuwe legislatuur</AuLink>
-          </:link>
-        </LoketModuleCard>
-      </li>
+      {{#if (is-feature-enabled "show-iv-module")}}
+        <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
+          <LoketModuleCard @icon="vote">
+            <:title>Opstart nieuwe legislatuur</:title>
+            <:description>Hier vind je een overzicht van de legislaturen.</:description>
+            <:link>
+              <AuLink
+                @route="verkiezingen.installatievergadering"
+                @skin="button"
+              >Ga naar opstart nieuwe legislatuur</AuLink>
+            </:link>
+          </LoketModuleCard>
+        </li>
+      {{/if}}
       {{#if (is-feature-enabled "show-forms-module")}}
         <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
           <LoketModuleCard @icon="draft">

--- a/config/environment.js
+++ b/config/environment.js
@@ -34,6 +34,7 @@ module.exports = function (environment) {
     },
     features: {
       'show-forms-module': false,
+      'show-iv-module': false,
     },
     lpdcUrl: '{{LPDC_URL}}',
     worshipDecisionsDatabaseUrl: '{{WORSHIP_DECISIONS_DATABASE_URL}}',


### PR DESCRIPTION
## Description

The legislatuur page cannot be access by users yet as there is no election list atm. Hide the module behind a feature flag

## How to test

Check all menu's in the app and the module cards on the main page. 
If you have knowledge about a place where we reference to the legislatuur page please add a comment about it
