### PR TITLE
lmb-543: Modal info is reset when creating mandataris from orgaan

### DIFF
--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -41,10 +41,11 @@ export default class MandatarissenPersoonMandatenController extends Controller {
 
   @action
   createMandataris() {
-    this.toggleModal();
+    const bestuursorgaan = this.selectedBestuursorgaan;
+    this.closeModal();
     this.router.transitionTo(
       'organen.orgaan.mandataris.new',
-      this.selectedBestuursorgaan.id,
+      bestuursorgaan.id,
       { queryParams: { person: this.model.persoon.id } }
     );
   }


### PR DESCRIPTION
## Description

When going to mandatarissen>persoon>mandaten and pressing the add butto. When selecting the orgaan option and than cancelling the input data is reset. But when pressing create of the mandataris than going back to the modal it shows the last set value.

## How to test

1.go to mandatarissen>persoon>mandaten
2. Add mandaat and create mandataris (you can just cancel when going the route has switched to the separate page)
3. open the modal again and no option should be selected

## Attachments

PREVIOUS 
[Screencast_20241018_095714.webm](https://github.com/user-attachments/assets/6693d8f7-1bab-4cf7-8bed-96176f5ca9f4)

NOW
[Screencast_20241018_095824.webm](https://github.com/user-attachments/assets/9ba058cf-1f8b-4f46-aafe-dc89c9d8603c)
