### PR TITLE
Show error toast when mandate can't be removed

### DIFF
--- a/app/components/mandatenbeheer/bestuursorgaan-mandaten.js
+++ b/app/components/mandatenbeheer/bestuursorgaan-mandaten.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 import { task } from 'ember-concurrency';
+import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
 
 export default class MandatenbeheerBestuursorgaanMandatenComponent extends Component {
   @service store;
@@ -63,11 +64,16 @@ export default class MandatenbeheerBestuursorgaanMandatenComponent extends Compo
       );
       return;
     }
-    await mandaat.destroyRecord();
-    this.toaster.notify('Het mandaat werd verwijderd.', 'Success', {
-      type: 'success',
-      icon: 'circle-check',
-    });
+    try {
+      await mandaat.destroyRecord();
+    } catch (error) {
+      showErrorToast(
+        this.toaster,
+        'Het mandaat kon niet verwijderd worden, probeer later opnieuw.'
+      );
+      return;
+    }
+    showSuccessToast(this.toaster, 'Het mandaat werd verwijderd.');
     this.router.refresh();
   });
 


### PR DESCRIPTION
## Description

Show error toast when mandate couldn't be removed from bestuursorgaan detail page.

## How to test

Go to the detail page of a new bestuursorgaan. Block the following call: `localhost:4200/mandaten/*` and try to delete a mandate. This should now give an error message. If you re-enable the call, the mandate should disappear.
