### PR TITLE
lmb-946:  generate mandatarissen for IV in mandataris service

### DIFF
--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -97,8 +97,8 @@ export default class GenerateRowsFormComponent extends Component {
       mandaat: this.selectedMandaat.parent,
       startDate: this.startDate ?? this.args.startDate,
       endDate: notRequiredEndDate,
-      rows: this.rowsToGenerate,
-      existingMandaten: this.lengthExistingMandaten,
+      count: this.rowsToGenerate,
+      existingMandatenLength: this.lengthExistingMandaten,
     });
   });
 

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -7,9 +7,9 @@ import { A } from '@ember/array';
 
 import { task, restartableTask, timeout } from 'ember-concurrency';
 
+import { rangordeStringToNumber } from 'frontend-lmb/utils/rangorde';
 import { INPUT_DEBOUNCE } from 'frontend-lmb/utils/constants';
 import { isValidDate } from '../date-input';
-import { rangordeStringToNumber } from 'frontend-lmb/utils/rangorde';
 
 export default class GenerateRowsFormComponent extends Component {
   @service store;
@@ -99,21 +99,9 @@ export default class GenerateRowsFormComponent extends Component {
       endDate: notRequiredEndDate,
       count: this.rowsToGenerate,
       rangordeStartsAt: this.getHighestRangordeAsNumber() + 1,
-      rangordeLabel: this.rangordeMandaatLabel,
+      rangordeLabel: this.selectedMandaat.parent.rangordeLabel,
     });
   });
-
-  get rangordeMandaatLabel() {
-    if (this.selectedMandaat.parent.isSchepen) {
-      return 'schepenen';
-    }
-
-    if (this.selectedMandaat.parent.isGemeenteraadslid) {
-      return 'lid';
-    }
-
-    return '';
-  }
 
   getHighestRangordeAsNumber() {
     if (this.existingMandatarissen.length === 0) {

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -99,7 +99,7 @@ export default class GenerateRowsFormComponent extends Component {
       startDate: this.startDate ?? this.args.startDate,
       endDate: notRequiredEndDate,
       count: this.rowsToGenerate,
-      startRangordeCount: this.getHighestRangordeAsNumber + 1,
+      rangordeStartsAt: this.getHighestRangordeAsNumber + 1,
     });
   });
 

