### PR TITLE
lmb-963: update rangorde input icons

### DIFF
--- a/app/components/verkiezingen/rangorde-input.hbs
+++ b/app/components/verkiezingen/rangorde-input.hbs
@@ -2,7 +2,7 @@
   <div class="order-input-as-string">
     <AuButton
       hideText={{true}}
-      @icon="chevron-up"
+      @icon="plus"
       @skin="secondary"
       class="order-input-as-string--minus"
       @disabled={{this.isMinusDisabled}}
@@ -18,7 +18,7 @@
     <AuButton
       hideText={{true}}
       @skin="secondary"
-      @icon="chevron-down"
+      @icon="remove"
       class="order-input-as-string--plus"
       @disabled={{this.isPlusDisabled}}
       {{on "click" this.rangordeUp}}


### PR DESCRIPTION
## Description

The icons of rangorde should be updated to plus and minus where plus sets a higher order e.g. Eerste

## How to test

- Go to the IV create a mandataris and change the rangorde on the overview page with the plus and minus icon

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/413 => generation of mandatarissen moved to the mandataris service
