### PR TITLE
remove frontend code from mirroring and move it to the mandataris service

### DIFF
--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -109,9 +109,9 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   }
 
   async loadBurgemeesterPersoon() {
-    const burgemeesters = await this.burgemeesterMandate.bekleedDoor;
+    const burgemeesters = await this.burgemeesterMandate.bekleedDoor.reload();
     const voorzitterVastBureau =
-      await this.voorzitterVastBureauMandate.bekleedDoor;
+      await this.voorzitterVastBureauMandate.bekleedDoor.reload();
 
     const targetMandatarisses = [];
 
@@ -136,6 +136,7 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   }
 
   onUpdate = restartableTask(async (persoon) => {
+    await this.setup.perform();
     this.persoon = persoon;
     if (!this.targetMandatarisses) {
       return;

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -1,31 +1,19 @@
 import Component from '@glimmer/component';
 
-import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
-import { service } from '@ember/service';
 import { A } from '@ember/array';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 import { restartableTask, task } from 'ember-concurrency';
 
-import { getApplicationContextMetaTtl } from 'frontend-lmb/utils/form-context/application-context-meta-ttl';
 import { buildNewMandatarisSourceTtl } from 'frontend-lmb/utils/build-new-mandataris-source-ttl';
+import { getApplicationContextMetaTtl } from 'frontend-lmb/utils/form-context/application-context-meta-ttl';
+import { showErrorToast, showWarningToast } from 'frontend-lmb/utils/toasts';
 import {
   CBS_BESTUURSORGAAN_URI,
   GEMEENTERAAD_BESTUURSORGAAN_URI,
-  MANDAAT_LID_RMW_CODE,
-  MANDAAT_SCHEPEN_CODE,
-  MANDAAT_GEMEENTERAADSLID_CODE,
-  MANDAAT_VOORZITTER_GEMEENTERAAD_CODE,
-  MANDAAT_VOORZITTER_RMW_CODE,
-  MANDAAT_LID_VAST_BUREAU_CODE,
-  MANDAAT_VOORZITTER_VAST_BUREAU_CODE,
-  MANDAAT_BURGEMEESTER_CODE,
 } from 'frontend-lmb/utils/well-known-uris';
-import {
-  getDraftPublicationStatus,
-  getEffectiefStatus,
-} from 'frontend-lmb/utils/get-mandataris-status';
-import { showErrorToast, showWarningToast } from 'frontend-lmb/utils/toasts';
 
 const CREATE_MODE = 'create';
 

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -128,6 +128,7 @@ export default class PrepareLegislatuurSectionComponent extends Component {
     });
     this.bcsd.forceRecomputeBCSD();
     this.getMandatarissen.perform({ updated: true });
+    this.router.refresh(); // not doing this breaks burgemeester selector synchronization
   });
 
   async getBestuursorgaanMandatarissen(bestuursorgaan) {

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -107,6 +107,18 @@ export default class PrepareLegislatuurSectionComponent extends Component {
       return;
     }
 
+    const mandatarissenToSync = await this.getBestuursorgaanMandatarissen(
+      bestuursorgaanToSyncFrom
+    );
+
+    if (mandatarissenToSync.length == 0) {
+      showWarningToast(
+        this.toaster,
+        'Geen mandatarissen gevonden om over te nemen.'
+      );
+      return;
+    }
+
     await fetch(
       '/mandataris-api/installatievergadering-api/copy-gemeente-to-ocmw-draft',
       {


### PR DESCRIPTION
## Description
remove frontend code from mirroring and move it to the mandataris service

## How to test

- Add some mandataris instances to gemeente, CBS and aangewezen burgemeester
- Add some mandatarises (to be removed automatically) to ocmw, VB
- click 'neem over van' button in each OCMW organ
- see that the old mandataris instances have been removed (with tombstones). The new mandataris instances for the OCMW organs are created with fracties and beleidsdomeinen. Once the mandataris instances are fixed and the IV has been completed, the link is also made between these mandataris instances
- now remove the mayor and select a new one. This should still update all of his corresponding roles in the other organs

![image](https://github.com/user-attachments/assets/a1938c83-673d-4a2a-845b-fda3e269bbd7)


## Links to other PR's
requires the work done in the mandataris service
- https://github.com/lblod/mandataris-service/pull/50
