### PR TITLE
Lmb 841 | banner for correct and wijzig mandataris

### DIFF
--- a/app/controllers/mandatarissen/persoon/mandataris.js
+++ b/app/controllers/mandatarissen/persoon/mandataris.js
@@ -128,7 +128,16 @@ export default class MandatarissenPersoonMandatarisController extends Controller
     if (!this.model.mandataris.isActive) {
       return 'Het is niet mogelijk de status van een afgelopen mandaat aan te passen.';
     }
-    return '';
+
+    return 'Dit zal een nieuw mandaat starten met de gewijzigde situatie';
+  }
+
+  get toolTipTextCorrecting() {
+    if (this.isDisabledBecauseLegislatuur) {
+      return 'Tijdens het voorbereiden van een legislatuur is het niet mogelijk een mandaat in die legislatuur te bewerken.';
+    }
+
+    return 'Om fouten te corrigeren, bijvoorbeeld een typefout';
   }
 
   get warningTextOCMWLinkToGemeente() {

--- a/app/controllers/mandatarissen/persoon/mandataris.js
+++ b/app/controllers/mandatarissen/persoon/mandataris.js
@@ -130,4 +130,11 @@ export default class MandatarissenPersoonMandatarisController extends Controller
     }
     return '';
   }
+
+  get warningTextOCMWLinkToGemeente() {
+    return `Let op! Bij het wijzigen van deze gegevens worden mogelijke koppelingen
+      verbroken. Het doorstromen van gegevens van de gemeente naar OCMW zal
+      hierdoor ook niet meer gebeuren. Om een wijziging aan beide mandaten te
+      maken, gelieve dit te doen bij de Gemeente.`;
+  }
 }

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -28,7 +28,10 @@
           @tooltipText={{this.toolTipText}}
         >
           <Shared::Tooltip
-            @showTooltip={{(not this.isDisabledBecauseLegislatuur)}}
+            @showTooltip={{(or
+              (not this.isDisabledBecauseLegislatuur)
+              this.model.mandataris.isActive
+            )}}
             @tooltipText="Dit zal een nieuw mandaat starten met de gewijzigde situatie"
           >
             <AuButton

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -21,43 +21,27 @@
     >
       <AuButtonGroup class="au-u-flex--spaced-small">
         <Shared::Tooltip
-          @showTooltip={{(or
-            (not this.model.mandataris.isActive)
-            this.isDisabledBecauseLegislatuur
-          )}}
+          @showTooltip={{true}}
           @tooltipText={{this.toolTipText}}
         >
-          <Shared::Tooltip
-            @showTooltip={{(or
-              (not this.isDisabledBecauseLegislatuur)
-              this.model.mandataris.isActive
+          <AuButton
+            @disabled={{(or
+              (not this.model.mandataris.isActive)
+              this.isDisabledBecauseLegislatuur
             )}}
-            @tooltipText="Dit zal een nieuw mandaat starten met de gewijzigde situatie"
-          >
-            <AuButton
-              @disabled={{(or
-                (not this.model.mandataris.isActive)
-                this.isDisabledBecauseLegislatuur
-              )}}
-              {{on "click" (fn (mut this.isChanging) true)}}
-            >Wijzig huidig mandaat</AuButton>
-          </Shared::Tooltip>
+            {{on "click" (fn (mut this.isChanging) true)}}
+          >Wijzig huidig mandaat</AuButton>
         </Shared::Tooltip>
         <Shared::Tooltip
-          @showTooltip={{this.isDisabledBecauseLegislatuur}}
-          @tooltipText={{this.toolTipText}}
+          @showTooltip={{true}}
+          @tooltipText={{this.toolTipTextCorrecting}}
         >
-          <Shared::Tooltip
-            @showTooltip={{(not this.isDisabledBecauseLegislatuur)}}
-            @tooltipText="Om fouten te corrigeren, bijvoorbeeld een typefout"
-          >
-            <AuButton
-              @alert={{true}}
-              @skin="secondary"
-              @disabled={{this.isDisabledBecauseLegislatuur}}
-              {{on "click" (fn (mut this.isCorrecting) true)}}
-            >Corrigeer fouten</AuButton>
-          </Shared::Tooltip>
+          <AuButton
+            @alert={{true}}
+            @skin="secondary"
+            @disabled={{this.isDisabledBecauseLegislatuur}}
+            {{on "click" (fn (mut this.isCorrecting) true)}}
+          >Corrigeer fouten</AuButton>
         </Shared::Tooltip>
       </AuButtonGroup>
     </div>

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -27,41 +27,40 @@
           )}}
           @tooltipText={{this.toolTipText}}
         >
