### PR TITLE
Ben/lmb 1019 warning no chair

### DIFF
--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -79,6 +79,10 @@
       {{/unless}}
     </div>
   </div>
+  <Verkiezingen::VoorzitterAlert
+    @bestuursorgaanIT={{@bestuursorgaan}}
+    @mandatarissen={{this.mandatarissen}}
+  />
   {{#if (await @bestuursorgaan.isBCSD)}}
     <Verkiezingen::BcsdVoorzitterAlert
       @bcsdBestuursorgaanInTijd={{@bestuursorgaan}}

--- a/app/components/verkiezingen/voorzitter-alert.hbs
+++ b/app/components/verkiezingen/voorzitter-alert.hbs
@@ -1,0 +1,7 @@
+{{#if this.errorMessage}}
+  <div class="au-o-box">
+    <AuAlert @skin="warning" @icon="alert-triangle" @closable={{true}}>
+      <p>{{this.errorMessage}}</p>
+    </AuAlert>
+  </div>
+{{/if}}

--- a/app/components/verkiezingen/voorzitter-alert.hbs
+++ b/app/components/verkiezingen/voorzitter-alert.hbs
@@ -1,4 +1,4 @@
-{{#if (and (await @bestuursorgaanIT.hasVoorzitter) this.errorMessage)}}
+{{#if (and @bestuursorgaanIT.hasVoorzitter this.errorMessage)}}
   <div class="au-o-box">
     <AuAlert @skin="warning" @icon="alert-triangle" @closable={{true}}>
       <p>{{this.errorMessage}}</p>

--- a/app/components/verkiezingen/voorzitter-alert.hbs
+++ b/app/components/verkiezingen/voorzitter-alert.hbs
@@ -1,4 +1,4 @@
-{{#if this.errorMessage}}
+{{#if (and (await @bestuursorgaanIT.hasVoorzitter) this.errorMessage)}}
   <div class="au-o-box">
     <AuAlert @skin="warning" @icon="alert-triangle" @closable={{true}}>
       <p>{{this.errorMessage}}</p>

--- a/app/components/verkiezingen/voorzitter-alert.js
+++ b/app/components/verkiezingen/voorzitter-alert.js
@@ -5,7 +5,13 @@ export default class VerkiezingenVoorzitterAlertComponent extends Component {
   @service store;
 
   get errorMessage() {
-    if (this.args.mandatarissen.length == 0) {
+    if (this.args.mandatarissen.length === 0) {
+      return '';
+    }
+    if (
+      this.args.mandatarissen.length === 1 &&
+      this.args.mandatarissen.at(0).isVoorzitter
+    ) {
       return '';
     }
     const hasVoorzitter = this.args.mandatarissen.some(

--- a/app/components/verkiezingen/voorzitter-alert.js
+++ b/app/components/verkiezingen/voorzitter-alert.js
@@ -13,7 +13,7 @@ export default class VerkiezingenVoorzitterAlertComponent extends Component {
         mandataris.isVoorzitter && mandataris.isBestuurlijkeAliasVan?.id
     );
     if (!hasVoorzitter) {
-      return 'Je hebt nog geen voorzitter voor dit orgaan aangeduid. Voeg hiervoor een nieuwe mandataris met het mandaat voorzitter toe.';
+      return `Je hebt nog geen voorzitter voor het orgaan ${this.args.bestuursorgaanIT.get('isTijdsspecialisatieVan').get('naam')} aangeduid. Voeg hiervoor een nieuwe mandataris met het mandaat voorzitter toe.`;
     }
     return '';
   }

--- a/app/components/verkiezingen/voorzitter-alert.js
+++ b/app/components/verkiezingen/voorzitter-alert.js
@@ -9,7 +9,8 @@ export default class VerkiezingenVoorzitterAlertComponent extends Component {
       return '';
     }
     const hasVoorzitter = this.args.mandatarissen.some(
-      (item) => item.isVoorzitter
+      (mandataris) =>
+        mandataris.isVoorzitter && mandataris.isBestuurlijkeAliasVan?.id
     );
     if (!hasVoorzitter) {
       return 'Je hebt nog geen voorzitter voor dit orgaan aangeduid. Voeg hiervoor een nieuwe mandataris met het mandaat voorzitter toe.';

--- a/app/components/verkiezingen/voorzitter-alert.js
+++ b/app/components/verkiezingen/voorzitter-alert.js
@@ -1,0 +1,19 @@
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class VerkiezingenVoorzitterAlertComponent extends Component {
+  @service store;
+
+  get errorMessage() {
+    if (this.args.mandatarissen.length == 0) {
+      return '';
+    }
+    const hasVoorzitter = this.args.mandatarissen.some(
+      (item) => item.isVoorzitter
+    );
+    if (!hasVoorzitter) {
+      return 'Je hebt nog geen voorzitter voor dit orgaan aangeduid. Voeg hiervoor een nieuwe mandataris met het mandaat voorzitter toe.';
+    }
+    return '';
+  }
+}

--- a/app/components/verkiezingen/voorzitter-alert.js
+++ b/app/components/verkiezingen/voorzitter-alert.js
@@ -1,9 +1,6 @@
-import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class VerkiezingenVoorzitterAlertComponent extends Component {
-  @service store;
-
   get errorMessage() {
     if (this.args.mandatarissen.length === 0) {
       return '';

--- a/app/models/bestuursfunctie-code.js
+++ b/app/models/bestuursfunctie-code.js
@@ -58,4 +58,13 @@ export default class BestuursfunctieCodeModel extends Model {
       this.uri === MANDAAT_DISTRICT_BURGEMEESTER_CODE
     );
   }
+
+  get isVoorzitter() {
+    return (
+      this.uri === MANDAAT_VOORZITTER_GEMEENTERAAD_CODE ||
+      this.uri === MANDAAT_VOORZITTER_RMW_CODE ||
+      this.uri === MANDAAT_VOORZITTER_VAST_BUREAU_CODE ||
+      this.uri === MANDAAT_VOORZITTER_BCSD_CODE
+    );
+  }
 }

--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -150,6 +150,10 @@ export default class BestuursorgaanModel extends Model {
     return this.hasBestuursorgaanClassificatie(BURGEMEESTER_BESTUURSORGAAN_URI);
   }
 
+  get hasVoorzitter() {
+    return this.isGR || this.isRMW || this.isVastBureau || this.isBCSD;
+  }
+
   async getNbMembers() {
     const queryParam = this.router.currentRoute.queryParams.bestuursperiode;
     // TODO look if we can prevent these queries.

--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -151,7 +151,12 @@ export default class BestuursorgaanModel extends Model {
   }
 
   get hasVoorzitter() {
-    return this.isGR || this.isRMW || this.isVastBureau || this.isBCSD;
+    return [
+      GEMEENTERAAD_BESTUURSORGAAN_URI,
+      RMW_BESTUURSORGAAN_URI,
+      VAST_BUREAU_BESTUURSORGAAN_URI,
+      BCSD_BESTUURSORGAAN_URI,
+    ].includes(this.isTijdsspecialisatieVan.get('classificatie').get('uri'));
   }
 
   async getNbMembers() {

--- a/app/models/mandaat.js
+++ b/app/models/mandaat.js
@@ -74,6 +74,10 @@ export default class MandaatModel extends Model {
     );
   }
 
+  get isVoorzitter() {
+    return this.bestuursfunctie.get('isVoorzitter');
+  }
+
   get hasRangorde() {
     return this.isSchepen || this.isGemeenteraadslid;
   }

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -104,6 +104,10 @@ export default class MandatarisModel extends Model {
     return this.getUnique(this.vervangerVan);
   }
 
+  get isVoorzitter() {
+    return this.bekleedt.get('isVoorzitter');
+  }
+
   async getUnique(people) {
     const vervangers = new Map();
     const allPeople = (await people).slice();


### PR DESCRIPTION
## Description

Give a warning if no voorzitter is selected for an organ in the preperation of legislature. The warning only shows if at least one other mandataris has been added. It does also show if a voorzitter is added without a person (VB), but not if that is the only mandataris added (like in the initial situation).

![Screenshot 2024-11-06 at 17 23 23](https://github.com/user-attachments/assets/eb3a8d8d-9bad-49d6-8643-50f54ad5f550)

## How to test

Check if no warnings are given in the initial state.
Check if warnings are given if you add a lid, but not a voorzitter.
Check if the warning disappears if you add a voorzitter.
