### PR TITLE
filter mandatarissen from non fake bestuursorganen

### DIFF
--- a/app/components/mandatarissen/mandaten-as-links.js
+++ b/app/components/mandatarissen/mandaten-as-links.js
@@ -16,6 +16,7 @@ export default class MandatarissenMandatenAsLinks extends Component {
       'filter[is-bestuurlijke-alias-van][:id:]': this.args.persoon.id,
       'filter[bekleedt][bevat-in][heeft-bestuursperiode][:id:]':
         this.args.bestuursperiode.id,
+      'filter[bekleedt][bevat-in][is-tijdsspecialisatie-van][:has-no:original-bestuurseenheid]': true,
       include: ['bekleedt', 'bekleedt.bestuursfunctie'].join(','),
     });
 

--- a/app/routes/mandatarissen/persoon/mandaten.js
+++ b/app/routes/mandatarissen/persoon/mandaten.js
@@ -53,6 +53,10 @@ export default class MandatarissenPersoonMandatenRoute extends Route {
           id: persoon.id,
         },
       },
+      // We have to check the original-bestuurseenheid instead of the following, because we don't have access to the
+      // type of the original-bestuursorgaan (other graph) and mu-auth needs the type to be able to check the filter.
+      // 'filter[bekleedt][bevat-in][:has-no:original-bestuursorgaan]': true,
+      'filter[bekleedt][bevat-in][is-tijdsspecialisatie-van][:has-no:original-bestuurseenheid]': true,
       include: [
         'is-bestuurlijke-alias-van',
         'bekleedt.bestuursfunctie',

--- a/app/routes/mandatarissen/search.js
+++ b/app/routes/mandatarissen/search.js
@@ -55,6 +55,7 @@ export default class MandatarissenSearchRoute extends Route {
     const allBestuurfunctieCodes = [];
     const mandatenVoorPeriode = await this.store.query('mandaat', {
       'filter[bevat-in][heeft-bestuursperiode][:id:]': selectedPeriod.id,
+      'filter[bevat-in][is-tijdsspecialisatie-van][:has-no:original-bestuurseenheid]': true,
       include: ['bevat-in', 'bevat-in.heeft-bestuursperiode'].join(','),
     });
     for (const mandaat of mandatenVoorPeriode) {
@@ -89,6 +90,7 @@ export default class MandatarissenSearchRoute extends Route {
       },
       'filter[bekleedt][bevat-in][heeft-bestuursperiode][:id:]':
         bestuursperiode.id,
+      'filter[bekleedt][bevat-in][is-tijdsspecialisatie-van][:has-no:original-bestuurseenheid]': true,
       include: [
         'is-bestuurlijke-alias-van',
         'bekleedt',


### PR DESCRIPTION
## Description

When fetching mandatarissen, only show mandatarissen of a non fake bestuursorgaan.

## How to test

You first have to create a few mandatarissen in the prepare legislature, be sure to create some in the OCMW as well.
Then you need to update the status of the installatievergadering to done.
Then you need to check the mandatarissen of 2025-heden and see the ocmw mandates don't show up.

The following, is what you should NOT see!
![Screenshot 2024-10-15 at 16 14 32](https://github.com/user-attachments/assets/3fecdf67-5c4a-489d-9a19-2da1ce0b1d3f)