-          <AuButton
-            @disabled={{(or
-              (not this.model.mandataris.isActive)
-              this.isDisabledBecauseLegislatuur
-            )}}
-            {{on "click" (fn (mut this.isChanging) true)}}
-          >Wijzig huidig mandaat</AuButton>
+          <Shared::Tooltip
+            @showTooltip={{(not this.isDisabledBecauseLegislatuur)}}
+            @tooltipText="Dit zal een nieuw mandaat starten met de gewijzigde situatie"
+            @alignment="left"
+          >
+            <AuButton
+              @disabled={{(or
+                (not this.model.mandataris.isActive)
+                this.isDisabledBecauseLegislatuur
+              )}}
+              {{on "click" (fn (mut this.isChanging) true)}}
+            >Wijzig huidig mandaat</AuButton>
+          </Shared::Tooltip>
         </Shared::Tooltip>
         <Shared::Tooltip
           @showTooltip={{this.isDisabledBecauseLegislatuur}}
           @tooltipText={{this.toolTipText}}
           @alignment="right"
         >
-          <AuButton
-            @alert={{true}}
-            @skin="secondary"
-            @disabled={{this.isDisabledBecauseLegislatuur}}
-            {{on "click" (fn (mut this.isCorrecting) true)}}
-          >Corrigeer fouten</AuButton>
+          <Shared::Tooltip
+            @showTooltip={{(not this.isDisabledBecauseLegislatuur)}}
+            @tooltipText="Om fouten te corrigeren, bijvoorbeeld een typefout, ..."
+            @alignment="right"
+          >
+            <AuButton
+              @alert={{true}}
+              @skin="secondary"
+              @disabled={{this.isDisabledBecauseLegislatuur}}
+              {{on "click" (fn (mut this.isCorrecting) true)}}
+            >Corrigeer fouten</AuButton>
+          </Shared::Tooltip>
         </Shared::Tooltip>
       </AuButtonGroup>
     </div>
-    <AuAlert
-      @skin="info"
-      @icon="info-circle"
-      class="alert-grey-info-circle-icon"
-    >
-      Om een mandaat te bewerken, zoals een fractiewijziging, kies voor
-      <span class="au-u-medium">Wijzig huidig mandaat</span>. Dit zal een nieuw
-      mandaat starten met de gewijzigde situatie.
-      <br />
-      Om fouten te corrigeren, bijvoorbeeld een typefout of een foutieve
-      startdatum, kies voor
-      <span class="au-u-medium">Corrigeer fouten</span>.
-    </AuAlert>
   </div>
 </div>
 
@@ -114,7 +113,7 @@
   >
     <p><span class="au-u-medium">Wijzig mandataris</span>
       wordt gebruikt om bijvoorbeeld de fractie te wijzigen of de status van de
