### PR TITLE
LMB-890 restrict create mandataris on person to organen with current bestuursperiode

### DIFF
--- a/app/routes/mandatarissen/persoon/mandaten.js
+++ b/app/routes/mandatarissen/persoon/mandaten.js
@@ -22,7 +22,7 @@ export default class MandatarissenPersoonMandatenRoute extends Route {
     const mandatarissen = await this.getMandatarissen(persoon, params);
 
     const bestuursorganen =
-      await this.bestuursorganen.getAllRealPoliticalBestuursorganen();
+      await this.bestuursorganen.getRealCurrentPoliticalBestuursorganen();
 
     const foldedMandatarissen = await foldMandatarisses(params, mandatarissen);
 

--- a/app/services/bestuursorganen.js
+++ b/app/services/bestuursorganen.js
@@ -5,12 +5,28 @@ import { service } from '@ember/service';
 export default class BestuursorganenService extends Service {
   @service store;
   @service decretaleOrganen;
+  @service bestuursperioden;
 
   async getAllRealPoliticalBestuursorganen() {
     return await this.store.query('bestuursorgaan', {
       'filter[:has-no:deactivated-at]': true,
       'filter[:has-no:is-tijdsspecialisatie-van]': true,
       'filter[:has-no:original-bestuurseenheid]': true,
+      'filter[classificatie][id]':
+        this.decretaleOrganen.classificatieIds.join(','), // only organs with a political mandate
+      include: 'classificatie,heeft-tijdsspecialisaties',
+    });
+  }
+
+  async getRealCurrentPoliticalBestuursorganen() {
+    const currentPeriod =
+      await this.bestuursperioden.getCurrentBestuursperiode();
+    return await this.store.query('bestuursorgaan', {
+      'filter[:has-no:deactivated-at]': true,
+      'filter[:has-no:is-tijdsspecialisatie-van]': true,
+      'filter[:has-no:original-bestuurseenheid]': true,
+      'filter[heeft-tijdsspecialisaties][heeft-bestuursperiode][:id:]':
+        currentPeriod.id,
       'filter[classificatie][id]':
         this.decretaleOrganen.classificatieIds.join(','), // only organs with a political mandate
       include: 'classificatie,heeft-tijdsspecialisaties',

--- a/app/services/bestuursperioden.js
+++ b/app/services/bestuursperioden.js
@@ -21,6 +21,13 @@ export default class BestuursperiodenService extends Service {
     return filtered;
   }
 
+  async getCurrentBestuursperiode() {
+    const periods = await this.store.query('bestuursperiode', {
+      sort: 'label',
+    });
+    return this.getClosestPeriod(periods);
+  }
+
   getRelevantPeriod(periods, bestuursperiodeId) {
     if (bestuursperiodeId) {
       return periods.find((period) => {


### PR DESCRIPTION
## Description

When you create a mandataris from a person page, you need to select a bestuursorgaan. This selector should only show you bestuursorganen that have a current bestuursperiode (not GECORO etc.) It should look like this if you manually added a test orgaan.

![Screenshot 2024-10-11 at 10 24 25](https://github.com/user-attachments/assets/f0be7a2f-15a9-4f8a-a0f8-90f491683c9c)

## How to test

Check if you don't have to many bestuursorganen when trying to create a mandataris from the person page.