--- a/app/components/verkiezingen/generate-rows-form.js
+++ b/app/components/verkiezingen/generate-rows-form.js
@@ -33,7 +33,6 @@ export default class GenerateRowsFormComponent extends Component {
   async selectMandaat(mandaatOption) {
     this.selectedMandaat = mandaatOption;
     await this.checkPossibleMandatenToGenerate.perform();
-    console.log(this.getHighestRangordeAsNumber());
   }
 
   checkPossibleMandatenToGenerate = restartableTask(async () => {
@@ -95,15 +94,32 @@ export default class GenerateRowsFormComponent extends Component {
     const notRequiredEndDate = isValidDate(this.endDate) ? this.endDate : null;
 
     this.args.onConfigReceived({
-      mandaat: this.selectedMandaat.parent,
+      mandaatUri: this.selectedMandaat.parent.uri,
       startDate: this.startDate ?? this.args.startDate,
       endDate: notRequiredEndDate,
       count: this.rowsToGenerate,
-      rangordeStartsAt: this.getHighestRangordeAsNumber + 1,
+      rangordeStartsAt: this.getHighestRangordeAsNumber() + 1,
+      rangordeLabel: this.rangordeMandaatLabel,
     });
   });
 
+  get rangordeMandaatLabel() {
+    if (this.selectedMandaat.parent.isSchepen) {
+      return 'schepenen';
+    }
+
+    if (this.selectedMandaat.parent.isGemeenteraadslid) {
+      return 'lid';
+    }
+
+    return '';
+  }
+
   getHighestRangordeAsNumber() {
+    if (this.existingMandatarissen.length === 0) {
+      return 0;
+    }
+
     return Math.max(
       ...this.existingMandatarissen.map((mandataris) => {
         if (mandataris.rangorde) {

--- a/app/components/verkiezingen/generate-rows.hbs
+++ b/app/components/verkiezingen/generate-rows.hbs
@@ -19,6 +19,6 @@
     @mandaatOptions={{this.mandaatOptions}}
     @onCancel={{@onCancel}}
     @onConfigReceived={{perform this.generateMandatarissen}}
-    @loadingMessage="Genereren"
+    @loadingMessage={{this.loadingMessage}}
   />
 {{/if}}

--- a/app/components/verkiezingen/generate-rows.hbs
+++ b/app/components/verkiezingen/generate-rows.hbs
@@ -19,6 +19,6 @@
     @mandaatOptions={{this.mandaatOptions}}
     @onCancel={{@onCancel}}
     @onConfigReceived={{perform this.generateMandatarissen}}
-    @loadingMessage={{this.loadingMessageOfGeneration}}
+    @loadingMessage="Genereren"
   />
 {{/if}}

--- a/app/components/verkiezingen/generate-rows.js
+++ b/app/components/verkiezingen/generate-rows.js
@@ -46,12 +46,9 @@ export default class GenerateRowsFormComponent extends Component {
   });
 
   generateMandatarissen = task(async (config) => {
-    const createdIds = await this.mandatarisApi.generate(config);
-    const models = await this.store.query('mandataris', {
-      'filter[:id:]': createdIds.join(','),
-    });
+    await this.mandatarisApi.generateRows(config);
     this.args.onCreated({
-      added: models,
+      updated: true,
     });
     this.args.onCancel();
   });

--- a/app/components/verkiezingen/generate-rows.js
+++ b/app/components/verkiezingen/generate-rows.js
@@ -51,4 +51,12 @@ export default class GenerateRowsFormComponent extends Component {
     });
     this.args.onCancel();
   });
+
+  get loadingMessage() {
+    if (this.generateMandatarissen.isRunning) {
+      return 'Genereren';
+    }
+
+    return null;
+  }
 }

--- a/app/components/verkiezingen/generate-rows.js
+++ b/app/components/verkiezingen/generate-rows.js
@@ -46,8 +46,12 @@ export default class GenerateRowsFormComponent extends Component {
   });
 
   generateMandatarissen = task(async (config) => {
+    const createdIds = await this.mandatarisApi.generate(config);
+    const models = await this.store.query('mandataris', {
+      'filter[:id:]': createdIds.join(','),
+    });
     this.args.onCreated({
-      added: await this.mandatarisApi.generate(config),
+      added: models,
     });
     this.args.onCancel();
   });

--- a/app/services/mandataris-api.js
+++ b/app/services/mandataris-api.js
@@ -136,7 +136,7 @@ export default class MandatarisApiService extends Service {
     return `${API.MANDATARIS_SERVICE}/mandatarissen/download?${createQueryParamsAsString.join('&')}`;
   }
 
-  async generate(config) {
+  async generateRows(config) {
     const {
       count,
       mandaatUri,
@@ -146,7 +146,7 @@ export default class MandatarisApiService extends Service {
       rangordeLabel,
     } = config;
     const response = await fetch(
-      `${API.MANDATARIS_SERVICE}/mandatarissen/generate`,
+      `${API.MANDATARIS_SERVICE}/mandatarissen/generate-rows`,
       {
         method: 'POST',
         headers: {
@@ -171,7 +171,5 @@ export default class MandatarisApiService extends Service {
         message: jsonReponse.message,
       };
     }
-
-    return jsonReponse.ids;
   }
 }

--- a/app/services/mandataris-api.js
+++ b/app/services/mandataris-api.js
@@ -135,4 +135,36 @@ export default class MandatarisApiService extends Service {
 
     return `${API.MANDATARIS_SERVICE}/mandatarissen/download?${createQueryParamsAsString.join('&')}`;
   }
+
+  async generate(config) {
+    const { count, mandaat, startDate, endDate } = config;
+    const response = await fetch(
+      `${API.MANDATARIS_SERVICE}/mandatarissen/generate`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': JSON_API_TYPE,
+        },
+        body: JSON.stringify({
+          count: count,
+          start: startDate,
+          einde: endDate,
+          bekleedt: mandaat,
+        }),
+      }
+    );
+    const jsonReponse = await response.json();
+
+    if (response.status !== STATUS_CODE.OK) {
+      console.error(jsonReponse.message);
+      throw {
+        status: response.status,
+        message: jsonReponse.message,
+      };
+    }
+
+    if (jsonReponse.fracties.length === 0) {
+      return [];
+    }
+  }
 }

--- a/app/services/mandataris-api.js
+++ b/app/services/mandataris-api.js
@@ -137,7 +137,7 @@ export default class MandatarisApiService extends Service {
   }
 
   async generate(config) {
-    const { count, mandaat, startDate, endDate } = config;
+    const { count, mandaat, startDate, endDate, rangordeStartsAt } = config;
     const response = await fetch(
       `${API.MANDATARIS_SERVICE}/mandatarissen/generate`,
       {
@@ -146,10 +146,11 @@ export default class MandatarisApiService extends Service {
           'Content-Type': JSON_API_TYPE,
         },
         body: JSON.stringify({
-          count: count,
-          start: startDate,
-          einde: endDate,
-          bekleedt: mandaat,
+          count,
+          rangordeStartsAt,
+          startDate,
+          endDate,
+          mandaat,
         }),
       }
     );

--- a/app/services/mandataris-api.js
+++ b/app/services/mandataris-api.js
@@ -137,7 +137,14 @@ export default class MandatarisApiService extends Service {
   }
 
   async generate(config) {
-    const { count, mandaat, startDate, endDate, rangordeStartsAt } = config;
+    const {
+      count,
+      mandaatUri,
+      startDate,
+      endDate,
+      rangordeStartsAt,
+      rangordeLabel,
+    } = config;
     const response = await fetch(
       `${API.MANDATARIS_SERVICE}/mandatarissen/generate`,
       {
@@ -148,9 +155,10 @@ export default class MandatarisApiService extends Service {
         body: JSON.stringify({
           count,
           rangordeStartsAt,
+          rangordeLabel,
           startDate,
           endDate,
-          mandaat,
+          mandaatUri,
         }),
       }
     );
@@ -164,8 +172,6 @@ export default class MandatarisApiService extends Service {
       };
     }
 
-    if (jsonReponse.fracties.length === 0) {
-      return [];
-    }
+    return jsonReponse.ids;
   }
 }


### PR DESCRIPTION
## Description

We want to generate the mandatarissen for IV in the mandataris service as this is way more efficient than looping over a createRecord in the frontend. 

## How to test

- Generate X amount of mandatarissen for the IV bestuursorgaan
- The rangorde will start counting from the highest rangorde

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/63

## Attachments

[generate_in_mandataris_service_Screencast_20241107_102545.webm](https://github.com/user-attachments/assets/d94608de-fb0b-4963-957a-3ef8db2fe596)
