### PR TITLE
do not allow add/remove mandates at all

### DIFF
--- a/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
+++ b/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
@@ -73,36 +73,11 @@
             >
               Bewerk
             </AuButton>
-            {{#unless (await @bestuursorgaanIT.isDecretaal)}}
-              <AuButton
-                @skin="link"
-                @icon="bin"
-                @alert="true"
-                @loading={{(and
-                  (eq this.removingMandaatId mandaat.id)
-                  this.removeMandaat.isRunning
-                )}}
-                {{on "click" (perform this.removeMandaat mandaat)}}
-              >
-                Verwijder
-              </AuButton>
-            {{/unless}}
           {{/if}}
         </td>
       </c.body>
     </t.content>
   </AuDataTable>
-  <div class="au-u-margin-top">
-    {{#unless (await @bestuursorgaanIT.isDecretaal)}}
-      <AuButton
-        @disabled={{this.loadingBestuursfuncties}}
-        {{on "click" this.createNewMandaat}}
-        @icon="plus"
-      >
-        Voeg mandaat toe
-      </AuButton>
-    {{/unless}}
-  </div>
   {{yield}}
 </div>
 


### PR DESCRIPTION
## Description

As the list of mandates that can be added is too weird they don't want users to be able to add/remove mandates to organs at all for now
## How to test
![image](https://github.com/user-attachments/assets/9c197302-5cf9-42b2-8d78-a70125341ec6)

