### PR TITLE
lmb-909: hide publication status when eigen orgaan

### DIFF
--- a/app/components/organen/mandataris-table.hbs
+++ b/app/components/organen/mandataris-table.hbs
@@ -43,11 +43,13 @@
         @currentSorting={{@sort}}
         @label="Einde mandaat"
       />
-      <AuDataTableThSortable
-        @field="publicationStatus"
-        @currentSorting={{@sort}}
-        @label="Publicatie Status"
-      />
+      {{#unless @hidePublicationStatus}}
+        <AuDataTableThSortable
+          @field="publicationStatus"
+          @currentSorting={{@sort}}
+          @label="Publicatie Status"
+        />
+      {{/unless}}
     </c.header>
 
     <c.body as |row|>
@@ -89,13 +91,14 @@
         {{moment-format row.foldedStart "DD-MM-YYYY"}}</td>
       <td class={{if (is-in-past row.foldedEnd) "au-u-muted"}}>
         {{moment-format row.foldedEnd "DD-MM-YYYY"}}</td>
-      <td>
-        <Mandaat::PublicatieStatusPill
-          @mandataris={{row.mandataris}}
-          @showBekijkBewijs={{false}}
-        />
-      </td>
-
+      {{#unless @hidePublicationStatus}}
+        <td>
+          <Mandaat::PublicatieStatusPill
+            @mandataris={{row.mandataris}}
+            @showBekijkBewijs={{false}}
+          />
+        </td>
+      {{/unless}}
     </c.body>
   </t.content>
 </AuDataTable>

--- a/app/templates/organen/orgaan/mandatarissen.hbs
+++ b/app/templates/organen/orgaan/mandatarissen.hbs
@@ -50,6 +50,7 @@
   @size={{this.size}}
   @personRoute="mandatarissen.persoon.mandaten"
   @mandaatRoute="mandatarissen.persoon.mandataris"
+  @hidePublicationStatus={{(not (await this.model.bestuursorgaan.isDecretaal))}}
 />
 
 {{outlet}}


### PR DESCRIPTION
## Description

We should hide the publication status column when the orgaan is created by a person. All others should show the column on the mandatarissen overview of the orgaan

## How to test

1. Go to an orgaan mandatarissen overview
2. The publication status should be there
3. Create a new orgaan 
4. The column should be hidden

## Attachements

**EIGEN orgaan**
![image](https://github.com/user-attachments/assets/a00a877e-0ad1-4a73-a36f-90b965260bb3)

![image](https://github.com/user-attachments/assets/cea24382-435a-4c5d-962c-ed62fabdeffc)

