### PR TITLE
lmb-949: add extra check for serial part of rrn

### DIFF
--- a/app/utils/form-validations/rijksregisternummer.js
+++ b/app/utils/form-validations/rijksregisternummer.js
@@ -19,6 +19,11 @@ export function isValidRijksregisternummer(nrn) {
     return false;
   }
   const { birthDate, serial, checksum } = parse(nrn);
+
+  if (!serialOfRrnIsInRange(serial)) {
+    return false;
+  }
+
   const preNillies =
     parseInt(checksum) === parseInt(mod97(`${birthDate.join('')}${serial}`));
   const postNillies =
@@ -27,7 +32,13 @@ export function isValidRijksregisternummer(nrn) {
   return preNillies || postNillies;
 }
 
-export function getBirthDay(birthDate) {
+function serialOfRrnIsInRange(serial) {
+  // https://nl.wikipedia.org/wiki/Rijksregisternummer
+  const serialAsInt = parseInt(serial, 10);
+  return serialAsInt >= parseInt('001', 10) && serialAsInt <= 998;
+}
+
+function getBirthDay(birthDate) {
   return birthDate[2];
 }
 


### PR DESCRIPTION
## Description

We need to check if the serial part of rrn is between 001 and 998

## How to test

1. Fill in this rrn with serial part 000 and it should not be a valid rrn. `06.02.02-000.80`
2. When running the test suit of with flag `-f="RRN helpers" it should pass instead of fail now

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/379