### PR TITLE
fix broken date conversion

### DIFF
--- a/app/utils/form-context/application-context-meta-ttl.js
+++ b/app/utils/form-context/application-context-meta-ttl.js
@@ -1,6 +1,5 @@
 import { EXT, LMB } from 'frontend-lmb/rdf/namespaces';
 import { NULL_DATE } from 'frontend-lmb/utils/constants';
-import moment from 'moment';
 
 // Expects bestuursorgaan in de tijd
 export const getApplicationContextMetaTtl = (bestuursorganen) => {
@@ -70,9 +69,7 @@ const getBestuursperiodeForBestuursorganen = (bestuursorganen) => {
     const bestuursorgaan = bestuursorganen.at(0);
 
     return {
-      startDate: new Date(
-        moment(bestuursorgaan.bindingStart).format('DD-MM-YYYY')
-      ),
+      startDate: bestuursorgaan.bindingStart,
       endDate: bestuursorgaan.bindingEinde ?? NULL_DATE,
     };
   }


### PR DESCRIPTION
## Description

The date validation mixed days and months.
If you have the latest version of the app (with the migration that correctly sets the bestuurorgaan in de tijd starts at 4 December), you should now get validations that check on 4 December instead of 12 April.

## How to test

Go to prepare legislature add some mandatees and play around with the dates.