### PR TITLE
Ben/lmb 928 fractie selector burgemeester

### DIFF
--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -117,9 +117,8 @@
             @alignment="left"
           >
             <AuButton
-              {{on "click" (perform this.updateBurgemeester)}}
+              {{on "click" this.updateBurgemeester}}
               @disabled={{this.disabled}}
-              @loading={{this.updateBurgemeester.isRunning}}
             >
               Sla op
             </AuButton>

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -80,6 +80,7 @@
   @closable={{true}}
 >
   <div class="au-o-box">
+    {{! TODO This should be in a component }}
     <Person::SearchForm
       @showDefaultHead={{false}}
       @onSelect={{perform this.onUpdate}}
@@ -87,5 +88,19 @@
       @onCancel={{this.closeModal}}
       @allowCreate={{false}}
     />
+
+    {{#if this.persoon}}
+      <Mandatarissen::FractieSelector
+        @fractie={{this.selectedFractie}}
+        @isRequired={{true}}
+        @onSelect={{this.updateFractie}}
+        @bestuurseenheid={{@bestuurseenheid}}
+        @bestuursperiode={{@bestuursperiode}}
+        @person={{this.person}}
+        @limitPersonFractionsToCurrent={{true}}
+      />
+    {{/if}}
+
+    {{! TODO Add saving here }}
   </div>
 </AuModal>

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -109,6 +109,24 @@
         @person={{this.persoon}}
         @limitPersonFractionsToCurrent={{true}}
       />
+      <div>
+        <AuLabel>
+          Beleidsdomeinen
+        </AuLabel>
+        <PowerSelectMultiple
+          @allowClear={{true}}
+          @placeholder="Selecteer beleidsdomeinen"
+          @noMatchesMessage="Geen resultaten"
+          @selected={{this.selectedBeleidsdomeinen}}
+          @options={{this.possibleBeleidsdomeinen}}
+          @onChange={{this.selectBeleidsdomeinen}}
+          @searchEnabled={{true}}
+          @searchField="label"
+          as |beleidsdomein|
+        >
+          {{beleidsdomein.label}}
+        </PowerSelectMultiple>
+      </div>
     {{/if}}
 
     <AuToolbar class="au-u-margin-top" as |Group|>

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -82,7 +82,7 @@
   @closeModal={{this.closeModal}}
   @closable={{true}}
 >
-  <div class="au-o-box">
+  <div class="au-o-box au-o-flow">
     <div>
       <AuLabel @required={{true}}>
         Persoon

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -29,7 +29,6 @@
   {{else}}
     <AuDataTable
       @content={{this.aangewezenBurgemeesters}}
-      @fields="gebruikteVoornaam achternaam actions"
       @noDataMessage="Geen burgemeester aangewezen"
       as |t|
     >
@@ -37,15 +36,19 @@
         <c.header>
           <th class="au-u-padding-small">Voornaam</th>
           <th>Familienaam</th>
+          <th>Fractie</th>
+          <th>Beleidsomeinen</th>
           {{#unless @readOnly}}
             <th>
               {{! actions }}
             </th>
           {{/unless}}
         </c.header>
-        <c.body as |persoon|>
-          <td>{{persoon.gebruikteVoornaam}}</td>
-          <td>{{persoon.achternaam}}</td>
+        <c.body as |row|>
+          <td>{{row.isBestuurlijkeAliasVan.gebruikteVoornaam}}</td>
+          <td>{{row.isBestuurlijkeAliasVan.achternaam}}</td>
+          <td>{{row.heeftLidmaatschap.binnenFractie.naam}}</td>
+          <td><Beleidsdomeinen @mandataris={{row}} /></td>
           {{#unless @readOnly}}
             <td class="au-u-text-right">
               {{#if this.persoon}}

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -81,16 +81,17 @@
 >
   <div class="au-o-box">
     <div>
-      <AuLabel>
+      <AuLabel @required={{true}}>
         Persoon
       </AuLabel>
       <div>
         <Person::Selector
-          @person={{this.person}}
+          @person={{this.persoon}}
           @onUpdate={{this.selectPerson}}
           @searchElected={{true}}
           @bestuursperiode={{@bestuursperiode}}
           @allowCreate={{false}}
+          @inline={{true}}
         />
       </div>
     </div>

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -107,6 +107,27 @@
       />
     {{/if}}
 
-    {{! TODO Add saving here }}
+    <AuToolbar class="au-u-margin-top" as |Group|>
+      <Group>
+        <AuButtonGroup>
+          <Shared::Tooltip
+            @showTooltip={{this.disabled}}
+            @tooltipText="Het is nodig zowel een persoon als een fractie te selecteren vooraleer het mogelijk is op te slaan."
+            @alignment="left"
+          >
+            <AuButton
+              {{on "click" (perform this.updateBurgemeester)}}
+              @disabled={{this.disabled}}
+              @loading={{this.updateBurgemeester.isRunning}}
+            >
+              Sla op
+            </AuButton>
+          </Shared::Tooltip>
+          <AuButton {{on "click" this.closeModal}} @skin="secondary">
+            Annuleer
+          </AuButton>
+        </AuButtonGroup>
+      </Group>
+    </AuToolbar>
   </div>
 </AuModal>

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -113,19 +113,10 @@
         <AuLabel>
           Beleidsdomeinen
         </AuLabel>
-        <PowerSelectMultiple
-          @allowClear={{true}}
-          @placeholder="Selecteer beleidsdomeinen"
-          @noMatchesMessage="Geen resultaten"
-          @selected={{this.selectedBeleidsdomeinen}}
-          @options={{this.possibleBeleidsdomeinen}}
-          @onChange={{this.selectBeleidsdomeinen}}
-          @searchEnabled={{true}}
-          @searchField="label"
-          as |beleidsdomein|
-        >
-          {{beleidsdomein.label}}
-        </PowerSelectMultiple>
+        <Mandatarissen::BeleidsdomeinSelectorWithCreate
+          @onSelect={{this.selectBeleidsomeinen}}
+          @beleidsdomeinen={{this.selectedBeleidsdomeinen}}
+        />
       </div>
     {{/if}}
 

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -11,7 +11,6 @@
       >
         <AuButton
           @icon="add"
-          @loading={{this.onUpdate.isRunning}}
           @loadingMessage="laden"
           @disabled={{this.persoon}}
           {{on "click" (fn (mut this.isModalOpen) true)}}
@@ -24,46 +23,42 @@
 </div>
 
 <div class="no-pagination au-u-margin-left au-u-margin-right">
-  {{#if this.onUpdate.isRunning}}
-    <Skeleton::Table @columns={{3}} @rows={{1}} />
-  {{else}}
-    <AuDataTable
-      @content={{this.aangewezenBurgemeesters}}
-      @noDataMessage="Geen burgemeester aangewezen"
-      as |t|
-    >
-      <t.content as |c|>
-        <c.header>
-          <th class="au-u-padding-small">Voornaam</th>
-          <th>Familienaam</th>
-          <th>Fractie</th>
-          <th>Beleidsomeinen</th>
-          {{#unless @readOnly}}
-            <th>
-              {{! actions }}
-            </th>
-          {{/unless}}
-        </c.header>
-        <c.body as |row|>
-          <td>{{row.isBestuurlijkeAliasVan.gebruikteVoornaam}}</td>
-          <td>{{row.isBestuurlijkeAliasVan.achternaam}}</td>
-          <td>{{row.heeftLidmaatschap.binnenFractie.naam}}</td>
-          <td><Beleidsdomeinen @mandataris={{row}} /></td>
-          {{#unless @readOnly}}
-            <td class="au-u-text-right">
-              {{#if this.persoon}}
-                <AuButton
-                  @skin="link"
-                  @alert={{true}}
-                  {{on "click" this.removeBurgemeester}}
-                >Verwijder</AuButton>
-              {{/if}}
-            </td>
-          {{/unless}}
-        </c.body>
-      </t.content>
-    </AuDataTable>
-  {{/if}}
+  <AuDataTable
+    @content={{this.aangewezenBurgemeesters}}
+    @noDataMessage="Geen burgemeester aangewezen"
+    as |t|
+  >
+    <t.content as |c|>
+      <c.header>
+        <th class="au-u-padding-small">Voornaam</th>
+        <th>Familienaam</th>
+        <th>Fractie</th>
+        <th>Beleidsomeinen</th>
+        {{#unless @readOnly}}
+          <th>
+            {{! actions }}
+          </th>
+        {{/unless}}
+      </c.header>
+      <c.body as |row|>
+        <td>{{row.isBestuurlijkeAliasVan.gebruikteVoornaam}}</td>
+        <td>{{row.isBestuurlijkeAliasVan.achternaam}}</td>
+        <td>{{row.heeftLidmaatschap.binnenFractie.naam}}</td>
+        <td><Beleidsdomeinen @mandataris={{row}} /></td>
+        {{#unless @readOnly}}
+          <td class="au-u-text-right">
+            {{#if this.persoon}}
+              <AuButton
+                @skin="link"
+                @alert={{true}}
+                {{on "click" this.removeBurgemeester}}
+              >Verwijder</AuButton>
+            {{/if}}
+          </td>
+        {{/unless}}
+      </c.body>
+    </t.content>
+  </AuDataTable>
 </div>
 
 <div class="au-o-box">

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -80,14 +80,20 @@
   @closable={{true}}
 >
   <div class="au-o-box">
-    {{! TODO This should be in a component }}
-    <Person::SearchForm
-      @showDefaultHead={{false}}
-      @onSelect={{perform this.onUpdate}}
-      @onCreateNewPerson={{this.onCreateNewPerson}}
-      @onCancel={{this.closeModal}}
-      @allowCreate={{false}}
-    />
+    <div>
+      <AuLabel>
+        Persoon
+      </AuLabel>
+      <div>
+        <Person::Selector
+          @person={{this.person}}
+          @onUpdate={{this.selectPerson}}
+          @searchElected={{true}}
+          @bestuursperiode={{@bestuursperiode}}
+          @allowCreate={{false}}
+        />
+      </div>
+    </div>
 
     {{#if this.persoon}}
       <Mandatarissen::FractieSelector
@@ -96,7 +102,7 @@
         @onSelect={{this.updateFractie}}
         @bestuurseenheid={{@bestuurseenheid}}
         @bestuursperiode={{@bestuursperiode}}
-        @person={{this.person}}
+        @person={{this.persoon}}
         @limitPersonFractionsToCurrent={{true}}
       />
     {{/if}}

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -11,10 +11,10 @@
       >
         <AuButton
           @icon="add"
-          @loading={{(or this.setup.isRunning this.onUpdate.isRunning)}}
+          @loading={{this.onUpdate.isRunning}}
           @loadingMessage="laden"
           @disabled={{this.persoon}}
-          {{on "click" (fn (mut this.isPersonSelectOpen) true)}}
+          {{on "click" (fn (mut this.isModalOpen) true)}}
         >
           Toevoegen
         </AuButton>
@@ -24,7 +24,7 @@
 </div>
 
 <div class="no-pagination au-u-margin-left au-u-margin-right">
-  {{#if (or this.setup.isRunning this.onUpdate.isRunning)}}
+  {{#if this.onUpdate.isRunning}}
     <Skeleton::Table @columns={{3}} @rows={{1}} />
   {{else}}
     <AuDataTable
@@ -75,7 +75,7 @@
 
 <AuModal
   @title={{"Selecteer een persoon"}}
-  @modalOpen={{this.isPersonSelectOpen}}
+  @modalOpen={{this.isModalOpen}}
   @closeModal={{this.closeModal}}
   @closable={{true}}
 >

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -77,7 +77,7 @@
 </div>
 
 <AuModal
-  @title={{"Selecteer een persoon"}}
+  @title={{"Voeg een burgemeester toe"}}
   @modalOpen={{this.isModalOpen}}
   @closeModal={{this.closeModal}}
   @closable={{true}}

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -80,21 +80,12 @@
   @closable={{true}}
 >
   <div class="au-o-box">
-
-    {{#if this.isCreatingPerson}}
-      <Form::NewInstance
-        @onCreate={{this.onSelectNewPerson}}
-        @form={{this.createPersonFormDefinition}}
-        @onCancel={{this.closeModal}}
-        @buildSourceTtl={{this.buildSourceTtl}}
-      />
-    {{else}}
-      <Person::SearchForm
-        @showDefaultHead={{false}}
-        @onSelect={{perform this.onUpdate}}
-        @onCreateNewPerson={{this.onCreateNewPerson}}
-        @onCancel={{this.closeModal}}
-      />
-    {{/if}}
+    <Person::SearchForm
+      @showDefaultHead={{false}}
+      @onSelect={{perform this.onUpdate}}
+      @onCreateNewPerson={{this.onCreateNewPerson}}
+      @onCancel={{this.closeModal}}
+      @allowCreate={{false}}
+    />
   </div>
 </AuModal>

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -5,7 +5,6 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { restartableTask } from 'ember-concurrency';
-import { getFormFrom } from 'frontend-lmb/utils/get-form';
 import {
   getDraftPublicationStatus,
   getEffectiefStatus,
@@ -13,20 +12,19 @@ import {
 import {
   BESTUURSFUNCTIE_AANGEWEZEN_BURGEMEESTER_ID,
   BESTUURSFUNCTIE_VOORZITTER_VAST_BUREAU_ID,
-  CREATE_PERSON_FORM_ID,
 } from 'frontend-lmb/utils/well-known-ids';
 import moment from 'moment';
+import { showErrorToast } from 'frontend-lmb/utils/toasts';
 
 export default class MandaatBurgemeesterSelectorComponent extends Component {
   @service store;
   @service bcsd;
+  @service toaster;
 
   @tracked persoon = null;
   @tracked mandataris = null;
   @tracked aangewezenBurgemeesters;
   @tracked isPersonSelectOpen;
-  @tracked isCreatingPerson;
-  @tracked createPersonFormDefinition;
   // no need to track these
   burgemeesterMandate = null;
   voorzitterVastBureauMandate = null;
@@ -156,17 +154,15 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
 
   @action
   closeModal() {
-    this.isCreatingPerson = false;
     this.isPersonSelectOpen = false;
   }
 
   @action
   async onCreateNewPerson() {
-    this.createPersonFormDefinition = await getFormFrom(
-      this.store,
-      CREATE_PERSON_FORM_ID
+    showErrorToast(
+      this.toaster,
+      'Bij het toevoegen van een burgemeester is het niet mogelijk een persoon aan te maken die niet uit de kieslijst komt'
     );
-    this.isCreatingPerson = true;
   }
 
   @action

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -38,6 +38,10 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
     return this.args.bestuursorgaanInTijd.bindingEinde;
   }
 
+  get disabled() {
+    return !this.persoon || !this.selectedFractie;
+  }
+
   constructor() {
     super(...arguments);
     this.setup.perform();
@@ -178,6 +182,7 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
     this.selectedFractie = null;
     this.aangewezenBurgemeesters = [];
     await this.updateBurgemeester.perform();
+    // TODO Fractie needs to be removed here as well from the mandatees ...
   }
 
   get toolTipText() {

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -13,7 +13,6 @@ import {
   BESTUURSFUNCTIE_AANGEWEZEN_BURGEMEESTER_ID,
   BESTUURSFUNCTIE_VOORZITTER_VAST_BUREAU_ID,
 } from 'frontend-lmb/utils/well-known-ids';
-import moment from 'moment';
 
 export default class MandaatBurgemeesterSelectorComponent extends Component {
   @service store;
@@ -50,10 +49,6 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   @action async setup() {
     await this.loadBurgemeesterMandates();
     await this.loadBurgemeesterMandatarissen();
-  }
-
-  formatToDateString(dateTime) {
-    return dateTime ? moment(dateTime).format('YYYY-MM-DD') : undefined;
   }
 
   async loadBurgemeesterMandates() {

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -167,12 +167,15 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
       this.args.onUpdateBurgemeester();
     }
 
-    this.closeModal();
+    this.isModalOpen = false;
   }
 
   @action
   closeModal() {
     this.isModalOpen = false;
+    this.persoon = null;
+    this.selectedFractie = null;
+    this.selectedBeleidsdomeinen = [];
   }
 
   @action

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -4,7 +4,6 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-import { restartableTask } from 'ember-concurrency';
 import {
   getDraftPublicationStatus,
   getEffectiefStatus,
@@ -119,7 +118,8 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
       : [];
   }
 
-  updateBurgemeester = restartableTask(async () => {
+  @action
+  async updateBurgemeester() {
     await this.loadBurgemeesterMandatarissen();
     if (!this.targetMandatarisses) {
       return;
@@ -148,7 +148,7 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
     }
 
     this.closeModal();
-  });
+  }
 
   @action
   closeModal() {
@@ -169,7 +169,7 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
     this.persoon = null;
     this.selectedFractie = null;
     this.aangewezenBurgemeesters = [];
-    await this.updateBurgemeester.perform();
+    await this.updateBurgemeester();
   }
 
   get toolTipText() {

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -23,6 +23,8 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   @tracked aangewezenBurgemeester;
   @tracked isModalOpen;
   @tracked selectedFractie = null;
+  @tracked selectedBeleidsdomeinen = [];
+  @tracked possibleBeleidsdomeinen = null;
 
   // no need to track these
   burgemeesterMandate = null;
@@ -42,6 +44,7 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
     await this.loadBurgemeesterMandates();
     await this.loadBurgemeesterMandatarissen();
     await this.loadBurgemeesterPerson();
+    await this.getBeleidsdomeinen();
   }
 
   async loadBurgemeesterMandates() {
@@ -126,6 +129,11 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
     }
   }
 
+  async getBeleidsdomeinen() {
+    this.possibleBeleidsdomeinen =
+      await this.store.findAll('beleidsdomein-code');
+  }
+
   @action
   async updateBurgemeester() {
     await this.loadBurgemeesterMandatarissen();
@@ -142,6 +150,9 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
           );
         } else {
           await this.mandatarisService.destroyLidmaatschap(target);
+        }
+        if (await target.bekleedt.get('isBurgemeester')) {
+          target.beleidsdomein = this.selectedBeleidsdomeinen;
         }
         return target.save();
       })
@@ -173,10 +184,15 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
     this.selectedFractie = newFractie;
   }
 
+  @action selectBeleidsdomeinen(domeinen) {
+    this.selectedBeleidsdomeinen = domeinen;
+  }
+
   @action
   async removeBurgemeester() {
     this.persoon = null;
     this.selectedFractie = null;
+    this.selectedBeleidsdomeinen = [];
     this.aangewezenBurgemeesters = [];
     await this.updateBurgemeester();
   }

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -22,9 +22,10 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   @service toaster;
 
   @tracked persoon = null;
-  @tracked mandataris = null;
   @tracked aangewezenBurgemeesters;
   @tracked isPersonSelectOpen;
+  @tracked selectedFractie = null;
+
   // no need to track these
   burgemeesterMandate = null;
   voorzitterVastBureauMandate = null;
@@ -59,13 +60,11 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   }
 
   async loadBurgemeesterMandates() {
-    const bestuursperiode =
-      await this.args.bestuursorgaanInTijd.heeftBestuursperiode;
     const mandates = await this.store.query('mandaat', {
       filter: {
         'bevat-in': {
           'heeft-bestuursperiode': {
-            id: bestuursperiode.id,
+            id: this.args.bestuursperiode.id,
           },
         },
         bestuursfunctie: {
@@ -133,6 +132,7 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
     return burgemeesters[0]?.isBestuurlijkeAliasVan || null;
   }
 
+  // This needs to happen on save instead.
   onUpdate = restartableTask(async (persoon) => {
     await this.setup.perform();
     this.persoon = persoon;
@@ -169,6 +169,10 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   async onSelectNewPerson({ instanceId }) {
     this.persoon = await this.store.findRecord('persoon', instanceId);
     await this.onUpdate.perform(this.persoon);
+  }
+
+  @action updateFractie(newFractie) {
+    this.selectedFractie = newFractie;
   }
 
   @action

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -24,7 +24,6 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   @tracked isModalOpen;
   @tracked selectedFractie = null;
   @tracked selectedBeleidsdomeinen = [];
-  @tracked possibleBeleidsdomeinen = null;
 
   // no need to track these
   burgemeesterMandate = null;
@@ -44,7 +43,6 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
     await this.loadBurgemeesterMandates();
     await this.loadBurgemeesterMandatarissen();
     await this.loadBurgemeesterPerson();
-    await this.getBeleidsdomeinen();
   }
 
   async loadBurgemeesterMandates() {
@@ -127,18 +125,6 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
     } else {
       this.aangewezenBurgemeesters = [];
     }
-  }
-
-  async getBeleidsdomeinen() {
-    this.possibleBeleidsdomeinen = await this.store.query(
-      'beleidsdomein-code',
-      {
-        page: {
-          size: 500,
-        },
-        sort: 'label',
-      }
-    );
   }
 
   @action

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -177,7 +177,7 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
     this.persoon = null;
     this.selectedFractie = null;
     this.aangewezenBurgemeesters = [];
-    await this.onUpdate.perform(this.persoon);
+    await this.updateBurgemeester.perform();
   }
 
   get toolTipText() {

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -29,14 +29,6 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   voorzitterVastBureauMandate = null;
   targetMandatarisses = null;
 
-  get bindingStart() {
-    return this.args.bestuursorgaanInTijd.bindingStart;
-  }
-
-  get bindingEinde() {
-    return this.args.bestuursorgaanInTijd.bindingEinde;
-  }
-
   get disabled() {
     return !this.persoon || !this.selectedFractie;
   }
@@ -85,8 +77,8 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   async createMandataris(burgemeesterMandaat) {
     const newMandataris = this.store.createRecord('mandataris', {
       rangorde: null,
-      start: this.bindingStart,
-      einde: this.bindingEinde,
+      start: this.args.bestuursorgaanInTijd.bindingStart,
+      einde: this.args.bestuursorgaanInTijd.bindingEinde,
       bekleedt: burgemeesterMandaat,
       isBestuurlijkeAliasVan: null,
       beleidsdomein: [],

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -144,10 +144,14 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
     await Promise.all(
       this.targetMandatarisses.map(async (target) => {
         target.isBestuurlijkeAliasVan = this.persoon;
-        await this.mandatarisService.createNewLidmaatschap(
-          target,
-          this.selectedFractie
-        );
+        if (this.selectedFractie) {
+          await this.mandatarisService.createNewLidmaatschap(
+            target,
+            this.selectedFractie
+          );
+        } else {
+          await this.mandatarisService.destroyLidmaatschap(target);
+        }
         return target.save();
       })
     );

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -14,7 +14,6 @@ import {
   BESTUURSFUNCTIE_VOORZITTER_VAST_BUREAU_ID,
 } from 'frontend-lmb/utils/well-known-ids';
 import moment from 'moment';
-import { showErrorToast } from 'frontend-lmb/utils/toasts';
 
 export default class MandaatBurgemeesterSelectorComponent extends Component {
   @service store;
@@ -158,17 +157,8 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   }
 
   @action
-  async onCreateNewPerson() {
-    showErrorToast(
-      this.toaster,
-      'Bij het toevoegen van een burgemeester is het niet mogelijk een persoon aan te maken die niet uit de kieslijst komt'
-    );
-  }
-
-  @action
-  async onSelectNewPerson({ instanceId }) {
-    this.persoon = await this.store.findRecord('persoon', instanceId);
-    await this.onUpdate.perform(this.persoon);
+  async selectPerson(newPerson) {
+    this.persoon = newPerson;
   }
 
   @action updateFractie(newFractie) {

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -130,8 +130,15 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   }
 
   async getBeleidsdomeinen() {
-    this.possibleBeleidsdomeinen =
-      await this.store.findAll('beleidsdomein-code');
+    this.possibleBeleidsdomeinen = await this.store.query(
+      'beleidsdomein-code',
+      {
+        page: {
+          size: 500,
+        },
+        sort: 'label',
+      }
+    );
   }
 
   @action

--- a/app/components/mandatarissen/beleidsdomein-selector-with-create.js
+++ b/app/components/mandatarissen/beleidsdomein-selector-with-create.js
@@ -67,7 +67,9 @@ export default class MandatenbeheerBeleidsdomeinSelectorWithCreateComponent exte
   @action
   select(beleidsdomeinen) {
     this.selected.setObjects(beleidsdomeinen);
-    this.args.onSelect(this.selected);
+    if (this.args.onSelect) {
+      this.args.onSelect(this.selected);
+    }
   }
 
   @action

--- a/app/components/mandatarissen/beleidsdomein-selector-with-create.js
+++ b/app/components/mandatarissen/beleidsdomein-selector-with-create.js
@@ -26,13 +26,35 @@ export default class MandatenbeheerBeleidsdomeinSelectorWithCreateComponent exte
   }
 
   async fetchOptions(searchData) {
-    let queryParams = {
+    // let queryParams = {
+    //   page: {
+    //     size: 500,
+    //   },
+    //   sort: 'label',
+    // };
+    // if (searchData) {
+    //   queryParams['filter[label]'] = searchData;
+    // }
+    // return await this.store.query('beleidsdomein-code', queryParams);
+
+    // This returns different results...
+    const queryParams = {
+      filter: {
+        label: searchData,
+        'concept-schemes': {
+          ':uri:':
+            'http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode',
+        },
+      },
       sort: 'label',
+      page: {
+        size: 9999,
+      },
     };
     if (searchData) {
-      queryParams['filter[label]'] = searchData;
+      queryParams['filter']['label'] = searchData;
     }
-    return await this.store.query('beleidsdomein-code', queryParams);
+    return await this.store.query('concept', queryParams);
   }
 
   search = task({ restartable: true }, async (searchData) => {

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -3,6 +3,8 @@
     @bestuursorgaanInTijd={{@bestuursorgaan}}
     @readOnly={{@isBehandeld}}
     @onUpdateBurgemeester={{@onUpdateBurgemeester}}
+    @bestuursperiode={{@bestuursperiode}}
+    @bestuurseenheid={{@bestuurseenheid}}
     @bestuursorganen={{@bestuursorganen}}
   />
 {{else}}

--- a/app/services/mandataris.js
+++ b/app/services/mandataris.js
@@ -89,6 +89,13 @@ export default class MandatarisService extends Service {
     await newLidmaatschap.save();
   }
 
+  async destroyLidmaatschap(mandataris) {
+    const lidmaatschap = await mandataris.heeftLidmaatschap;
+    lidmaatschap.destroyRecord();
+    mandataris.heeftLidmaatschap = null;
+    await mandataris.save();
+  }
+
   async createNewProps(mandataris, overwrites) {
     return {
       rangorde: overwrites.rangorde ?? mandataris.rangorde,

--- a/app/templates/verkiezingen/installatievergadering.hbs
+++ b/app/templates/verkiezingen/installatievergadering.hbs
@@ -83,6 +83,8 @@
     {{#each @model.bestuursorganenInTijd as |bestuursorgaan|}}
       <Verkiezingen::PrepareLegislatuurSection
         @isBehandeld={{@model.isBehandeld}}
+        @bestuurseenheid={{@model.bestuurseenheid}}
+        @bestuursperiode={{@model.selectedPeriod}}
         @bestuursorgaan={{bestuursorgaan}}
         @bestuursorganen={{@model.bestuursorganenInTijd}}
         @form={{@model.mandatarisForm}}


### PR DESCRIPTION
## Description

Extend burgemeester selector in the prepare legislature page. Now you can also select a fractie and beleidsdomeinen. There are still a few issues with it which need to be looked at, but they are not introduced by this change, see the issue section.

![Screenshot 2024-10-26 at 11 08 14](https://github.com/user-attachments/assets/4caec2f9-73a6-46d9-a899-71158ad3c3a4)
![Screenshot 2024-10-26 at 11 08 41](https://github.com/user-attachments/assets/d30d8501-71cf-4038-8d32-70a49712550f)

## How to test

Go to the prepare legislature page and add a burgemeester, this should also be added to the other mandates (voorzitter ...). The fractie and beleidsdomeinen should be added and it should also be possible to remove a burgemeester, which should result in the deletion of the voorzitter as well.

## Issues
There are a few issues that don't really have to do with this story, they already existed in the previous burgemeester selector or are an issue somewhere else.
- On the first load of the prepare-legislature page, the burgemeester mandate in CBS and the voorzitter in VB are not shown, but the are created behind the screens. This can be confusing.
- If you edit the aangewezen burgemeester in CBS, this also updates the burgemeester ambt, but it is only shown if you manually refresh
- In general the selector just feels too wonkey, with selecting the first one etc. We might need to improve this, maybe with linked mandatarissen or something like that, now it just does not feel very safe.
- Something weird happens with fetching beleidsdomeincodes, see comment in code, but depending on if you search for beleidsdomein-codes or concepts with the correct scheme, different results get shown. Probably an issue with the types that are set on these resources?