### PR TITLE
lmb-830: show all bestuursorgaan classificatie codes when adding a bestuursorgaan

### DIFF
--- a/app/components/rdf-input-fields/concept-selector.js
+++ b/app/components/rdf-input-fields/concept-selector.js
@@ -78,6 +78,9 @@ export default class ConceptSchemeSelectorComponent extends InputFieldComponent 
         },
       },
       sort: 'label',
+      page: {
+        size: 9999,
+      },
     };
     if (searchData) {
       queryParams['filter']['label'] = searchData;


### PR DESCRIPTION
## Description

We only show 20 items in the conceptscheme selector. Raise the limit of the page to 9999 so it shows all the items. 

## How to test

Add a new bestuursorgaan and check that it shows more than 20 results

## Attachments

![image](https://github.com/user-attachments/assets/4fa9f2e6-203d-44cd-97d2-f93860d85fc4)

