### PR TITLE
Ben/lmb 1026 rework verkiezing relations

### DIFF
--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -87,7 +87,7 @@
           @person={{this.persoon}}
           @onUpdate={{this.selectPerson}}
           @onlyElected={{true}}
-          @bestuursperiode={{@bestuursperiode}}
+          @bestuursorgaanIT={{@bestuursorgaanInTijd}}
           @inline={{true}}
         />
       </div>

--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -126,7 +126,7 @@
               @nothingSelectedText="Voeg vervanger toe"
               @selected={{this.selectedVervanger}}
               @onSelect={{perform this.addReplacement}}
-              @bestuursperiode={{@bestuursperiode}}
+              @bestuursorgaanIT={{@bestuursorgaanIT}}
               @inline={{true}}
             />
           {{else}}

--- a/app/components/mandatarissen/replacement-select.hbs
+++ b/app/components/mandatarissen/replacement-select.hbs
@@ -7,7 +7,7 @@
     @showDelete={{@showDelete}}
     @showEditAsIcon={{@showEditAsIcon}}
     @nothingSelectedText={{@nothingSelectedText}}
-    @bestuursperiode={{@bestuursperiode}}
+    @bestuursorgaanIT={{@bestuursorgaanIT}}
   />
   {{#if this.overlappingMandate}}
     <AuAlert @skin="warning" @icon="alert-triangle" class="au-u-margin-top">

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -63,6 +63,7 @@
             @mandataris={{@mandataris}}
             @selected={{this.selectedReplacement}}
             @onSelect={{this.updateReplacement}}
+            @bestuursorgaanIT={{this.currentBestuursorgaan}}
             @inline={{true}}
           />
           {{#if this.inValidReplacement}}

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -42,7 +42,7 @@ export default class MandatarissenUpdateState extends Component {
   @service fractieApi;
   @service mandatarisApi;
 
-  currentBestuursorgaan;
+  @tracked currentBestuursorgaan;
 
   constructor() {
     super(...arguments);

--- a/app/components/mandatenbeheer/mandaat-bestuursorganen-selector.js
+++ b/app/components/mandatenbeheer/mandaat-bestuursorganen-selector.js
@@ -34,11 +34,9 @@ export default class MandaatBestuursorganenSelector extends Component {
       this.args.bestuursorganen.length === 1 &&
       !(await this.args.bestuursorganen.at(0).isBCSD)
     ) {
-      const bestuursperiode =
-        await this.args.bestuursorganen.at(0).heeftBestuursperiode;
       const isElected = await this.verkiezingService.checkIfPersonIsElected(
         this.args.person.id,
-        bestuursperiode
+        this.args.bestuursorganen.at(0)
       );
       if (!isElected) {
         const burgemeesterMandaten = await Promise.all(

--- a/app/components/person/search-form.js
+++ b/app/components/person/search-form.js
@@ -85,14 +85,12 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
     }
 
     const extraFilter = {};
-    if (this.args.onlyElected && this.args.bestuursperiode) {
+    if (this.args.onlyElected && this.args.bestuursorgaanIT) {
       extraFilter.verkiezingsresultaten = {
         kandidatenlijst: {
           verkiezing: {
             'bestuursorgaan-in-tijd': {
-              'heeft-bestuursperiode': {
-                ':id:': this.args.bestuursperiode.id,
-              },
+              ':id:': this.args.bestuursorgaanIT.id,
             },
           },
         },

--- a/app/components/person/search-form.js
+++ b/app/components/person/search-form.js
@@ -89,7 +89,7 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
       extraFilter.verkiezingsresultaten = {
         kandidatenlijst: {
           verkiezing: {
-            'bestuursorgaan-in-tijd': {
+            'bestuursorganen-in-tijd': {
               ':id:': this.args.bestuursorgaanIT.id,
             },
           },

--- a/app/components/person/selector.hbs
+++ b/app/components/person/selector.hbs
@@ -58,7 +58,7 @@
         @showDefaultHead={{false}}
         @onSelect={{this.onSelectPerson}}
         @onCreateNewPerson={{this.onCreateNewPerson}}
-        @bestuursperiode={{@bestuursperiode}}
+        @bestuursorgaanIT={{@bestuursorgaanIT}}
         @onlyElected={{@onlyElected}}
       />
     {{/if}}
@@ -85,7 +85,7 @@
           @onSelect={{this.onSelectPerson}}
           @onCreateNewPerson={{this.onCreateNewPerson}}
           @onCancel={{this.cancelEdit}}
-          @bestuursperiode={{@bestuursperiode}}
+          @bestuursorgaanIT={{@bestuursorgaanIT}}
           @onlyElected={{@onlyElected}}
         />
       {{/if}}

--- a/app/components/rdf-input-fields/person-selector.hbs
+++ b/app/components/rdf-input-fields/person-selector.hbs
@@ -11,7 +11,7 @@
         @person={{this.person}}
         @onUpdate={{this.onUpdate}}
         @onlyElected={{this.onlyElected}}
-        @bestuursperiode={{this.currentBestuursperiode}}
+        @bestuursorgaanIT={{this.bestuursorgaanIT}}
       />
     </div>
     {{#each this.errors as |error|}}

--- a/app/components/rdf-input-fields/person-selector.js
+++ b/app/components/rdf-input-fields/person-selector.js
@@ -93,9 +93,8 @@ export default class PersonSelectorComponent extends InputFieldComponent {
     if (this.person && this.onlyElected) {
       const isElected = await this.verkiezingService.checkIfPersonIsElected(
         this.person.id,
-        this.currentBestuursperiode
+        this.bestuursorgaanIT
       );
-
       if (!isElected) {
         this.person = null;
         replaceSingleFormValue(this.storeOptions, null);

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -5,7 +5,6 @@
     @onUpdateBurgemeester={{@onUpdateBurgemeester}}
     @bestuursperiode={{@bestuursperiode}}
     @bestuurseenheid={{@bestuurseenheid}}
-    @bestuursorganen={{@bestuursorganen}}
   />
 {{else}}
   <div class="au-u-flex au-u-flex--column au-u-flex--row-when-medium">

--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -67,7 +67,7 @@ export default class BestuursorgaanModel extends Model {
 
   @belongsTo('rechtstreekse-verkiezing', {
     async: true,
-    inverse: 'bestuursorgaanInTijd',
+    inverse: 'bestuursorganenInTijd',
   })
   verkiezing;
 

--- a/app/models/rechtstreekse-verkiezing.js
+++ b/app/models/rechtstreekse-verkiezing.js
@@ -1,14 +1,14 @@
-import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class RechtstreekseVerkiezingModel extends Model {
   @attr('date') datum;
   @attr('date') geldigheid;
 
-  @belongsTo('bestuursorgaan', {
+  @hasMany('bestuursorgaan', {
     async: true,
     inverse: 'verkiezing',
   })
-  bestuursorgaanInTijd;
+  bestuursorganenInTijd;
 
   @hasMany('kandidatenlijst', {
     async: true,

--- a/app/routes/verkiezingen/installatievergadering.js
+++ b/app/routes/verkiezingen/installatievergadering.js
@@ -115,7 +115,7 @@ export default class PrepareInstallatievergaderingRoute extends Route {
 
   async getKandidatenLijsten(bestuursperiode) {
     const queryParams = {
-      'filter[verkiezing][bestuursorgaan-in-tijd][heeft-bestuursperiode][:id:]':
+      'filter[verkiezing][bestuursorganen-in-tijd][heeft-bestuursperiode][:id:]':
         bestuursperiode.id,
       include: 'resulterende-fracties',
     };

--- a/app/routes/verkiezingen/verkiezingsuitslag.js
+++ b/app/routes/verkiezingen/verkiezingsuitslag.js
@@ -42,7 +42,7 @@ export default class VerkiezingenVerkiezingsuitslagRoute extends Route {
         number: params.page,
         size: params.size,
       },
-      'filter[kandidatenlijst][verkiezing][bestuursorgaan-in-tijd][heeft-bestuursperiode][:id:]':
+      'filter[kandidatenlijst][verkiezing][bestuursorganen-in-tijd][heeft-bestuursperiode][:id:]':
         params.id,
       'filter[:has:persoon]': 'true',
       include: [

--- a/app/services/verkiezing.js
+++ b/app/services/verkiezing.js
@@ -5,7 +5,7 @@ import { service } from '@ember/service';
 export default class VerkiezingService extends Service {
   @service store;
 
-  async checkIfPersonIsElected(personId, bestuursperiode) {
+  async checkIfPersonIsElected(personId, bestuursorgaan) {
     const matches = await this.store.query('persoon', {
       include: [
         'verkiezingsresultaten',
@@ -14,8 +14,8 @@ export default class VerkiezingService extends Service {
         'verkiezingsresultaten.kandidatenlijst.verkiezing.bestuursorgaan-in-tijd',
         'verkiezingsresultaten.kandidatenlijst.verkiezing.bestuursorgaan-in-tijd.heeft-bestuursperiode',
       ].join(','),
-      'filter[verkiezingsresultaten][kandidatenlijst][verkiezing][bestuursorgaan-in-tijd][heeft-bestuursperiode][:id:]':
-        bestuursperiode.id,
+      'filter[verkiezingsresultaten][kandidatenlijst][verkiezing][bestuursorgaan-in-tijd][:id:]':
+        bestuursorgaan.id,
       'filter[verkiezingsresultaten][persoon][:id:]': personId,
     });
     return matches.length > 0;

--- a/app/services/verkiezing.js
+++ b/app/services/verkiezing.js
@@ -11,10 +11,10 @@ export default class VerkiezingService extends Service {
         'verkiezingsresultaten',
         'verkiezingsresultaten.kandidatenlijst',
         'verkiezingsresultaten.kandidatenlijst.verkiezing',
-        'verkiezingsresultaten.kandidatenlijst.verkiezing.bestuursorgaan-in-tijd',
-        'verkiezingsresultaten.kandidatenlijst.verkiezing.bestuursorgaan-in-tijd.heeft-bestuursperiode',
+        'verkiezingsresultaten.kandidatenlijst.verkiezing.bestuursorganen-in-tijd',
+        'verkiezingsresultaten.kandidatenlijst.verkiezing.bestuursorganen-in-tijd.heeft-bestuursperiode',
       ].join(','),
-      'filter[verkiezingsresultaten][kandidatenlijst][verkiezing][bestuursorgaan-in-tijd][:id:]':
+      'filter[verkiezingsresultaten][kandidatenlijst][verkiezing][bestuursorganen-in-tijd][:id:]':
         bestuursorgaan.id,
       'filter[verkiezingsresultaten][persoon][:id:]': personId,
     });

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -52,7 +52,7 @@
   <div class="au-o-box">
     <Mandatarissen::MandatarisCard
       @mandataris={{@model.mandataris}}
-      @bestuursperiode={{@model.selectedBestuursperiode}}
+      @bestuursorgaanIT={{get @model.bestuursorganen 0}}
       @disableEdits={{this.isDisabledBecauseLegislatuur}}
     />
   </div>


### PR DESCRIPTION
## Description

Update the verkiezing - bestuursorgaan relation. Before a verkiezing could only have one bestuursorgaan. Now verkiezingen can have many. We also link the verkiezing to all relevant bestuursorganen and update the person selectors to use the verkiezing linked to the bestuursorgaan in de tijd instead of the verkiezing with the correct bestuursperiode.

## How to test

First checkout the linked PR in the app. You need to restart your resources and your migrations.
After that you should now have two verkiezingsresultaten in the faciliteitengemeentes. See the PR itself for which gemeentes are faciliteitengemeentes.
This should be clear when you go to the prepare installatievergadering of such a gemeente. For the gemeente bestuursorganen you should get different elected people you can select then for the ocmw bestuursorganen. Just check a few people from the verkiezingsresultaten and see them pop up in one selector, but not the other. 
I used "Cogels" in "Drogenbos", but it would be best if you check someone else in another bestuurseenheid.

Lastly you should check if the person-selector still works as expected in the different locations it is used.

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/279