-      mandataris aan te passen.Dit zal een nieuw mandaat starten met de
+      mandataris aan te passen. Dit zal een nieuw mandaat starten met de
       gewijzigde situatie.</p>
   </AuAlert>
   {{#if @model.bestuurseenheid.isOCMW}}

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -111,10 +111,10 @@
     @closable={{false}}
     class="au-u-margin-small"
   >
-    <p><span class="au-u-medium">Wijzig mandataris</span>
-      wordt gebruikt om bijvoorbeeld de fractie te wijzigen of de status van de
-      mandataris aan te passen. Dit zal een nieuw mandaat starten met de
-      gewijzigde situatie.</p>
+    <p><span class="au-u-medium">Wijzig huidig mandaat</span>
+      wordt gebruikt om bijvoorbeeld de fractie te wijzigen of de status van het
+      mandaat aan te passen. Dit zal een nieuw mandaat starten met de gewijzigde
+      situatie.</p>
   </AuAlert>
   {{#if @model.bestuurseenheid.isOCMW}}
     <AuAlert
@@ -124,9 +124,7 @@
       @size="small"
       class="au-u-margin-left-small au-u-margin-right-small au-u-margin-bottom-small"
     >
-      Let op! Gegevens die hier gewijzigd worden zullen niet doorgevoerd worden
-      in het gekoppelde gemeente mandaat. Om een wijziging aan beide mandaten te
-      maken, gelieve dit te doen bij de Gemeente.
+      {{this.warningTextOCMWLinkToGemeente}}
     </AuAlert>
   {{/if}}
 </Mandatarissen::UpdateState>
@@ -149,7 +147,8 @@
     <p><span class="au-u-medium">Corrigeer fouten</span>
       wordt gebruikt om bijvoorbeeld typfouten of een foutieve startdatum aan te
       passen. Voor alle andere mandaatwijzigingen, zoals fractiewijzigingen,
-      gebruik Wijzig huidige mandaat.</p>
+      gebruik
+      <span class="au-u-medium">Wijzig huidig mandaat</span>.</p>
   </AuAlert>
   {{#if @model.bestuurseenheid.isOCMW}}
     <AuAlert
@@ -159,9 +158,7 @@
       @size="small"
       class="au-u-margin-left-small au-u-margin-right-small au-u-margin-bottom-small"
     >
-      Let op! Gegevens die hier gewijzigd worden zullen niet doorgevoerd worden
-      in het gekoppelde gemeente mandaat. Om een wijziging aan beide mandaten te
-      maken, gelieve dit te doen bij de Gemeente.
+      {{this.warningTextOCMWLinkToGemeente}}
     </AuAlert>
   {{/if}}
   <div class="au-o-box">

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -46,7 +46,7 @@
         >
           <Shared::Tooltip
             @showTooltip={{(not this.isDisabledBecauseLegislatuur)}}
-            @tooltipText="Om fouten te corrigeren, bijvoorbeeld een typefout, ..."
+            @tooltipText="Om fouten te corrigeren, bijvoorbeeld een typefout"
           >
             <AuButton
               @alert={{true}}
@@ -142,8 +142,8 @@
     class="au-u-margin-small"
   >
     <p><span class="au-u-medium">Corrigeer fouten</span>
-      wordt gebruikt om bijvoorbeeld typfouten of een foutieve startdatum aan te
-      passen. Voor alle andere mandaatwijzigingen, zoals fractiewijzigingen,
+      wordt gebruikt om bijvoorbeeld typefouten of een foutieve startdatum aan
+      te passen. Voor alle andere mandaatwijzigingen, zoals fractiewijzigingen,
       gebruik
       <span class="au-u-medium">Wijzig huidig mandaat</span>.</p>
   </AuAlert>

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -105,6 +105,18 @@
   @onStateChanged={{this.onUpdateState}}
   @mandataris={{this.model.mandataris}}
 >
+  <AuAlert
+    @skin="info"
+    @icon="info-circle"
+    @size="small"
+    @closable={{false}}
+    class="au-u-margin-small"
+  >
+    <p><span class="au-u-medium">Wijzig mandataris</span>
+      wordt gebruikt om bijvoorbeeld de fractie te wijzigen of de status van de
+      mandataris aan te passen.Dit zal een nieuw mandaat starten met de
+      gewijzigde situatie.</p>
+  </AuAlert>
   {{#if @model.bestuurseenheid.isOCMW}}
     <AuAlert @skin="warning" @icon="alert-triangle" @closable={{false}}>
       Mandatarissen in het OCMW hebben vaak een corresponderend mandaat in de
@@ -126,6 +138,18 @@
   @closable={{true}}
   @closeModal={{this.closeModals}}
 >
+  <AuAlert
+    @skin="info"
+    @icon="info-circle"
+    @size="small"
+    @closable={{false}}
+    class="center-alert-icon au-u-margin-small"
+  >
+    <p><span class="au-u-medium">Corrigeer fouten</span>
+      wordt gebruikt om bijvoorbeeld typfouten of een foutieve startdatum aan te
+      passen. Voor alle andere mandaatwijzigingen, zoals fractiewijzigingen,
+      gebruik Wijzig huidige mandaat.</p>
+  </AuAlert>
   {{#if @model.bestuurseenheid.isOCMW}}
     <AuAlert @skin="warning" @icon="alert-triangle" @closable={{false}}>
       Mandatarissen in het OCMW hebben vaak een corresponderend mandaat in de

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -30,7 +30,6 @@
           <Shared::Tooltip
             @showTooltip={{(not this.isDisabledBecauseLegislatuur)}}
             @tooltipText="Dit zal een nieuw mandaat starten met de gewijzigde situatie"
-            @alignment="left"
           >
             <AuButton
               @disabled={{(or
@@ -44,12 +43,10 @@
         <Shared::Tooltip
           @showTooltip={{this.isDisabledBecauseLegislatuur}}
           @tooltipText={{this.toolTipText}}
-          @alignment="right"
         >
           <Shared::Tooltip
             @showTooltip={{(not this.isDisabledBecauseLegislatuur)}}
             @tooltipText="Om fouten te corrigeren, bijvoorbeeld een typefout, ..."
-            @alignment="right"
           >
             <AuButton
               @alert={{true}}

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -118,14 +118,16 @@
       gewijzigde situatie.</p>
   </AuAlert>
   {{#if @model.bestuurseenheid.isOCMW}}
-    <AuAlert @skin="warning" @icon="alert-triangle" @closable={{false}}>
-      Mandatarissen in het OCMW hebben vaak een corresponderend mandaat in de
-      gemeente. Indien aan deze mandataris een corresponderend mandaat gekoppeld
-      is in de gemeente zal je de koppeling breken door hier wijzigingen uit te
-      voeren, in dat geval moet je wijzigingen aan beide mandaten manueel
-      doorvoeren. Zijn ze gekoppeld en voeg je de wijzigingen uit in de
-      gemeente, dan zullen de wijzigingen ook uitgevoerd worden in het OCMW
-      (indien gewenst).
+    <AuAlert
+      @skin="warning"
+      @icon="alert-triangle"
+      @closable={{false}}
+      @size="small"
+      class="au-u-margin-left-small au-u-margin-right-small au-u-margin-bottom-small"
+    >
+      Let op! Gegevens die hier gewijzigd worden zullen niet doorgevoerd worden
+      in het gekoppelde gemeente mandaat. Om een wijziging aan beide mandaten te
+      maken, gelieve dit te doen bij de Gemeente.
     </AuAlert>
   {{/if}}
 </Mandatarissen::UpdateState>
@@ -143,7 +145,7 @@
     @icon="info-circle"
     @size="small"
     @closable={{false}}
-    class="center-alert-icon au-u-margin-small"
+    class="au-u-margin-small"
   >
     <p><span class="au-u-medium">Corrigeer fouten</span>
       wordt gebruikt om bijvoorbeeld typfouten of een foutieve startdatum aan te
@@ -151,14 +153,16 @@
       gebruik Wijzig huidige mandaat.</p>
   </AuAlert>
   {{#if @model.bestuurseenheid.isOCMW}}
-    <AuAlert @skin="warning" @icon="alert-triangle" @closable={{false}}>
-      Mandatarissen in het OCMW hebben vaak een corresponderend mandaat in de
-      gemeente. Indien aan deze mandataris een corresponderend mandaat gekoppeld
-      is in de gemeente zal je de koppeling breken door hier wijzigingen uit te
-      voeren, in dat geval moet je wijzigingen aan beide mandaten manueel
-      doorvoeren. Zijn ze gekoppeld en voeg je de wijzigingen uit in de
-      gemeente, dan zullen de wijzigingen ook uitgevoerd worden in het OCMW
-      (indien gewenst).
+    <AuAlert
+      @skin="warning"
+      @icon="alert-triangle"
+      @closable={{false}}
+      @size="small"
+      class="au-u-margin-left-small au-u-margin-right-small au-u-margin-bottom-small"
+    >
+      Let op! Gegevens die hier gewijzigd worden zullen niet doorgevoerd worden
+      in het gekoppelde gemeente mandaat. Om een wijziging aan beide mandaten te
+      maken, gelieve dit te doen bij de Gemeente.
     </AuAlert>
   {{/if}}
   <div class="au-o-box">


### PR DESCRIPTION
## Description

WE want the alert on the mandataris detail page to be removed. Add tooltips to wijzig and corrigeer button and show a small info alert in the modals.

## How to test

1. The alert should be removed on the madnataris detail page
2. When hovering over the buttons it should show a descriptive line of text
3. When opening the modal it should show an info alert with action dependend text
4. When mandataris is blokced because of IV the tooltips of IV are shown

## Attachments

Coming from 
![image](https://github.com/user-attachments/assets/aa31e2f1-0e29-4e9e-ae4f-db5e21494819)

Tooltips of IV shown instead of action of button
![image](https://github.com/user-attachments/assets/1297e470-93c6-4e92-9a69-be9196ee6ec4)


Clip of alerts
[alert_for_correct_action.webm](https://github.com/user-attachments/assets/399ccf9a-4e02-4f1a-ab10-86f76b88dec8)

