### PR TITLE
make sure the correct bestuursperiode is used for selecting elected people

### DIFF
--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -86,9 +86,8 @@
         <Person::Selector
           @person={{this.persoon}}
           @onUpdate={{this.selectPerson}}
-          @searchElected={{true}}
+          @onlyElected={{true}}
           @bestuursperiode={{@bestuursperiode}}
-          @allowCreate={{false}}
           @inline={{true}}
         />
       </div>

--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -126,6 +126,7 @@
               @nothingSelectedText="Voeg vervanger toe"
               @selected={{this.selectedVervanger}}
               @onSelect={{perform this.addReplacement}}
+              @bestuursperiode={{@bestuursperiode}}
               @inline={{true}}
             />
           {{else}}

--- a/app/components/mandatarissen/replacement-select.hbs
+++ b/app/components/mandatarissen/replacement-select.hbs
@@ -4,6 +4,7 @@
     @onUpdate={{@onSelect}}
     @inline={{@inline}}
     @allowCreate={{await @mandataris.bekleedt.allowsNonElectedPersons}}
+    @searchElected={{not (await @mandataris.bekleedt.allowsNonElectedPersons)}}
     @showDelete={{@showDelete}}
     @showEditAsIcon={{@showEditAsIcon}}
     @nothingSelectedText={{@nothingSelectedText}}

--- a/app/components/mandatarissen/replacement-select.hbs
+++ b/app/components/mandatarissen/replacement-select.hbs
@@ -3,8 +3,7 @@
     @person={{@selected}}
     @onUpdate={{@onSelect}}
     @inline={{@inline}}
-    @allowCreate={{await @mandataris.bekleedt.allowsNonElectedPersons}}
-    @searchElected={{not (await @mandataris.bekleedt.allowsNonElectedPersons)}}
+    @onlyElected={{not (await @mandataris.bekleedt.allowsNonElectedPersons)}}
     @showDelete={{@showDelete}}
     @showEditAsIcon={{@showEditAsIcon}}
     @nothingSelectedText={{@nothingSelectedText}}

--- a/app/components/mandatarissen/replacement-select.hbs
+++ b/app/components/mandatarissen/replacement-select.hbs
@@ -7,6 +7,7 @@
     @showDelete={{@showDelete}}
     @showEditAsIcon={{@showEditAsIcon}}
     @nothingSelectedText={{@nothingSelectedText}}
