### PR TITLE
decrease number of calls in person search

### DIFF
--- a/app/components/person/search-form.js
+++ b/app/components/person/search-form.js
@@ -101,7 +101,7 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
 
     let queryParams = {
       sort: 'achternaam',
-      include: ['geboorte', 'identificator'].join(','),
+      include: ['geboorte', 'identificator', 'geslacht'].join(','),
       filter: {
         achternaam: this.achternaam || undefined,
         'gebruikte-voornaam': this.voornaam || undefined,


### PR DESCRIPTION
## Description

Before for every person in the person search, a seperate call happened to retrieve the geslacht. This should be fixed now.
![Screenshot 2024-11-05 at 12 37 34](https://github.com/user-attachments/assets/049c6319-ec26-48cc-8d71-ba24d82da132)

## How to test

Open a person search form, the calls shown in the screenshot, should not be done anymore.
