### PR TITLE
Ben/lmb 730 bulk besluiten

### DIFF
--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -11,6 +11,7 @@ import {
 import { restartableTask, task, timeout } from 'ember-concurrency';
 
 import { INPUT_DEBOUNCE } from 'frontend-lmb/utils/constants';
+import { isValidUri } from 'frontend-lmb/utils/is-valid-uri';
 
 export default class MandatarissenMandatarisPublicationStatusSelectorComponent extends Component {
   @service store;
@@ -92,17 +93,10 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
     }
   }
 
-  isValidUri(inputValue) {
-    // eslint-disable-next-line no-useless-escape, prettier/prettier
-    const regex = '^(https?://|www\.)[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*(/.*)?$';
-    const uriRegex = new RegExp(regex);
-    return uriRegex.test(inputValue);
-  }
-
   setLinkTodecision = restartableTask(async (event) => {
     await timeout(INPUT_DEBOUNCE);
     this.linkToDecision = event.target?.value;
-    this.isInputLinkValid = this.isValidUri(this.linkToDecision);
+    this.isInputLinkValid = isValidUri(this.linkToDecision);
   });
 
   addDecisionToMandataris = task(async () => {

--- a/app/components/organen/bekrachtig-mandataris-table.hbs
+++ b/app/components/organen/bekrachtig-mandataris-table.hbs
@@ -8,7 +8,9 @@
 >
   <t.content as |c|>
     <c.header>
-      <th></th>
+      <th>
+        <AuCheckbox @checked={{false}} @onChange={{@checkAll}} />
+      </th>
       <AuDataTableThSortable
         @field="bekleedt.bestuursfunctie.label"
         @currentSorting={{@sort}}
@@ -54,7 +56,7 @@
     <c.body as |row|>
       <td>
         <AuCheckbox
-          @checked={{false}}
+          @checked={{@checkedByDefault}}
           @onChange={{fn @onCheck row.mandataris.id}}
         />
       </td>

--- a/app/components/organen/bekrachtig-mandataris-table.hbs
+++ b/app/components/organen/bekrachtig-mandataris-table.hbs
@@ -52,7 +52,12 @@
     </c.header>
 
     <c.body as |row|>
-      <td></td>
+      <td>
+        <AuCheckbox
+          @checked={{false}}
+          @onChange={{@onCheck row.mandataris.id}}
+        />
+      </td>
       <td>
         {{row.mandataris.bekleedt.bestuursfunctie.label}}
       </td>

--- a/app/components/organen/bekrachtig-mandataris-table.hbs
+++ b/app/components/organen/bekrachtig-mandataris-table.hbs
@@ -1,0 +1,87 @@
+<AuDataTable
+  @content={{@content}}
+  @noDataMessage="Geen mandatarissen gevonden"
+  @sort={{@sort}}
+  @page={{@page}}
+  @size={{@size}}
+  as |t|
+>
+  <t.content as |c|>
+    <c.header>
+      <th></th>
+      <AuDataTableThSortable
+        @field="bekleedt.bestuursfunctie.label"
+        @currentSorting={{@sort}}
+        @label="Mandaat"
+      />
+      <AuDataTableThSortable
+        @field="isBestuurlijkeAliasVan.gebruikteVoornaam"
+        @currentSorting={{@sort}}
+        @label="Voornaam"
+      />
+      <AuDataTableThSortable
+        @field="isBestuurlijkeAliasVan.achternaam"
+        @currentSorting={{@sort}}
+        @label="Familienaam"
+      />
+      <AuDataTableThSortable
+        @field="heeftLidmaatschap.binnenFractie.naam"
+        @currentSorting={{@sort}}
+        @label="Fractie"
+      />
+      <AuDataTableThSortable
+        @field="status.label"
+        @currentSorting={{@sort}}
+        @label="Status"
+      />
+      <AuDataTableThSortable
+        @field="start"
+        @currentSorting={{@sort}}
+        @label="Start mandaat"
+      />
+      <AuDataTableThSortable
+        @field="einde"
+        @currentSorting={{@sort}}
+        @label="Einde mandaat"
+      />
+      <AuDataTableThSortable
+        @field="publicationStatus"
+        @currentSorting={{@sort}}
+        @label="Publicatie Status"
+      />
+    </c.header>
+
+    <c.body as |row|>
+      <td></td>
+      <td>
+        {{row.mandataris.bekleedt.bestuursfunctie.label}}
+      </td>
+      <td>
+        {{row.mandataris.isBestuurlijkeAliasVan.gebruikteVoornaam}}
+      </td>
+      <td>
+        {{row.mandataris.isBestuurlijkeAliasVan.achternaam}}
+      </td>
+      <td>
+        <Mandaat::FoldedFracties
+          @persoon={{row.mandataris.isBestuurlijkeAliasVan}}
+          @bestuursperiode={{@bestuursperiode}}
+          @mandaat={{row.mandataris.bekleedt}}
+        />
+      </td>
+      <td>
+        <Mandaat::MandatarisStatusPill @mandataris={{row.mandataris}} />
+      </td>
+      <td class={{if (is-in-past row.foldedEnd) "au-u-muted"}}>
+        {{moment-format row.foldedStart "DD-MM-YYYY"}}</td>
+      <td class={{if (is-in-past row.foldedEnd) "au-u-muted"}}>
+        {{moment-format row.foldedEnd "DD-MM-YYYY"}}</td>
+      <td>
+        <Mandaat::PublicatieStatusPill
+          @mandataris={{row.mandataris}}
+          @showBekijkBewijs={{false}}
+        />
+      </td>
+    </c.body>
+  </t.content>
+</AuDataTable>

--- a/app/components/organen/bekrachtig-mandataris-table.hbs
+++ b/app/components/organen/bekrachtig-mandataris-table.hbs
@@ -55,7 +55,7 @@
       <td>
         <AuCheckbox
           @checked={{false}}
-          @onChange={{@onCheck row.mandataris.id}}
+          @onChange={{fn @onCheck row.mandataris.id}}
         />
       </td>
       <td>

--- a/app/components/organen/bekrachtig-mandataris-table.hbs
+++ b/app/components/organen/bekrachtig-mandataris-table.hbs
@@ -57,35 +57,35 @@
       <td>
         <AuCheckbox
           @checked={{@checkedByDefault}}
-          @onChange={{fn @onCheck row.mandataris.id}}
+          @onChange={{fn @onCheck row.id}}
         />
       </td>
       <td>
-        {{row.mandataris.bekleedt.bestuursfunctie.label}}
+        {{row.bekleedt.bestuursfunctie.label}}
       </td>
       <td>
-        {{row.mandataris.isBestuurlijkeAliasVan.gebruikteVoornaam}}
+        {{row.isBestuurlijkeAliasVan.gebruikteVoornaam}}
       </td>
       <td>
-        {{row.mandataris.isBestuurlijkeAliasVan.achternaam}}
+        {{row.isBestuurlijkeAliasVan.achternaam}}
       </td>
       <td>
-        <Mandaat::FoldedFracties
-          @persoon={{row.mandataris.isBestuurlijkeAliasVan}}
-          @bestuursperiode={{@bestuursperiode}}
-          @mandaat={{row.mandataris.bekleedt}}
-        />
+        {{if
+          row.heeftLidmaatschap.binnenFractie
+          row.heeftLidmaatschap.binnenFractie.naam
+          "Niet beschikbaar"
+        }}
       </td>
       <td>
-        <Mandaat::MandatarisStatusPill @mandataris={{row.mandataris}} />
+        <Mandaat::MandatarisStatusPill @mandataris={{row}} />
       </td>
-      <td class={{if (is-in-past row.foldedEnd) "au-u-muted"}}>
-        {{moment-format row.foldedStart "DD-MM-YYYY"}}</td>
-      <td class={{if (is-in-past row.foldedEnd) "au-u-muted"}}>
-        {{moment-format row.foldedEnd "DD-MM-YYYY"}}</td>
+      <td class={{if (is-in-past row.einde) "au-u-muted"}}>
+        {{moment-format row.start "DD-MM-YYYY"}}</td>
+      <td class={{if (is-in-past row.einde) "au-u-muted"}}>
+        {{moment-format row.einde "DD-MM-YYYY"}}</td>
       <td>
         <Mandaat::PublicatieStatusPill
-          @mandataris={{row.mandataris}}
+          @mandataris={{row}}
           @showBekijkBewijs={{false}}
         />
       </td>

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -36,7 +36,7 @@ export default class BulkBekrachtigingController extends Controller {
     this.modalOpen = false;
   }
 
-  get isDisabled() {
+  get openModalDisabled() {
     if (this.setSize == 0) {
       return true;
     }
@@ -68,7 +68,7 @@ export default class BulkBekrachtigingController extends Controller {
     this.linkToBesluit = link;
   }
 
-  get disabled() {
+  get executeDisabled() {
     if (!this.status) {
       return true;
     }

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class BulkBekrachtigingController extends Controller {}

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -48,6 +48,10 @@ export default class BulkBekrachtigingController extends Controller {
     this.status = status;
   }
 
+  get showLinkField() {
+    return this.status == 'Bekrachtigd' ? true : false;
+  }
+
   @action
   updateLink(event) {
     if (event && typeof event.preventDefault === 'function') {

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -14,6 +14,7 @@ export default class BulkBekrachtigingController extends Controller {
 
   checked = new Set();
   @tracked setSize = 0;
+  @tracked allChecked = false;
 
   get isDisabled() {
     if (this.setSize == 0) {
@@ -29,6 +30,16 @@ export default class BulkBekrachtigingController extends Controller {
     } else {
       this.checked.delete(mandataris);
       this.setSize -= 1;
+    }
+  }
+
+  @action checkAll(state) {
+    if (state) {
+      this.allChecked = true;
+      this.setSize = this.model.mandatarissen.length;
+    } else {
+      this.allChecked = false;
+      this.setSize = 0;
     }
   }
 

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -16,6 +16,18 @@ export default class BulkBekrachtigingController extends Controller {
   @tracked setSize = 0;
   @tracked allChecked = false;
 
+  @tracked modalOpen = false;
+
+  @action
+  openModal() {
+    this.modalOpen = true;
+  }
+
+  @action
+  closeModal() {
+    this.modalOpen = false;
+  }
+
   get isDisabled() {
     if (this.setSize == 0) {
       return true;
@@ -43,10 +55,16 @@ export default class BulkBekrachtigingController extends Controller {
     }
   }
 
+  @action setEffectief() {
+    this.mandatarisApi.bulkEffectief(Array.from(this.checked));
+    this.closeModal();
+  }
+
   @action bekrachtig() {
     this.mandatarisApi.bulkBekrachtig(
       Array.from(this.checked),
       'www.example.com'
     );
+    this.closeModal();
   }
 }

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -21,7 +21,7 @@ export default class BulkBekrachtigingController extends Controller {
   @tracked modalOpen = false;
 
   @tracked status;
-  @tracked statusOptions = ['effectief', 'bekrachtigd'];
+  @tracked statusOptions = ['Effectief', 'Bekrachtigd'];
 
   @tracked linkToBesluit;
   @tracked invalidLink = false;
@@ -84,20 +84,11 @@ export default class BulkBekrachtigingController extends Controller {
     }
   }
 
-  @action setEffectief() {
+  @action bulkEdit() {
     this.mandatarisApi.bulkSetPublicationStatus(
       Array.from(this.checked),
-      'effectief'
-    );
-    this.closeModal();
-    setTimeout(() => this.router.refresh(), 1000);
-  }
-
-  @action bekrachtig() {
-    this.mandatarisApi.bulkSetPublicationStatus(
-      Array.from(this.checked),
-      'bekrachtigd',
-      'www.example.com'
+      this.status,
+      this.linkToBesluit
     );
     this.closeModal();
     setTimeout(() => this.router.refresh(), 1000);

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -112,6 +112,7 @@ export default class BulkBekrachtigingController extends Controller {
       this.linkToBesluit
     );
     this.closeModal();
+    this.checked.clear();
     setTimeout(() => this.router.refresh(), 1000);
   }
 }

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { isValidUri } from 'frontend-lmb/utils/is-valid-uri';
 
 export default class BulkBekrachtigingController extends Controller {
   @service mandatarisApi;
@@ -19,6 +20,12 @@ export default class BulkBekrachtigingController extends Controller {
 
   @tracked modalOpen = false;
 
+  @tracked status;
+  @tracked statusOptions = ['effectief', 'bekrachtigd'];
+
+  @tracked linkToBesluit;
+  @tracked invalidLink = false;
+
   @action
   openModal() {
     this.modalOpen = true;
@@ -34,6 +41,27 @@ export default class BulkBekrachtigingController extends Controller {
       return true;
     }
     return false;
+  }
+
+  @action
+  updateStatus(status) {
+    this.status = status;
+  }
+
+  @action
+  updateLink(event) {
+    if (event && typeof event.preventDefault === 'function') {
+      event.preventDefault();
+    }
+    const link = event.target.value;
+
+    if (!isValidUri(link)) {
+      this.invalidLink = true;
+    } else {
+      this.invalidLink = false;
+    }
+
+    this.linkToBesluit = link;
   }
 
   @action checkBox(mandataris, state) {

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -9,7 +9,8 @@ export default class BulkBekrachtigingController extends Controller {
   @tracked page = 0;
   @tracked sort = 'is-bestuurlijke-alias-van.achternaam';
 
-  @action checkBox(mandataris) {
+  @action checkBox(mandataris, state) {
     console.log(mandataris);
+    console.log(state);
   }
 }

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -9,8 +9,13 @@ export default class BulkBekrachtigingController extends Controller {
   @tracked page = 0;
   @tracked sort = 'is-bestuurlijke-alias-van.achternaam';
 
+  checked = new Set();
+
   @action checkBox(mandataris, state) {
-    console.log(mandataris);
-    console.log(state);
+    if (state) {
+      this.checked.add(mandataris);
+    } else {
+      this.checked.delete(mandataris);
+    }
   }
 }

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -66,7 +66,7 @@ export default class BulkBekrachtigingController extends Controller {
   @action bekrachtig() {
     this.mandatarisApi.bulkSetPublicationStatus(
       Array.from(this.checked),
-      'bekrachtig',
+      'bekrachtigd',
       'www.example.com'
     );
     this.closeModal();

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -1,3 +1,10 @@
 import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
 
-export default class BulkBekrachtigingController extends Controller {}
+export default class BulkBekrachtigingController extends Controller {
+  queryParams = ['size', 'page', 'sort'];
+
+  @tracked size = 900000;
+  @tracked page = 0;
+  @tracked sort = 'is-bestuurlijke-alias-van.achternaam';
+}

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -68,6 +68,19 @@ export default class BulkBekrachtigingController extends Controller {
     this.linkToBesluit = link;
   }
 
+  get disabled() {
+    if (!this.status) {
+      return true;
+    }
+    if (
+      this.status == 'Bekrachtigd' &&
+      (!this.linkToBesluit || this.invalidLink)
+    ) {
+      return true;
+    }
+    return false;
+  }
+
   @action checkBox(mandataris, state) {
     if (state) {
       this.checked.add(mandataris);

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -5,6 +5,7 @@ import { service } from '@ember/service';
 
 export default class BulkBekrachtigingController extends Controller {
   @service mandatarisApi;
+  @service router;
 
   queryParams = ['size', 'page', 'sort'];
 
@@ -61,6 +62,7 @@ export default class BulkBekrachtigingController extends Controller {
       'effectief'
     );
     this.closeModal();
+    setTimeout(() => this.router.refresh(), 1000);
   }
 
   @action bekrachtig() {
@@ -70,5 +72,6 @@ export default class BulkBekrachtigingController extends Controller {
       'www.example.com'
     );
     this.closeModal();
+    setTimeout(() => this.router.refresh(), 1000);
   }
 }

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -1,8 +1,11 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 
 export default class BulkBekrachtigingController extends Controller {
+  @service mandatarisApi;
+
   queryParams = ['size', 'page', 'sort'];
 
   @tracked size = 900000;
@@ -10,12 +13,29 @@ export default class BulkBekrachtigingController extends Controller {
   @tracked sort = 'is-bestuurlijke-alias-van.achternaam';
 
   checked = new Set();
+  @tracked setSize = 0;
+
+  get isDisabled() {
+    if (this.setSize == 0) {
+      return true;
+    }
+    return false;
+  }
 
   @action checkBox(mandataris, state) {
     if (state) {
       this.checked.add(mandataris);
+      this.setSize += 1;
     } else {
       this.checked.delete(mandataris);
+      this.setSize -= 1;
     }
+  }
+
+  @action bekrachtig() {
+    this.mandatarisApi.bulkBekrachtig(
+      Array.from(this.checked),
+      'www.example.com'
+    );
   }
 }

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -94,9 +94,13 @@ export default class BulkBekrachtigingController extends Controller {
   @action checkAll(state) {
     if (state) {
       this.allChecked = true;
+      this.model.mandatarissen.forEach((mandataris) => {
+        this.checked.add(mandataris.id);
+      });
       this.setSize = this.model.mandatarissen.length;
     } else {
       this.allChecked = false;
+      this.checked.clear();
       this.setSize = 0;
     }
   }

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -56,13 +56,17 @@ export default class BulkBekrachtigingController extends Controller {
   }
 
   @action setEffectief() {
-    this.mandatarisApi.bulkEffectief(Array.from(this.checked));
+    this.mandatarisApi.bulkSetPublicationStatus(
+      Array.from(this.checked),
+      'effectief'
+    );
     this.closeModal();
   }
 
   @action bekrachtig() {
-    this.mandatarisApi.bulkBekrachtig(
+    this.mandatarisApi.bulkSetPublicationStatus(
       Array.from(this.checked),
+      'bekrachtig',
       'www.example.com'
     );
     this.closeModal();

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 export default class BulkBekrachtigingController extends Controller {
   queryParams = ['size', 'page', 'sort'];
@@ -7,4 +8,8 @@ export default class BulkBekrachtigingController extends Controller {
   @tracked size = 900000;
   @tracked page = 0;
   @tracked sort = 'is-bestuurlijke-alias-van.achternaam';
+
+  @action checkBox(mandataris) {
+    console.log(mandataris);
+  }
 }

--- a/app/controllers/organen/orgaan/mandatarissen.js
+++ b/app/controllers/organen/orgaan/mandatarissen.js
@@ -35,6 +35,10 @@ export default class OrganenMandatarissenController extends Controller {
     this.filter = searchData;
   });
 
+  get isDisabled() {
+    return this.model.legislatuurInBehandeling;
+  }
+
   @action
   setIsCreatingMandataris(toggleTo) {
     this.isCreatingMandataris = toggleTo;
@@ -67,9 +71,5 @@ export default class OrganenMandatarissenController extends Controller {
   @action
   toggleActiveOnly() {
     this.activeOnly = !this.activeOnly;
-  }
-
-  get toolTipText() {
-    return 'Het is niet mogelijk mandatarissen toe te voegen aan een bestuursperiode terwijl de voorbereiding van de legislatuur actief is.';
   }
 }

--- a/app/router.js
+++ b/app/router.js
@@ -32,6 +32,7 @@ Router.map(function () {
   this.route('organen', function () {
     this.route('orgaan', { path: '/:id' }, function () {
       this.route('mandatarissen');
+      this.route('bulk-bekrachtiging');
       this.route('mandataris', function () {
         this.route('new');
       });

--- a/app/routes/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/routes/organen/orgaan/bulk-bekrachtiging.js
@@ -1,13 +1,63 @@
 import Route from '@ember/routing/route';
 
+import { service } from '@ember/service';
+
+import { foldMandatarisses } from 'frontend-lmb/utils/fold-mandatarisses';
+
 export default class BulkBekrachtigingRoute extends Route {
-  async model() {
+  @service store;
+  @service installatievergadering;
+
+  queryParams = {
+    page: { refreshModel: true },
+    size: { refreshModel: true },
+    sort: { refreshModel: true },
+  };
+
+  async model(params) {
     const parentModel = this.modelFor('organen.orgaan');
     const currentBestuursorgaan = await parentModel.currentBestuursorgaan;
 
+    let mandatarissen;
+    if (currentBestuursorgaan) {
+      const options = this.getOptions(params, currentBestuursorgaan);
+
+      mandatarissen = await this.store.query('mandataris', options);
+    }
+    const folded = await foldMandatarisses(params, mandatarissen);
+
     return {
+      mandatarissen: folded,
       bestuursorgaan: parentModel.bestuursorgaan,
+      selectedBestuursperiode: parentModel.selectedBestuursperiode,
       currentBestuursorgaan: currentBestuursorgaan,
     };
+  }
+
+  getOptions(params, bestuursOrgaan) {
+    const queryParams = {
+      sort: params.sort,
+      page: {
+        number: params.page,
+        size: params.size,
+      },
+      filter: {
+        bekleedt: {
+          'bevat-in': {
+            id: bestuursOrgaan.id,
+          },
+        },
+        ':has:is-bestuurlijke-alias-van': true,
+      },
+      include: [
+        'is-bestuurlijke-alias-van',
+        'bekleedt.bestuursfunctie',
+        'heeft-lidmaatschap.binnen-fractie',
+        'status',
+        'publication-status',
+      ].join(','),
+    };
+
+    return queryParams;
   }
 }

--- a/app/routes/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/routes/organen/orgaan/bulk-bekrachtiging.js
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+
+export default class BulkBekrachtigingRoute extends Route {
+  async model() {
+    const parentModel = this.modelFor('organen.orgaan');
+    const currentBestuursorgaan = await parentModel.currentBestuursorgaan;
+
+    return {
+      bestuursorgaan: parentModel.bestuursorgaan,
+      currentBestuursorgaan: currentBestuursorgaan,
+    };
+  }
+}

--- a/app/routes/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/routes/organen/orgaan/bulk-bekrachtiging.js
@@ -2,8 +2,6 @@ import Route from '@ember/routing/route';
 
 import { service } from '@ember/service';
 
-import { foldMandatarisses } from 'frontend-lmb/utils/fold-mandatarisses';
-
 export default class BulkBekrachtigingRoute extends Route {
   @service store;
   @service installatievergadering;
@@ -24,10 +22,8 @@ export default class BulkBekrachtigingRoute extends Route {
 
       mandatarissen = await this.store.query('mandataris', options);
     }
-    const folded = await foldMandatarisses(params, mandatarissen);
-
     return {
-      mandatarissen: folded,
+      mandatarissen,
       bestuursorgaan: parentModel.bestuursorgaan,
       selectedBestuursperiode: parentModel.selectedBestuursperiode,
       currentBestuursorgaan: currentBestuursorgaan,
@@ -52,6 +48,7 @@ export default class BulkBekrachtigingRoute extends Route {
       include: [
         'is-bestuurlijke-alias-van',
         'bekleedt.bestuursfunctie',
+        'heeft-lidmaatschap',
         'heeft-lidmaatschap.binnen-fractie',
         'status',
         'publication-status',

--- a/app/services/mandataris-api.js
+++ b/app/services/mandataris-api.js
@@ -49,7 +49,7 @@ export default class MandatarisApiService extends Service {
     return jsonReponse.decisionUri;
   }
 
-  async bulkEffectief(mandatarissen) {
+  async bulkSetPublicationStatus(mandatarissen, status, decision) {
     const response = await fetch(
       `${API.MANDATARIS_SERVICE}/mandatarissen/bulk-set-publication-status`,
       {
@@ -58,32 +58,7 @@ export default class MandatarisApiService extends Service {
           'Content-Type': JSON_API_TYPE,
         },
         body: JSON.stringify({
-          status: 'effectief',
-          mandatarissen: mandatarissen,
-        }),
-      }
-    );
-    const jsonReponse = await response.json();
-
-    if (response.status !== STATUS_CODE.OK) {
-      console.error(jsonReponse.message);
-      throw {
-        status: response.status,
-        message: jsonReponse.message,
-      };
-    }
-  }
-
-  async bulkBekrachtig(mandatarissen, decision) {
-    const response = await fetch(
-      `${API.MANDATARIS_SERVICE}/mandatarissen/bulk-set-publication-status`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': JSON_API_TYPE,
-        },
-        body: JSON.stringify({
-          status: 'bekrachtig',
+          status: status,
           decision: decision,
           mandatarissen: mandatarissen,
         }),

--- a/app/services/mandataris-api.js
+++ b/app/services/mandataris-api.js
@@ -8,9 +8,11 @@ import {
   RESOURCE_CACHE_TIMEOUT,
   STATUS_CODE,
 } from 'frontend-lmb/utils/constants';
+import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
 
 export default class MandatarisApiService extends Service {
   @service store;
+  @service toaster;
 
   async copyOverNonDomainResourceProperties(oldMandatarisId, newMandatarisId) {
     const response = await fetch(
@@ -68,11 +70,15 @@ export default class MandatarisApiService extends Service {
 
     if (response.status !== STATUS_CODE.OK) {
       console.error(jsonReponse.message);
-      throw {
-        status: response.status,
-        message: jsonReponse.message,
-      };
+      showErrorToast(
+        this.toaster,
+        'Er ging iets mis bij het updaten van de publicatiestatussen'
+      );
     }
+    showSuccessToast(
+      this.toaster,
+      `De publicatiestatussen werden succesvol geüpdatet naar ${status}`
+    );
   }
 
   async getMandatarisFracties(mandatarisId) {

--- a/app/services/mandataris-api.js
+++ b/app/services/mandataris-api.js
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 import { timeout } from 'ember-concurrency';
 import {
   API,
+  JSON_API_TYPE,
   RESOURCE_CACHE_TIMEOUT,
   STATUS_CODE,
 } from 'frontend-lmb/utils/constants';
@@ -46,6 +47,31 @@ export default class MandatarisApiService extends Service {
     }
 
     return jsonReponse.decisionUri;
+  }
+
+  async bulkBekrachtig(mandatarissen, decision) {
+    const response = await fetch(
+      `${API.MANDATARIS_SERVICE}/mandatarissen/bulk-bekrachtig`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': JSON_API_TYPE,
+        },
+        body: JSON.stringify({
+          decision: decision,
+          mandatarissen: mandatarissen,
+        }),
+      }
+    );
+    const jsonReponse = await response.json();
+
+    if (response.status !== STATUS_CODE.OK) {
+      console.error(jsonReponse.message);
+      throw {
+        status: response.status,
+        message: jsonReponse.message,
+      };
+    }
   }
 
   async getMandatarisFracties(mandatarisId) {

--- a/app/services/mandataris-api.js
+++ b/app/services/mandataris-api.js
@@ -49,15 +49,41 @@ export default class MandatarisApiService extends Service {
     return jsonReponse.decisionUri;
   }
 
-  async bulkBekrachtig(mandatarissen, decision) {
+  async bulkEffectief(mandatarissen) {
     const response = await fetch(
-      `${API.MANDATARIS_SERVICE}/mandatarissen/bulk-bekrachtig`,
+      `${API.MANDATARIS_SERVICE}/mandatarissen/bulk-set-publication-status`,
       {
         method: 'POST',
         headers: {
           'Content-Type': JSON_API_TYPE,
         },
         body: JSON.stringify({
+          status: 'effectief',
+          mandatarissen: mandatarissen,
+        }),
+      }
+    );
+    const jsonReponse = await response.json();
+
+    if (response.status !== STATUS_CODE.OK) {
+      console.error(jsonReponse.message);
+      throw {
+        status: response.status,
+        message: jsonReponse.message,
+      };
+    }
+  }
+
+  async bulkBekrachtig(mandatarissen, decision) {
+    const response = await fetch(
+      `${API.MANDATARIS_SERVICE}/mandatarissen/bulk-set-publication-status`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': JSON_API_TYPE,
+        },
+        body: JSON.stringify({
+          status: 'bekrachtig',
           decision: decision,
           mandatarissen: mandatarissen,
         }),

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -18,7 +18,7 @@
     </AuButton>
   </Group>
 </AuToolbar>
-<AuHeading @skin="3" class="au-u-regular au-u-padding-left">
+<AuHeading @skin="3" class="au-u-regular au-u-padding-left au-u-padding-bottom">
   {{this.model.bestuursorgaan.naam}}
 </AuHeading>
 

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -84,11 +84,8 @@
     <AuToolbar class="au-u-margin-top" as |Group|>
       <Group>
         <AuButtonGroup>
-          <AuButton {{on "click" this.setEffectief}}>
-            Maak effectief
-          </AuButton>
-          <AuButton {{on "click" this.bekrachtig}}>
-            Bekrachtig
+          <AuButton {{on "click" this.bulkEdit}}>
+            Pas aan
           </AuButton>
           <AuButton {{on "click" this.closeModal}} @skin="secondary">
             Annuleer

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -29,6 +29,8 @@
   @page={{this.page}}
   @size={{this.size}}
   @onCheck={{this.checkBox}}
+  @checkAll={{this.checkAll}}
+  @checkedByDefault={{this.allChecked}}
 />
 
 {{outlet}}

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -64,23 +64,25 @@
         {{status}}
       </PowerSelect>
     </div>
-    <div>
-      <AuLabel for="link-to-page">Link naar besluit</AuLabel>
-      <AuInput
-        @error={{this.invalidLink}}
-        @width="block"
-        @iconAlignment="left"
-        value={{this.linkToBesluit}}
-        id="link-to-page"
-        placeholder="Link naar de besluitpagina"
-        {{on "input" this.updateLink}}
-      />
-      {{#if this.invalidLink}}
-        <AuHelpText @skin="secondary" @error={{true}}>
-          Vul een geldige url in, een url start met http://, https:// of www.
-        </AuHelpText>
-      {{/if}}
-    </div>
+    {{#if this.showLinkField}}
+      <div>
+        <AuLabel for="link-to-page">Link naar besluit</AuLabel>
+        <AuInput
+          @error={{this.invalidLink}}
+          @width="block"
+          @iconAlignment="left"
+          value={{this.linkToBesluit}}
+          id="link-to-page"
+          placeholder="Link naar de besluitpagina"
+          {{on "input" this.updateLink}}
+        />
+        {{#if this.invalidLink}}
+          <AuHelpText @skin="secondary" @error={{true}}>
+            Vul een geldige url in, een url start met http://, https:// of www.
+          </AuHelpText>
+        {{/if}}
+      </div>
+    {{/if}}
     <AuToolbar class="au-u-margin-top" as |Group|>
       <Group>
         <AuButtonGroup>

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -13,7 +13,10 @@
     </AuHeading>
   </Group>
   <Group>
-    <AuButton {{on "click" this.openModal}} @disabled={{this.isDisabled}}>
+    <AuButton
+      {{on "click" this.openModal}}
+      @disabled={{this.openModalDisabled}}
+    >
       Pas publicatiestatus aan
     </AuButton>
   </Group>
@@ -86,7 +89,10 @@
     <AuToolbar class="au-u-margin-top" as |Group|>
       <Group>
         <AuButtonGroup>
-          <AuButton {{on "click" this.bulkEdit}} @disabled={{this.disabled}}>
+          <AuButton
+            {{on "click" this.bulkEdit}}
+            @disabled={{this.executeDisabled}}
+          >
             Pas aan
           </AuButton>
           <AuButton {{on "click" this.closeModal}} @skin="secondary">

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -17,8 +17,12 @@
   {{this.model.bestuursorgaan.naam}}
 </AuHeading>
 
-<div class="au-o-box">
-  test
-</div>
+<Organen::BekrachtigMandatarisTable
+  @content={{@model.mandatarissen}}
+  @bestuursperiode={{@model.selectedBestuursperiode}}
+  @sort={{this.sort}}
+  @page={{this.page}}
+  @size={{this.size}}
+/>
 
 {{outlet}}

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -66,7 +66,7 @@
     </div>
     {{#if this.showLinkField}}
       <div>
-        <AuLabel for="link-to-page">Link naar besluit</AuLabel>
+        <AuLabel @required={{true}} for="link-to-page">Link naar besluit</AuLabel>
         <AuInput
           @error={{this.invalidLink}}
           @width="block"

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -12,6 +12,11 @@
       Bekrachtig Mandatarissen
     </AuHeading>
   </Group>
+  <Group>
+    <AuButton {{on "click" this.bekrachtig}} @disabled={{this.isDisabled}}>
+      Bekrachtig
+    </AuButton>
+  </Group>
 </AuToolbar>
 <AuHeading @skin="3" class="au-u-regular au-u-padding-left">
   {{this.model.bestuursorgaan.naam}}

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -1,0 +1,24 @@
+{{breadcrumb
+  "Bekrachtigen mandatarissen"
+  route="organen.orgaan.bulk-bekrachtiging"
+}}
+<AuToolbar
+  @size="large"
+  class="au-u-padding-bottom-none au-u-margin-bottom-none"
+  as |Group|
+>
+  <Group class="au-u-margin-bottom-none">
+    <AuHeading @skin="2">
+      Bekrachtig Mandatarissen
+    </AuHeading>
+  </Group>
+</AuToolbar>
+<AuHeading @skin="3" class="au-u-regular au-u-padding-left">
+  {{this.model.bestuursorgaan.naam}}
+</AuHeading>
+
+<div class="au-o-box">
+  test
+</div>
+
+{{outlet}}

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -13,8 +13,8 @@
     </AuHeading>
   </Group>
   <Group>
-    <AuButton {{on "click" this.bekrachtig}} @disabled={{this.isDisabled}}>
-      Bekrachtig
+    <AuButton {{on "click" this.openModal}} @disabled={{this.isDisabled}}>
+      Pas publicatiestatus aan
     </AuButton>
   </Group>
 </AuToolbar>
@@ -34,3 +34,30 @@
 />
 
 {{outlet}}
+
+<AuModal
+  @title="Pas publicatiestatus aan"
+  @modalOpen={{this.modalOpen}}
+  @closable={{true}}
+  @closeModal={{this.closeModal}}
+>
+  <AuAlert @skin="warning" @icon="alert-triangle" @closable={{false}}>
+    Indien je mandatarissen geselecteerd hebt die bekrachtigd zijn, deze kun je
+    niet terug aanpassen naar effectief.
+  </AuAlert>
+  <AuToolbar class="au-u-margin-top" as |Group|>
+    <Group>
+      <AuButtonGroup>
+        <AuButton {{on "click" this.setEffectief}}>
+          Maak effectief
+        </AuButton>
+        <AuButton {{on "click" this.bekrachtig}}>
+          Bekrachtig
+        </AuButton>
+        <AuButton {{on "click" this.closeModal}} @skin="secondary">
+          Annuleer
+        </AuButton>
+      </AuButtonGroup>
+    </Group>
+  </AuToolbar>
+</AuModal>

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -41,23 +41,28 @@
   @closable={{true}}
   @closeModal={{this.closeModal}}
 >
-  <AuAlert @skin="warning" @icon="alert-triangle" @closable={{false}}>
-    Indien je mandatarissen geselecteerd hebt die bekrachtigd zijn, deze kun je
-    niet terug aanpassen naar effectief.
-  </AuAlert>
-  <AuToolbar class="au-u-margin-top" as |Group|>
-    <Group>
-      <AuButtonGroup>
-        <AuButton {{on "click" this.setEffectief}}>
-          Maak effectief
-        </AuButton>
-        <AuButton {{on "click" this.bekrachtig}}>
-          Bekrachtig
-        </AuButton>
-        <AuButton {{on "click" this.closeModal}} @skin="secondary">
-          Annuleer
-        </AuButton>
-      </AuButtonGroup>
-    </Group>
-  </AuToolbar>
+  <div class="au-o-box au-o-flow">
+    <AuAlert @icon="info-circle" @closable={{false}}>
+      De publicatiestatus
+      <strong>bekrachtigd</strong>
+      is definitief. Indien je mandatarissen hebt geselecteerd met deze
+      publicatiestatus, het is niet mogelijk deze terug naar effectief te
+      zetten.
+    </AuAlert>
+    <AuToolbar class="au-u-margin-top" as |Group|>
+      <Group>
+        <AuButtonGroup>
+          <AuButton {{on "click" this.setEffectief}}>
+            Maak effectief
+          </AuButton>
+          <AuButton {{on "click" this.bekrachtig}}>
+            Bekrachtig
+          </AuButton>
+          <AuButton {{on "click" this.closeModal}} @skin="secondary">
+            Annuleer
+          </AuButton>
+        </AuButtonGroup>
+      </Group>
+    </AuToolbar>
+  </div>
 </AuModal>

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -86,7 +86,7 @@
     <AuToolbar class="au-u-margin-top" as |Group|>
       <Group>
         <AuButtonGroup>
-          <AuButton {{on "click" this.bulkEdit}}>
+          <AuButton {{on "click" this.bulkEdit}} @disabled={{this.disabled}}>
             Pas aan
           </AuButton>
           <AuButton {{on "click" this.closeModal}} @skin="secondary">

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -49,6 +49,38 @@
       publicatiestatus, het is niet mogelijk deze terug naar effectief te
       zetten.
     </AuAlert>
+    <div>
+      <AuLabel @required={{true}}>
+        Nieuwe publicatiestatus
+      </AuLabel>
+      <PowerSelect
+        @allowClear={{false}}
+        @selected={{this.status}}
+        @options={{this.statusOptions}}
+        @onChange={{this.updateStatus}}
+        @noMatchesMessage="Geen resultaten"
+        as |status|
+      >
+        {{status}}
+      </PowerSelect>
+    </div>
+    <div>
+      <AuLabel for="link-to-page">Link naar besluit</AuLabel>
+      <AuInput
+        @error={{this.invalidLink}}
+        @width="block"
+        @iconAlignment="left"
+        value={{this.linkToBesluit}}
+        id="link-to-page"
+        placeholder="Link naar de besluitpagina"
+        {{on "input" this.updateLink}}
+      />
+      {{#if this.invalidLink}}
+        <AuHelpText @skin="secondary" @error={{true}}>
+          Vul een geldige url in, een url start met http://, https:// of www.
+        </AuHelpText>
+      {{/if}}
+    </div>
     <AuToolbar class="au-u-margin-top" as |Group|>
       <Group>
         <AuButtonGroup>

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -23,6 +23,7 @@
   @sort={{this.sort}}
   @page={{this.page}}
   @size={{this.size}}
+  @onCheck={{this.checkBox}}
 />
 
 {{outlet}}

--- a/app/templates/organen/orgaan/mandatarissen.hbs
+++ b/app/templates/organen/orgaan/mandatarissen.hbs
@@ -10,13 +10,29 @@
     </AuHeading>
   </Group>
   <Group>
+    {{#if this.isDisabled}}
+      <Shared::Tooltip
+        @showTooltip={{true}}
+        @tooltipText="Het is niet mogelijk mandatarissen te bekrachtingen in een bestuursperiode waarvan de voorbereiding van de legislatuur nog actief is."
+      >
+        <AuButton @disabled={{true}}>
+          Bekrachtig mandatarissen
+        </AuButton>
+      </Shared::Tooltip>
+    {{else}}
+      <AuLink
+        @route="organen.orgaan.bulk-bekrachtiging"
+        @skin="button-secondary"
+      >Bekrachtig mandatarissen
+      </AuLink>
+    {{/if}}
     <Shared::Tooltip
-      @showTooltip={{@model.legislatuurInBehandeling}}
-      @tooltipText={{this.toolTipText}}
+      @showTooltip={{this.isDisabled}}
+      @tooltipText="Het is niet mogelijk mandatarissen toe te voegen aan een bestuursperiode terwijl de voorbereiding van de legislatuur actief is."
     >
       <AuButton
         {{on "click" (fn this.setIsCreatingMandataris true)}}
-        @disabled={{@model.legislatuurInBehandeling}}
+        @disabled={{this.isDisabled}}
       >
         Voeg nieuwe mandataris toe
       </AuButton>

--- a/app/utils/is-valid-uri.js
+++ b/app/utils/is-valid-uri.js
@@ -1,0 +1,6 @@
+export const isValidUri = (inputValue) => {
+  // eslint-disable-next-line no-useless-escape, prettier/prettier
+  const regex = '^(https?://|www.)[a-zA-Z0-9-]+(.[a-zA-Z0-9-]+)*(/.*)?$';
+  const uriRegex = new RegExp(regex);
+  return uriRegex.test(inputValue);
+};


### PR DESCRIPTION
## Description

Add a page with the possibility to bulk bekrachtig multiple mandatees at once. All mandatees are mentioned here, also multiple states of the same one, because you need to be able to handle them independently. It does not matter which publication status the mandataris had before, you are able to set it to bekrachtigd, the only thing you can't do is make a mandataris that is bekrachtigd effectief.

![Screenshot 2024-10-24 at 17 14 30](https://github.com/user-attachments/assets/bf73e6b1-5aee-47f4-81ef-f3be71c0899d)


## How to test

Go to the page, it is nested under the orgaan page. Play around with it a bit and see if it does what you expect it to do.

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/57