+    @bestuursperiode={{@bestuursperiode}}
   />
   {{#if this.overlappingMandate}}
     <AuAlert @skin="warning" @icon="alert-triangle" class="au-u-margin-top">

--- a/app/components/person/search-form.hbs
+++ b/app/components/person/search-form.hbs
@@ -86,7 +86,7 @@
             class="au-u-margin-top-small"
           >
             <p>
-              Kijk uw zoekopdracht na{{#if @allowCreate}}<span>
+              Kijk uw zoekopdracht na{{#if this.allowCreate}}<span>
                   of
                   <AuButton
                     @skin="link"
@@ -105,7 +105,7 @@
             @size="tiny"
           >
             <p>
-              Kijk uw zoekopdracht na{{#if @allowCreate}}<span>
+              Kijk uw zoekopdracht na{{#if this.allowCreate}}<span>
                   of
                   <AuButton
                     @skin="link"
@@ -122,7 +122,7 @@
         <AuContent>
           <p class="au-c-text-info">
             Zoek een reeds gekende persoon in de databank van het loket op naam
-            of op rijksregisternummer{{#if @allowCreate}}<span>,<br />of
+            of op rijksregisternummer{{#if this.allowCreate}}<span>,<br />of
                 <AuButton
                   @skin="link"
                   {{on "click" this.handleCreatePersonClick}}

--- a/app/components/person/search-form.js
+++ b/app/components/person/search-form.js
@@ -21,6 +21,10 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
   @tracked voornaam;
   @tracked rijksregisternummer;
 
+  get allowCreate() {
+    return !this.args.onlyElected;
+  }
+
   get searchTerms() {
     return [this.voornaam, this.achternaam, this.rijksregisternummer]
       .filter((t) => t)
@@ -81,7 +85,7 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
     }
 
     const extraFilter = {};
-    if (this.args.searchElected && this.args.bestuursperiode) {
+    if (this.args.onlyElected && this.args.bestuursperiode) {
       extraFilter.verkiezingsresultaten = {
         kandidatenlijst: {
           verkiezing: {

--- a/app/components/person/selector.hbs
+++ b/app/components/person/selector.hbs
@@ -58,9 +58,8 @@
         @showDefaultHead={{false}}
         @onSelect={{this.onSelectPerson}}
         @onCreateNewPerson={{this.onCreateNewPerson}}
-        @searchElected={{@searchElected}}
         @bestuursperiode={{@bestuursperiode}}
-        @allowCreate={{@allowCreate}}
+        @onlyElected={{@onlyElected}}
       />
     {{/if}}
   </div>
@@ -86,9 +85,8 @@
           @onSelect={{this.onSelectPerson}}
           @onCreateNewPerson={{this.onCreateNewPerson}}
           @onCancel={{this.cancelEdit}}
-          @searchElected={{@searchElected}}
           @bestuursperiode={{@bestuursperiode}}
-          @allowCreate={{@allowCreate}}
+          @onlyElected={{@onlyElected}}
         />
       {{/if}}
     </div>

--- a/app/components/rdf-input-fields/person-selector.hbs
+++ b/app/components/rdf-input-fields/person-selector.hbs
@@ -10,9 +10,8 @@
       <Person::Selector
         @person={{this.person}}
         @onUpdate={{this.onUpdate}}
-        @searchElected={{this.searchElected}}
+        @onlyElected={{this.onlyElected}}
         @bestuursperiode={{this.currentBestuursperiode}}
-        @allowCreate={{await this.mandaatModel.allowsNonElectedPersons}}
       />
     </div>
     {{#each this.errors as |error|}}

--- a/app/components/rdf-input-fields/person-selector.js
+++ b/app/components/rdf-input-fields/person-selector.js
@@ -23,7 +23,7 @@ export default class PersonSelectorComponent extends InputFieldComponent {
 
   @tracked initialized = false;
   @tracked isMandaatInForm = false;
-  @tracked searchElected = true;
+  @tracked onlyElected = true;
   @tracked currentBestuursperiode = null;
   @tracked mandaatModel = null;
 
@@ -71,7 +71,7 @@ export default class PersonSelectorComponent extends InputFieldComponent {
     this.hasBeenFocused = true;
     super.updateValidations();
     this.person = person;
-    if (this.person && this.searchElected) {
+    if (this.person && this.onlyElected) {
       const isElected = await this.verkiezingService.checkIfPersonIsElected(
         this.person.id,
         this.currentBestuursperiode
@@ -106,13 +106,13 @@ export default class PersonSelectorComponent extends InputFieldComponent {
     this.mandaatModel = mandaatModel;
 
     if (mandaatModel.isBurgemeester) {
-      this.searchElected = false;
+      this.onlyElected = false;
       return;
     }
 
-    this.searchElected = !(await mandaatModel.allowsNonElectedPersons);
+    this.onlyElected = !(await mandaatModel.allowsNonElectedPersons);
 
-    if (this.searchElected) {
+    if (this.onlyElected) {
       this.currentBestuursperiode = await (
         await mandaatModel.bevatIn
       )[0].heeftBestuursperiode;


### PR DESCRIPTION
## Description

Bestuursperiode and some other settings were not provided in the use of some person::Selector components. Which does not guarantee the selected people are elected in the correct bestuursperiode.

The commit b77e7f5d87cff243a0c0338eba916cb05512278a can be omitted if wanted, this just simplifies the arguments, since searchElected and allowCreate were just each others opposites.
 
## How to test

Double check each use of the person::Selector component and make sure you can only select elected people.