### PR TITLE
fix restore fractie failing silently

### DIFF
--- a/app/components/verkiezingen/kieslijst-splitter.js
+++ b/app/components/verkiezingen/kieslijst-splitter.js
@@ -141,7 +141,7 @@ export default class KieslijstSplitterComponent extends Component {
   async confirmRevertSplitKieslijst() {
     const fracties = await this.selectedKieslijst.get('resulterendeFracties');
     await Promise.all(
-      fracties.map(async (fractie) => {
+      [...fracties].map(async (fractie) => {
         await fracties.removeObject(fractie);
         await fractie.destroyRecord();
         this.fracties.removeObject(fractie);

--- a/app/components/verkiezingen/kieslijst-splitter.js
+++ b/app/components/verkiezingen/kieslijst-splitter.js
@@ -11,7 +11,6 @@ import { showErrorToast } from 'frontend-lmb/utils/toasts';
 export default class KieslijstSplitterComponent extends Component {
   @service store;
   @service toaster;
-  @service router;
 
   @tracked samenwerkingsVerband;
 


### PR DESCRIPTION
## Description

When the destroy of a fractie fails, it failed silently. now we show an error toast and don't remove the fractie from the list.
## How to test

Weirdly i could trigger this by writing and extra s in the type of my system-notification has-many relation, making it system-notification-links instead of system-notification-link as a type.
