### PR TITLE
lmb-934: do not show IV card for provincie and politiezone  (district…

### DIFF
--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -8,6 +8,10 @@ export const BESTUURSEENHEID_CLASSIFICATIECODE_OCMW =
   'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002';
 export const BESTUURSEENHEID_CLASSIFICATIECODE_DISTRICT =
   'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003';
+export const BESTUURSEENHEID_CLASSIFICATIECODE_POLITIEZONE =
+  'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc';
+export const BESTUURSEENHEID_CLASSIFICATIECODE_PROVINCIE =
+  'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000';
 export const MANDATARIS_VERHINDERD_STATE =
   'http://data.vlaanderen.be/id/concept/MandatarisStatusCode/c301248f-0199-45ca-b3e5-4c596731d5fe';
 export const MANDATARIS_TITELVOEREND_STATE =


### PR DESCRIPTION
## Description

As a IV is not done in provincie and politiezone we do not need to show IV card and menu  titles for it

## How to test

See if the IV card is not visible in provincie, districten and politiezones

