### PR TITLE
Ben/lmb 953 fix fractie selector v2

### DIFF
--- a/app/components/mandatarissen/fractie-selector.js
+++ b/app/components/mandatarissen/fractie-selector.js
@@ -84,7 +84,7 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
             );
         }
       } else if (
-        this.fractieOptions.length == 1 &&
+        this.fractieOptions.length > 1 ||
         this.fractieOptions.at(0).isOnafhankelijk
       ) {
         return;

--- a/app/components/mandatarissen/fractie-selector.js
+++ b/app/components/mandatarissen/fractie-selector.js
@@ -67,18 +67,38 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
         this.args.mandataris.id
       );
 
-      if (
-        this.fractieOptions.length <= 1 &&
-        this.fractieOptions.at(0).isSamenwerkingsverband
+      if (this.fractieOptions.length == 0) {
+        const currentFractie = await this.persoonApi.getCurrentFractie(
+          person.id,
+          this.args.bestuursperiode.id
+        );
+        if (currentFractie) {
+          this.fractieOptions = [currentFractie];
+          if (currentFractie.isOnafhankelijk) {
+            return;
+          }
+        } else {
+          this.fractieOptions =
+            await this.fractieApi.samenwerkingForBestuursperiode(
+              this.args.bestuursperiode.id
+            );
+        }
+      } else if (
+        this.fractieOptions.length == 1 &&
+        this.fractieOptions.at(0).isOnafhankelijk
       ) {
-        let onafhankelijkeFractie =
-          await this.fractieService.getOrCreateOnafhankelijkeFractie(
-            person,
-            this.bestuursorganen,
-            this.args.bestuurseenheid
-          );
-        this.fractieOptions = [...this.fractieOptions, onafhankelijkeFractie];
+        return;
       }
+
+      // If the onafhankelijke fractie was already present, we returned earlier,
+      // so now we can add a new onafhankelijke fractie
+      let onafhankelijkeFractie =
+        await this.fractieService.getOrCreateOnafhankelijkeFractie(
+          person,
+          this.bestuursorganen,
+          this.args.bestuurseenheid
+        );
+      this.fractieOptions = [...this.fractieOptions, onafhankelijkeFractie];
       return;
     }
 


### PR DESCRIPTION
## Description

In update state, the fractie selector sometimes errored if no the mandataris had no fractie selected. This should fix it.

## How to test

Go to some update state forms and see if it does not error. Certainly check a mandataris with fractie "Niet beschikbaar".