### PR TITLE
lmb-934: date input can handle undefined start date for bindingStart

### DIFF
--- a/app/utils/form-context/application-context-meta-ttl.js
+++ b/app/utils/form-context/application-context-meta-ttl.js
@@ -80,7 +80,7 @@ const getBestuursperiodeForBestuursorganen = (bestuursorganen) => {
     const bestuursorgaan = bestuursorganen.at(0);
 
     return {
-      startDate: bestuursorgaan.bindingStart,
+      startDate: bestuursorgaan.bindingStart ?? NULL_DATE,
       endDate: bestuursorgaan.bindingEinde ?? NULL_DATE,
     };
   }

--- a/app/utils/form-validations/mandataris-date-in-bestuursperiod.js
+++ b/app/utils/form-validations/mandataris-date-in-bestuursperiod.js
@@ -11,10 +11,14 @@ export const isValidMandatarisDate = ([dateLiteral], options) => {
   const date = new Date(dateLiteral.value);
   const period = loadBestuursorgaanPeriodFromContext(options);
   let maxDate = period.endDate;
+  let startDate = period.startDate;
 
   if (moment(period.endDate).isSame(moment(NULL_DATE))) {
     maxDate = null;
   }
+  if (moment(period.startDate).isSame(moment(NULL_DATE))) {
+    startDate = null;
+  }
 
-  return isDateInRange(date, period.startDate, maxDate);
+  return isDateInRange(date, startDate, maxDate);
 };


### PR DESCRIPTION
## Description

The date input field cannot handle returns invalid in the form when no min date is set.

## How to test

Create a mandataris in an eigen orgaan in the politieraad and it should create the mandataris even so the binding start and end are not defined.

