### PR TITLE
Lmb 799 fix inconsistencies update state en corrigeer fouten forms

### DIFF
--- a/app/components/date-input.hbs
+++ b/app/components/date-input.hbs
@@ -14,6 +14,11 @@
     {{au-inputmask options=(hash mask="99-99-9999" placeholder="_")}}
     {{on "input" (perform this.onChange)}}
   />
+  {{#unless @showFormatHelpText}}
+    <AuHelpText @error={{(or this.errorMessage this.invalidErrorMessage)}}>
+      Datum formaat: DD-MM-JJJJ
+    </AuHelpText>
+  {{/unless}}
 
   {{#if (or this.errorMessage this.invalidErrorMessage)}}
     <AuHelpText @error={{true}}>{{this.errorMessages}}</AuHelpText>

--- a/app/components/date-input.hbs
+++ b/app/components/date-input.hbs
@@ -16,17 +16,6 @@
   />
 
   {{#if (or this.errorMessage this.invalidErrorMessage)}}
-    {{#if @showErrorAsAlert}}
-      <AuAlert
-        @size="small"
-        @closable={{false}}
-        @skin="error"
-        class="au-u-margin-top"
-      >
-        {{this.errorMessages}}
-      </AuAlert>
-    {{else}}
-      <AuHelpText @error={{true}}>{{this.errorMessages}}</AuHelpText>
-    {{/if}}
+    <AuHelpText @error={{true}}>{{this.errorMessages}}</AuHelpText>
   {{/if}}
 </div>

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -33,7 +33,6 @@
         @from={{this.bestuursorgaanStartDate}}
         @to={{this.bestuursorgaanEndDate}}
         @onChange={{fn (mut this.date)}}
-        @showErrorAsAlert={{true}}
         @isRequired={{true}}
       />
     </div>

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -37,7 +37,7 @@
       />
     </div>
     <div>
-      <AuLabel>
+      <AuLabel @required={{true}}>
         Nieuwe Status
       </AuLabel>
       <PowerSelect
@@ -78,7 +78,7 @@
         </div>
       {{/if}}
       <div>
-        <AuLabel>
+        <AuLabel @required={{true}}>
           Fractie
         </AuLabel>
         {{#if this.load.isRunning}}

--- a/app/components/rdf-input-fields/rdf-date-input.hbs
+++ b/app/components/rdf-input-fields/rdf-date-input.hbs
@@ -11,13 +11,8 @@
   @isRequired={{this.isRequired}}
   @from={{this.from}}
   @to={{this.to}}
+  @showFormatHelpText={{@show}}
 />
-
-{{#unless @show}}
-  <AuHelpText @error={{this.hasErrors}}>
-    Datum formaat: DD-MM-JJJJ
-  </AuHelpText>
-{{/unless}}
 
 {{#each this.errors as |error|}}
   <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>

--- a/app/components/rdf-input-fields/rdf-date-input.hbs
+++ b/app/components/rdf-input-fields/rdf-date-input.hbs
@@ -8,7 +8,6 @@
   @id={{this.inputId}}
   @value={{this.date}}
   @onChange={{this.onUpdate}}
-  @showErrorAsAlert={{false}}
   @isRequired={{this.isRequired}}
   @from={{this.from}}
   @to={{this.to}}

--- a/app/components/verkiezingen/generate-rows-form.hbs
+++ b/app/components/verkiezingen/generate-rows-form.hbs
@@ -21,7 +21,6 @@
   @from={{@startDate}}
   @to={{@endDate}}
   @onChange={{fn (mut this.startDate)}}
-  @showErrorAsAlert={{false}}
   @isRequired={{true}}
 />
 <DateInput
@@ -31,7 +30,6 @@
   @from={{@startDate}}
   @to={{@endDate}}
   @onChange={{fn (mut this.endDate)}}
-  @showErrorAsAlert={{false}}
 />
 <AuLabel class="au-u-margin-top" for="input">Aantal rijen</AuLabel>
 <AuInput


### PR DESCRIPTION
## Description

We want the wijzig mandataris and the corrigeer mandataris form to react and look as good as identical.

- Date input errors are shown as alerts in update-state
- No help text under the date input of update-state
- Status must have the **verplicht** plaque next to the label
- Fractie selector does not show **Verplicht** (field cannot be empty but also change it i assume for the looks)

## How to test

1. Fill in an invalid date in the wijzig mandataris modal date input and it should show the error as text
2. The helptext of the date should always be under the date input with the same value as the correct forms
3. Status selector should have required plaque
4. Fractie selector should have required plaque

## Attachments

![image](https://github.com/user-attachments/assets/18a722d2-699d-4454-ba70-9b87e93131dc)

// Helptext always shown
![image](https://github.com/user-attachments/assets/bc0d3dc6-b125-4f43-a0ec-730c454c038f)
