### PR TITLE
Fix disabled bestuursperiode if iv already behandeld

### DIFF
--- a/app/models/installatievergadering.js
+++ b/app/models/installatievergadering.js
@@ -1,6 +1,7 @@
 import Model, { belongsTo } from '@ember-data/model';
 
 import { INSTALLATIEVERGADERING_TE_BEHANDELEN } from 'frontend-lmb/utils/well-known-ids';
+import { INSTALLATIEVERGADERING_BEHANDELD_STATUS } from 'frontend-lmb/utils/well-known-uris';
 
 export default class InstallatievergaderingModel extends Model {
   @belongsTo('installatievergadering-status', {
@@ -23,5 +24,8 @@ export default class InstallatievergaderingModel extends Model {
 
   get teBehandelen() {
     return this.status.id == INSTALLATIEVERGADERING_TE_BEHANDELEN;
+  }
+  get isBehandeld() {
+    return this.status.get('uri') === INSTALLATIEVERGADERING_BEHANDELD_STATUS;
   }
 }

--- a/app/routes/mandatarissen/search.js
+++ b/app/routes/mandatarissen/search.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { INSTALLATIEVERGADERING_BEHANDELD_STATUS } from 'frontend-lmb/utils/well-known-uris';
 import {
   placeholderNietBeschikbaar,
   placeholderOnafhankelijk,
@@ -28,6 +27,10 @@ export default class MandatarissenSearchRoute extends Route {
   async model(params) {
     const bestuursPeriods = await this.store.query('bestuursperiode', {
       sort: 'label',
+      include: [
+        'installatievergaderingen',
+        'installatievergaderingen.status',
+      ].join(','),
     });
     let selectedPeriod = this.bestuursperioden.getRelevantPeriod(
       bestuursPeriods,
@@ -42,10 +45,8 @@ export default class MandatarissenSearchRoute extends Route {
         if (ivs.length < 1) {
           return { period, disabled: false };
         }
-        if (
-          ivs.at(0).get('status').get('uri') ==
-          INSTALLATIEVERGADERING_BEHANDELD_STATUS
-        ) {
+        const isBehandeld = await ivs.at(0).isBehandeld;
+        if (isBehandeld) {
           return { period, disabled: false };
         }
         return { period, disabled: isDistrict ? false : true };


### PR DESCRIPTION
## Description

If you put on installatievergadering on behandeld. And then went to the mandatarissen search page, the bestuursperiodes did not always correctly show, often you still saw the following, even if the iv was actually behandeld.

<img width="320" alt="Screenshot 2024-10-20 at 22 28 12" src="https://github.com/user-attachments/assets/ff0de3dd-164f-4523-aa36-9e798c7b8164">


## How to test

Set an iv to behandeld and check if the bestuursperiode selector in the mandataris serach allows you to select the bestuursperiode 2024 - heden
