### PR TITLE
Lmb 812 hide iv for districts

### DIFF
--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -32,7 +32,7 @@
               @showInfoText={{true}}
               @showBekijkBewijs={{true}}
             />
-            {{#unless this.isBekrachtigd}}
+            {{#if this.canEditPublicationStatus}}
               <AuButton
                 {{on "click" this.editStatus}}
                 @icon="pencil"
@@ -43,7 +43,7 @@
               >
                 edit
               </AuButton>
-            {{/unless}}
+            {{/if}}
           </div>
         {{/if}}
       </div>

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -33,6 +33,10 @@ export default class MandatarisCardComponent extends Component {
       : '';
   }
 
+  get canEditPublicationStatus() {
+    return !this.isBekrachtigd && !this.args.disableEdits;
+  }
+
   get persoon() {
     return this.args.mandataris.isBestuurlijkeAliasVan;
   }

--- a/app/components/shared/compact-menu.hbs
+++ b/app/components/shared/compact-menu.hbs
@@ -13,7 +13,7 @@
     <AuIcon @icon="user-fill" @alignment="left" />
     Mandatarissen
   </AuLink>
-  {{#if (is-feature-enabled "show-iv-module")}}
+  {{#if this.showLegislatuurModule}}
     <AuLink @route="verkiezingen.installatievergadering" role="menuitem">
       <AuIcon @icon="vote" @alignment="left" />
       Opstart nieuwe legislatuur

--- a/app/components/shared/compact-menu.js
+++ b/app/components/shared/compact-menu.js
@@ -1,22 +1,12 @@
 import Component from '@glimmer/component';
 
 import { service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 
 export default class SharedCompactMenuComponent extends Component {
   @service currentSession;
   @service features;
 
-  @tracked showLegislatuurModule;
-
-  constructor() {
-    super(...arguments);
-
-    this.showModules();
-  }
-
-  async showModules() {
-    this.showLegislatuurModule =
-      await this.currentSession.showLegislatuurModule();
+  get showLegislatuurModule() {
+    return this.currentSession.showLegislatuurModule;
   }
 }

--- a/app/components/shared/compact-menu.js
+++ b/app/components/shared/compact-menu.js
@@ -1,12 +1,22 @@
 import Component from '@glimmer/component';
 
 import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class SharedCompactMenuComponent extends Component {
   @service currentSession;
   @service features;
 
-  get showLegislatuurModule() {
-    return this.features.isEnabled('show-iv-module');
+  @tracked showLegislatuurModule;
+
+  constructor() {
+    super(...arguments);
+
+    this.showModules();
+  }
+
+  async showModules() {
+    this.showLegislatuurModule =
+      await this.currentSession.showLegislatuurModule();
   }
 }

--- a/app/components/shared/compact-menu.js
+++ b/app/components/shared/compact-menu.js
@@ -4,4 +4,9 @@ import { service } from '@ember/service';
 
 export default class SharedCompactMenuComponent extends Component {
   @service currentSession;
+  @service features;
+
+  get showLegislatuurModule() {
+    return this.features.isEnabled('show-iv-module');
+  }
 }

--- a/app/components/shared/main-menu.hbs
+++ b/app/components/shared/main-menu.hbs
@@ -15,7 +15,7 @@
         Mandatarissen
       </AuNavigationLink>
     </li>
-    {{#if (is-feature-enabled "show-iv-module")}}
+    {{#if this.showLegislatuurModule}}
       <li class="au-c-list-navigation__item">
         <AuNavigationLink @route="verkiezingen.installatievergadering">
           <AuIcon @icon="vote" @alignment="left" />

--- a/app/components/shared/main-menu.js
+++ b/app/components/shared/main-menu.js
@@ -1,22 +1,12 @@
 import Component from '@glimmer/component';
 
 import { service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 
 export default class SharedMainMenuComponent extends Component {
   @service currentSession;
   @service features;
 
-  @tracked showLegislatuurModule;
-
-  constructor() {
-    super(...arguments);
-
-    this.showModules();
-  }
-
-  async showModules() {
-    this.showLegislatuurModule =
-      await this.currentSession.showLegislatuurModule();
+  get showLegislatuurModule() {
+    return this.currentSession.showLegislatuurModule;
   }
 }

--- a/app/components/shared/main-menu.js
+++ b/app/components/shared/main-menu.js
@@ -4,4 +4,9 @@ import { service } from '@ember/service';
 
 export default class SharedMainMenuComponent extends Component {
   @service currentSession;
+  @service features;
+
+  get showLegislatuurModule() {
+    return this.features.isEnabled('show-iv-module');
+  }
 }

--- a/app/components/shared/main-menu.js
+++ b/app/components/shared/main-menu.js
@@ -1,12 +1,22 @@
 import Component from '@glimmer/component';
 
 import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class SharedMainMenuComponent extends Component {
   @service currentSession;
   @service features;
 
-  get showLegislatuurModule() {
-    return this.features.isEnabled('show-iv-module');
+  @tracked showLegislatuurModule;
+
+  constructor() {
+    super(...arguments);
+
+    this.showModules();
+  }
+
+  async showModules() {
+    this.showLegislatuurModule =
+      await this.currentSession.showLegislatuurModule();
   }
 }

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,12 +1,22 @@
 import Controller from '@ember/controller';
 
 import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class IndexController extends Controller {
   @service currentSession;
   @service features;
 
-  get showLegislatuurModule() {
-    return this.features.isEnabled('show-iv-module');
+  @tracked showLegislatuurModule;
+
+  constructor() {
+    super(...arguments);
+
+    this.showModules();
+  }
+
+  async showModules() {
+    this.showLegislatuurModule =
+      await this.currentSession.showLegislatuurModule();
   }
 }

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,22 +1,8 @@
 import Controller from '@ember/controller';
 
 import { service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 
 export default class IndexController extends Controller {
   @service currentSession;
   @service features;
-
-  @tracked showLegislatuurModule;
-
-  constructor() {
-    super(...arguments);
-
-    this.showModules();
-  }
-
-  async showModules() {
-    this.showLegislatuurModule =
-      await this.currentSession.showLegislatuurModule();
-  }
 }

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -5,4 +5,8 @@ import { service } from '@ember/service';
 export default class IndexController extends Controller {
   @service currentSession;
   @service features;
+
+  get showLegislatuurModule() {
+    return this.currentSession.showLegislatuurModule;
+  }
 }

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -5,4 +5,8 @@ import { service } from '@ember/service';
 export default class IndexController extends Controller {
   @service currentSession;
   @service features;
+
+  get showLegislatuurModule() {
+    return this.features.isEnabled('show-iv-module');
+  }
 }

--- a/app/controllers/mandatarissen/persoon/mandataris.js
+++ b/app/controllers/mandatarissen/persoon/mandataris.js
@@ -113,15 +113,12 @@ export default class MandatarissenPersoonMandatarisController extends Controller
   });
 
   get isDisabledBecauseLegislatuur() {
-    if (
+    return (
       this.periodeHasLegislatuur &&
       this.behandeldeVergaderingen &&
-      this.behandeldeVergaderingen.length === 0
-    ) {
-      return this.model.isDistrictEenheid ? false : true;
-    }
-
-    return false;
+      this.behandeldeVergaderingen.length === 0 &&
+      !this.model.isDistrictEenheid
+    );
   }
 
   get toolTipText() {

--- a/app/controllers/mandatarissen/persoon/mandataris.js
+++ b/app/controllers/mandatarissen/persoon/mandataris.js
@@ -118,7 +118,7 @@ export default class MandatarissenPersoonMandatarisController extends Controller
       this.behandeldeVergaderingen &&
       this.behandeldeVergaderingen.length === 0
     ) {
-      return true;
+      return this.model.isDistrictEenheid ? false : true;
     }
 
     return false;

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -9,10 +9,4 @@ export default class IndexRoute extends Route {
   async beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
   }
-
-  async model() {
-    return {
-      showLegislatuurModule: await this.currentSession.showLegislatuurModule(),
-    };
-  }
 }

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -3,9 +3,16 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
+  @service currentSession;
   @service session;
 
   async beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+  }
+
+  async model() {
+    return {
+      showLegislatuurModule: await this.currentSession.showLegislatuurModule(),
+    };
   }
 }

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -12,7 +12,6 @@ import RSVP from 'rsvp';
 export default class MandatarissenPersoonMandatarisRoute extends Route {
   @service currentSession;
   @service store;
-  @service currentSession;
 
   async model(params) {
     const bestuurseenheid = this.currentSession.group;

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -10,6 +10,7 @@ import {
 import RSVP from 'rsvp';
 
 export default class MandatarissenPersoonMandatarisRoute extends Route {
+  @service currentSession;
   @service store;
   @service currentSession;
 
@@ -31,6 +32,7 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
     const bestuursorganen = await (await mandataris.bekleedt).get('bevatIn');
     const selectedBestuursperiode =
       await bestuursorganen.firstObject.heeftBestuursperiode;
+    const isDistrict = await this.currentSession.isDistrict();
 
     return RSVP.hash({
       bestuurseenheid,
@@ -40,6 +42,7 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
       mandatarisExtraInfoForm,
       bestuursorganen,
       selectedBestuursperiode,
+      isDistrictEenheid: isDistrict,
     });
   }
 

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -32,7 +32,7 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
     const bestuursorganen = await (await mandataris.bekleedt).get('bevatIn');
     const selectedBestuursperiode =
       await bestuursorganen.firstObject.heeftBestuursperiode;
-    const isDistrict = await this.currentSession.isDistrict();
+    const isDistrict = this.currentSession.isDistrict;
 
     return RSVP.hash({
       bestuurseenheid,

--- a/app/routes/mandatarissen/search.js
+++ b/app/routes/mandatarissen/search.js
@@ -34,7 +34,7 @@ export default class MandatarissenSearchRoute extends Route {
       params.bestuursperiode
     );
 
-    const isDistrict = await this.currentSession.isDistrict();
+    const isDistrict = this.currentSession.isDistrict;
     // This map is made for disabling certain options in the powerselect
     const periodMap = await Promise.all(
       bestuursPeriods.map(async (period) => {

--- a/app/routes/mandatarissen/search.js
+++ b/app/routes/mandatarissen/search.js
@@ -9,6 +9,7 @@ import {
 } from 'frontend-lmb/utils/constants';
 
 export default class MandatarissenSearchRoute extends Route {
+  @service currentSession;
   @service store;
   @service bestuursperioden;
   @service fractieApi;
@@ -33,6 +34,7 @@ export default class MandatarissenSearchRoute extends Route {
       params.bestuursperiode
     );
 
+    const isDistrict = await this.currentSession.isDistrict();
     // This map is made for disabling certain options in the powerselect
     const periodMap = await Promise.all(
       bestuursPeriods.map(async (period) => {
@@ -46,7 +48,7 @@ export default class MandatarissenSearchRoute extends Route {
         ) {
           return { period, disabled: false };
         }
-        return { period, disabled: true };
+        return { period, disabled: isDistrict ? false : true };
       })
     );
 

--- a/app/routes/organen/fracties.js
+++ b/app/routes/organen/fracties.js
@@ -30,7 +30,7 @@ export default class FractiesRoute extends Route {
     const bestuursPeriods = await this.store.query('bestuursperiode', {
       sort: 'label',
       'filter[:has:heeft-bestuursorganen-in-tijd]': true,
-      include: 'installatievergaderingen',
+      include: 'installatievergaderingen,installatievergaderingen.status',
     });
 
     const filteredBestuursPeriods = (

--- a/app/routes/organen/index.js
+++ b/app/routes/organen/index.js
@@ -8,6 +8,7 @@ import { BESTUURSORGAAN_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import RSVP from 'rsvp';
 
 export default class OrganenIndexRoute extends Route {
+  @service currentSession;
   @service store;
   @service decretaleOrganen;
   @service bestuursperioden;
@@ -42,6 +43,7 @@ export default class OrganenIndexRoute extends Route {
     const form = await getFormFrom(this.store, BESTUURSORGAAN_FORM_ID);
     const legislatuurInBehandeling =
       await this.installatievergadering.activeOrNoLegislature(selectedPeriod);
+    const isDistrict = await this.currentSession.isDistrict();
 
     return RSVP.hash({
       bestuurseenheid: parentModel.bestuurseenheid,
@@ -49,7 +51,7 @@ export default class OrganenIndexRoute extends Route {
       form,
       bestuursPeriods,
       selectedPeriod,
-      legislatuurInBehandeling,
+      legislatuurInBehandeling: isDistrict ? false : legislatuurInBehandeling,
     });
   }
 

--- a/app/routes/organen/index.js
+++ b/app/routes/organen/index.js
@@ -43,7 +43,7 @@ export default class OrganenIndexRoute extends Route {
     const form = await getFormFrom(this.store, BESTUURSORGAAN_FORM_ID);
     const legislatuurInBehandeling =
       await this.installatievergadering.activeOrNoLegislature(selectedPeriod);
-    const isDistrict = await this.currentSession.isDistrict();
+    const isDistrict = this.currentSession.isDistrict;
 
     return RSVP.hash({
       bestuurseenheid: parentModel.bestuurseenheid,

--- a/app/routes/organen/orgaan/mandatarissen.js
+++ b/app/routes/organen/orgaan/mandatarissen.js
@@ -42,7 +42,7 @@ export default class OrganenMandatarissenRoute extends Route {
       await this.installatievergadering.activeOrNoLegislature(
         parentModel.selectedBestuursperiode
       );
-    const isDistrict = await this.currentSession.isDistrict();
+    const isDistrict = this.currentSession.isDistrict;
 
     return {
       bestuurseenheid,

--- a/app/routes/organen/orgaan/mandatarissen.js
+++ b/app/routes/organen/orgaan/mandatarissen.js
@@ -10,7 +10,6 @@ export default class OrganenMandatarissenRoute extends Route {
   @service currentSession;
   @service store;
   @service installatievergadering;
-  @service currentSession;
 
   queryParams = {
     activeOnly: { refreshModel: true },

--- a/app/routes/organen/orgaan/mandatarissen.js
+++ b/app/routes/organen/orgaan/mandatarissen.js
@@ -7,6 +7,7 @@ import { MANDATARIS_NEW_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import { foldMandatarisses } from 'frontend-lmb/utils/fold-mandatarisses';
 
 export default class OrganenMandatarissenRoute extends Route {
+  @service currentSession;
   @service store;
   @service installatievergadering;
   @service currentSession;
@@ -41,6 +42,7 @@ export default class OrganenMandatarissenRoute extends Route {
       await this.installatievergadering.activeOrNoLegislature(
         parentModel.selectedBestuursperiode
       );
+    const isDistrict = await this.currentSession.isDistrict();
 
     return {
       bestuurseenheid,
@@ -49,7 +51,7 @@ export default class OrganenMandatarissenRoute extends Route {
       selectedBestuursperiode: parentModel.selectedBestuursperiode,
       mandatarisNewForm: mandatarisNewForm,
       currentBestuursorgaan: currentBestuursorgaan,
-      legislatuurInBehandeling,
+      legislatuurInBehandeling: isDistrict ? false : legislatuurInBehandeling,
     };
   }
 

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -87,14 +87,18 @@ export default class CurrentSessionService extends Service {
     return this.roles.includes(role);
   }
 
-  async showLegislatuurModule() {
+  async isDistrict() {
     const classificatie = await this.group?.classificatie;
 
-    const isDistrict = classificatie
+    return classificatie
       ? classificatie.uri === BESTUURSEENHEID_CLASSIFICATIECODE_DISTRICT
       : false;
+  }
 
-    return this.features.isEnabled('show-iv-module') && !isDistrict;
+  async showLegislatuurModule() {
+    return (
+      this.features.isEnabled('show-iv-module') && !(await this.isDistrict())
+    );
   }
 
   get canAccessMandaat() {

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { setContext, setUser } from '@sentry/ember';
 import { SHOULD_ENABLE_SENTRY } from 'frontend-lmb/utils/sentry';
+import { BESTUURSEENHEID_CLASSIFICATIECODE_DISTRICT } from 'frontend-lmb/utils/well-known-uris';
 
 const MODULE = {
   MANDATENBEHEER: 'LoketLB-mandaatGebruiker',
@@ -16,6 +17,7 @@ export default class CurrentSessionService extends Service {
   @service session;
   @service store;
   @service impersonation;
+  @service features;
 
   @tracked account;
   @tracked user;
@@ -83,6 +85,16 @@ export default class CurrentSessionService extends Service {
 
   canAccess(role) {
     return this.roles.includes(role);
+  }
+
+  async showLegislatuurModule() {
+    const classificatie = await this.group?.classificatie;
+
+    const isDistrict = classificatie
+      ? classificatie.uri === BESTUURSEENHEID_CLASSIFICATIECODE_DISTRICT
+      : false;
+
+    return this.features.isEnabled('show-iv-module') && !isDistrict;
   }
 
   get canAccessMandaat() {

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -23,6 +23,7 @@ export default class CurrentSessionService extends Service {
   @tracked user;
   @tracked group;
   @tracked groupClassification;
+  @tracked isDistrict;
   @tracked roles = [];
 
   async load() {
@@ -44,6 +45,7 @@ export default class CurrentSessionService extends Service {
         reload: true,
       });
       this.groupClassification = await this.group.classificatie;
+      this.isDistrict = await this.isDistrictBestuurseenheid();
 
       this.setupSentrySession();
     }
@@ -87,7 +89,7 @@ export default class CurrentSessionService extends Service {
     return this.roles.includes(role);
   }
 
-  async isDistrict() {
+  async isDistrictBestuurseenheid() {
     const classificatie = await this.group?.classificatie;
 
     return classificatie
@@ -95,10 +97,8 @@ export default class CurrentSessionService extends Service {
       : false;
   }
 
-  async showLegislatuurModule() {
-    return (
-      this.features.isEnabled('show-iv-module') && !(await this.isDistrict())
-    );
+  get showLegislatuurModule() {
+    return this.features.isEnabled('show-iv-module') && !this.isDistrict;
   }
 
   get canAccessMandaat() {

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -41,7 +41,7 @@
           </:link>
         </LoketModuleCard>
       </li>
-      {{#if this.model.showLegislatuurModule}}
+      {{#if this.showLegislatuurModule}}
         <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
           <LoketModuleCard @icon="vote">
             <:title>Opstart nieuwe legislatuur</:title>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -41,7 +41,7 @@
           </:link>
         </LoketModuleCard>
       </li>
-      {{#if this.showLegislatuurModule}}
+      {{#if this.model.showLegislatuurModule}}
         <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
           <LoketModuleCard @icon="vote">
             <:title>Opstart nieuwe legislatuur</:title>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -41,7 +41,7 @@
           </:link>
         </LoketModuleCard>
       </li>
-      {{#if (is-feature-enabled "show-iv-module")}}
+      {{#if this.showLegislatuurModule}}
         <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
           <LoketModuleCard @icon="vote">
             <:title>Opstart nieuwe legislatuur</:title>

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -70,6 +70,7 @@
     <Mandatarissen::MandatarisCard
       @mandataris={{@model.mandataris}}
       @bestuursperiode={{@model.selectedBestuursperiode}}
+      @disableEdits={{this.isDisabledBecauseLegislatuur}}
     />
   </div>
 

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -6,6 +6,8 @@ export const BESTUURSEENHEID_CLASSIFICATIECODE_GEMEENTE =
   'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001';
 export const BESTUURSEENHEID_CLASSIFICATIECODE_OCMW =
   'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002';
+export const BESTUURSEENHEID_CLASSIFICATIECODE_DISTRICT =
+  'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003';
 export const MANDATARIS_VERHINDERD_STATE =
   'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/c301248f-0199-45ca-b3e5-4c596731d5fe';
 export const MANDATARIS_TITELVOEREND_STATE =


### PR DESCRIPTION
## Description

Districts should never see the legislatuur module., they prepare it in the normal interface.

## How to test

1. does not see the menu item (main and compact menu)
2. on mandataris search page the period is not disabled
3. on organen route the `beheer fracties` are enabled
4. the mandatarissen of 2025 - heden can be edited

When in another bestuurseenheid than district the legislatuur should work as before
