### PR TITLE
on 401 or 403, invalidate session and apologise to the user

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,3 +1,32 @@
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import { service } from '@ember/service';
 
-export default class ApplicationAdapter extends JSONAPIAdapter {}
+const OFFENDING_STATUS_CODES = [401, 403];
+
+export default class ApplicationAdapter extends JSONAPIAdapter {
+  constructor() {
+    super(...arguments);
+    this.monkeyPatchFetch();
+  }
+
+  monkeyPatchFetch() {
+    const originalFetch = window.fetch;
+    const router = this.router;
+    window.fetch = async function () {
+      const response = await originalFetch.apply(this, arguments);
+      console.log('status', response.status);
+      if (OFFENDING_STATUS_CODES.indexOf(response.status) > -1) {
+        router.transitionTo('session-expired');
+      }
+      return response;
+    };
+  }
+
+  @service router;
+  handleResponse(status, headers, payload, requestData) {
+    if (OFFENDING_STATUS_CODES.indexOf(status) > -1) {
+      this.router.transitionTo('session-expired');
+    }
+    return super.handleResponse(status, headers, payload, requestData);
+  }
+}

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -14,7 +14,6 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
     const router = this.router;
     window.fetch = async function () {
       const response = await originalFetch.apply(this, arguments);
-      console.log('status', response.status);
       if (OFFENDING_STATUS_CODES.indexOf(response.status) > -1) {
         router.transitionTo('session-expired');
       }

--- a/app/components/error.hbs
+++ b/app/components/error.hbs
@@ -12,4 +12,5 @@
       <p>{{@statusMessage}}</p>
     </AuAlert>
   </div>
+  {{yield}}
 </div>

--- a/app/router.js
+++ b/app/router.js
@@ -68,4 +68,5 @@ Router.map(function () {
   this.route('error/404', {
     path: '/*wildcard',
   });
+  this.route('session-expired');
 });

--- a/app/routes/session-expired.js
+++ b/app/routes/session-expired.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class SessionExpiredRoute extends Route {
+  @service session;
+
+  async beforeModel() {
+    await this.session.invalidate();
+  }
+}

--- a/app/templates/session-expired.hbs
+++ b/app/templates/session-expired.hbs
@@ -1,0 +1,10 @@
+{{page-title "SessionExpired"}}
+<Error
+  @statusCode="401: Sessie Verlopen"
+  @statusMessage="Uw sessie is verlopen en u werd uitgelogd. Onze excuses voor het ongemak. Gelieve opnieuw aan te melden."
+>
+  <div class="au-o-box">
+    <AuLink @route="login" @skin="button">Aanmelden</AuLink>
+  </div>
+</Error>
+{{outlet}}

--- a/tests/unit/routes/session-expired-test.js
+++ b/tests/unit/routes/session-expired-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-lmb/tests/helpers';
+
+module('Unit | Route | session-expired', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:session-expired');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
## Description

Handle broken session by redirecting the user to an error page and logging them out in the frontend too.

![image](https://github.com/user-attachments/assets/86a1611c-a882-44d9-bc26-4b410ae5b5db)


## How to test

Triggering a 401 or 403 is not easy (though you could remove the session from the database)

Easier is probably just to modify lines 18 and 27 in the application adapter to also react to the 200 status code. Make sure you are logged in before that and that you test them separately so we know both the ember data requests AND fetch requests trigger this behaviour.
