### PR TITLE
Ben/lmb 1036 show election results faciliteitengemeentes

### DIFF
--- a/app/controllers/verkiezingen/installatievergadering.js
+++ b/app/controllers/verkiezingen/installatievergadering.js
@@ -36,6 +36,7 @@ export default class PrepareInstallatievergaderingController extends Controller 
   @tracked statusPillLabel = 'info';
   @tracked nextStatus;
   @tracked isModalOpen = false;
+  @tracked VerkiezingsUitslagModal = false;
 
   @action
   async selectStatus(status) {

--- a/app/controllers/verkiezingen/installatievergadering.js
+++ b/app/controllers/verkiezingen/installatievergadering.js
@@ -36,7 +36,7 @@ export default class PrepareInstallatievergaderingController extends Controller 
   @tracked statusPillLabel = 'info';
   @tracked nextStatus;
   @tracked isModalOpen = false;
-  @tracked VerkiezingsUitslagModal = false;
+  @tracked verkiezingsUitslagModal = false;
 
   @action
   async selectStatus(status) {

--- a/app/controllers/verkiezingen/verkiezingsuitslag.js
+++ b/app/controllers/verkiezingen/verkiezingsuitslag.js
@@ -17,6 +17,10 @@ export default class VerkiezingenVerkiezingsuitslagController extends Controller
 
   @tracked searchData;
 
+  get getYear() {
+    return this.model.verkiezing.datum.getFullYear();
+  }
+
   get downloadLink() {
     return `/election-results-api/${this.model.verkiezing.id}/download`;
   }

--- a/app/models/rechtstreekse-verkiezing.js
+++ b/app/models/rechtstreekse-verkiezing.js
@@ -1,4 +1,13 @@
 import Model, { attr, hasMany } from '@ember-data/model';
+import {
+  KANDIDATENLIJST_DISTRICTSRAAD,
+  KANDIDATENLIJST_GEMEENTERAAD,
+  KANDIDATENLIJST_KAMER_VOLKSVERTEGENWOORDIGING,
+  KANDIDATENLIJST_OCMW,
+  KANDIDATENLIJST_PROVINCIERAAD,
+  KANDIDATENLIJST_SENAAT,
+  KANDIDATENLIJST_VLAAMS_PARLEMENT,
+} from 'frontend-lmb/utils/well-known-uris';
 
 export default class RechtstreekseVerkiezingModel extends Model {
   @attr('date') datum;
@@ -16,7 +25,19 @@ export default class RechtstreekseVerkiezingModel extends Model {
   })
   kandidatenlijsten;
 
-  get getLijsttype() {
-    return this.kandidatenlijsten.slice().at(0).get('lijsttype').get('label');
+  get getType() {
+    const type = this.kandidatenlijsten.slice().at(0).get('lijsttype');
+    return typeMapping[type.get('uri')];
   }
 }
+
+const typeMapping = {
+  [KANDIDATENLIJST_GEMEENTERAAD]: 'Gemeenteraad',
+  [KANDIDATENLIJST_OCMW]: 'OCMW',
+  [KANDIDATENLIJST_DISTRICTSRAAD]: 'Districtsraad',
+  [KANDIDATENLIJST_PROVINCIERAAD]: 'Provincieraad',
+  [KANDIDATENLIJST_VLAAMS_PARLEMENT]: 'Vlaams Parlement',
+  [KANDIDATENLIJST_SENAAT]: 'Senaat',
+  [KANDIDATENLIJST_KAMER_VOLKSVERTEGENWOORDIGING]:
+    'Kamer van volksvertegenwoordiging',
+};

--- a/app/models/rechtstreekse-verkiezing.js
+++ b/app/models/rechtstreekse-verkiezing.js
@@ -15,4 +15,8 @@ export default class RechtstreekseVerkiezingModel extends Model {
     inverse: 'verkiezing',
   })
   kandidatenlijsten;
+
+  get getLijsttype() {
+    return this.kandidatenlijsten.slice().at(0).get('lijsttype').get('label');
+  }
 }

--- a/app/routes/verkiezingen/installatievergadering.js
+++ b/app/routes/verkiezingen/installatievergadering.js
@@ -59,6 +59,7 @@ export default class PrepareInstallatievergaderingRoute extends Route {
     const bestuursorganenInTijd =
       await this.getBestuursorganenInTijd(selectedPeriod);
 
+    const verkiezingen = await this.getVerkiezingen(selectedPeriod);
     const kandidatenlijsten = await this.getKandidatenLijsten(selectedPeriod);
 
     const mandatarisForm = getFormFrom(this.store, MANDATARIS_EXTENDED_FORM);
@@ -69,6 +70,7 @@ export default class PrepareInstallatievergaderingRoute extends Route {
       bestuurseenheid,
       bestuursorganenInTijd,
       mandatarisForm,
+      verkiezing: verkiezingen.at(0),
       kandidatenlijsten,
       bestuursPeriods,
       selectedPeriod,
@@ -111,6 +113,19 @@ export default class PrepareInstallatievergaderingRoute extends Route {
     });
 
     return sortedBestuursorganenInTijd;
+  }
+
+  async getVerkiezingen(bestuursperiode) {
+    const queryParams = {
+      'filter[bestuursorganen-in-tijd][heeft-bestuursperiode][:id:]':
+        bestuursperiode.id,
+      include: [
+        'kandidatenlijsten',
+        'kandidatenlijsten.resulterende-fracties',
+      ].join(','),
+    };
+
+    return await this.store.query('rechtstreekse-verkiezing', queryParams);
   }
 
   async getKandidatenLijsten(bestuursperiode) {

--- a/app/routes/verkiezingen/installatievergadering.js
+++ b/app/routes/verkiezingen/installatievergadering.js
@@ -121,6 +121,7 @@ export default class PrepareInstallatievergaderingRoute extends Route {
         bestuursperiode.id,
       include: [
         'kandidatenlijsten',
+        'kandidatenlijsten.lijsttype',
         'kandidatenlijsten.resulterende-fracties',
       ].join(','),
     };

--- a/app/routes/verkiezingen/installatievergadering.js
+++ b/app/routes/verkiezingen/installatievergadering.js
@@ -70,7 +70,7 @@ export default class PrepareInstallatievergaderingRoute extends Route {
       bestuurseenheid,
       bestuursorganenInTijd,
       mandatarisForm,
-      verkiezing: verkiezingen.at(0),
+      verkiezingen,
       kandidatenlijsten,
       bestuursPeriods,
       selectedPeriod,

--- a/app/routes/verkiezingen/installatievergadering.js
+++ b/app/routes/verkiezingen/installatievergadering.js
@@ -138,4 +138,10 @@ export default class PrepareInstallatievergaderingRoute extends Route {
 
     return await this.store.query('kandidatenlijst', queryParams);
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.set('verkiezingsUitslagModal', false);
+    }
+  }
 }

--- a/app/routes/verkiezingen/verkiezingsuitslag.js
+++ b/app/routes/verkiezingen/verkiezingsuitslag.js
@@ -15,21 +15,16 @@ export default class VerkiezingenVerkiezingsuitslagRoute extends Route {
 
   async model(params) {
     const options = this.getOptions(params);
+    const verkiezing = await this.store.findRecord(
+      'rechtstreekse-verkiezing',
+      params.id
+    );
     const verkiezingsresultaten = await this.store.query(
       'verkiezingsresultaat',
       options
     );
-    const selectedPeriod = await this.store.findRecord(
-      'bestuursperiode',
-      params.id
-    );
-
-    const verkiezing = await (
-      await verkiezingsresultaten[0]?.kandidatenlijst
-    )?.verkiezing;
 
     return {
-      selectedPeriod,
       verkiezing,
       verkiezingsresultaten,
     };
@@ -42,14 +37,9 @@ export default class VerkiezingenVerkiezingsuitslagRoute extends Route {
         number: params.page,
         size: params.size,
       },
-      'filter[kandidatenlijst][verkiezing][bestuursorganen-in-tijd][heeft-bestuursperiode][:id:]':
-        params.id,
+      'filter[kandidatenlijst][verkiezing][:id:]': params.id,
       'filter[:has:persoon]': 'true',
-      include: [
-        'kandidatenlijst',
-        'kandidatenlijst.verkiezing',
-        'persoon',
-      ].join(','),
+      include: ['kandidatenlijst', 'persoon'].join(','),
     };
     if (params.filter && params.filter.length > 0) {
       options['filter[persoon]'] = params.filter;

--- a/app/templates/verkiezingen/installatievergadering.hbs
+++ b/app/templates/verkiezingen/installatievergadering.hbs
@@ -135,7 +135,8 @@
               @route="verkiezingen.verkiezingsuitslag"
               @model={{verkiezing.id}}
               role="menuitem"
-            >{{verkiezing.getLijsttype}}
+            >Verkiezingsuitslag
+              {{verkiezing.getType}}
             </AuLink>
           {{/each}}
         </AuDropdown>

--- a/app/templates/verkiezingen/installatievergadering.hbs
+++ b/app/templates/verkiezingen/installatievergadering.hbs
@@ -135,7 +135,7 @@
               @route="verkiezingen.verkiezingsuitslag"
               @model={{verkiezing.id}}
               role="menuitem"
-            >Bekijk verkiezingsuitslag
+            >{{verkiezing.getLijsttype}}
             </AuLink>
           {{/each}}
         </AuDropdown>

--- a/app/templates/verkiezingen/installatievergadering.hbs
+++ b/app/templates/verkiezingen/installatievergadering.hbs
@@ -55,7 +55,10 @@
         >Bekijk verkiezingsuitslag
         </AuLink>
       {{else}}
-        <AuButton @skin="button-secondary">Bekijk verkiezingsuitslag
+        <AuButton
+          @skin="secondary"
+          {{on "click" (fn (mut this.verkiezingsUitslagModal) true)}}
+        >Bekijk verkiezingsuitslag
         </AuButton>
       {{/if}}
 
@@ -110,6 +113,36 @@
       </div>
     {{/unless}}
   </div>
+
+  <AuModal
+    @title="Selecteer type verkiezingsuitslag"
+    @modalOpen={{this.verkiezingsUitslagModal}}
+    @closable={{true}}
+    @closeModal={{fn (mut this.verkiezingsUitslagModal) false}}
+  >
+    <div class="au-o-box">
+      Deze installatievergadering bevat de uitslag van meerdere verkiezingen.
+      Selecteer welke uitslag je wilt bekijken.
+      <li class="au-c-list-horizontal__item au-u-margin-top-small">
+        <AuDropdown
+          @title="Selecteer verkiezingsuitslag"
+          @alignment="left"
+          @skin="secondary"
+          role="menu"
+        >
+          {{#each @model.verkiezingen as |verkiezing|}}
+            <AuLink
+              @route="verkiezingen.verkiezingsuitslag"
+              @model={{verkiezing.id}}
+              role="menuitem"
+            >Bekijk verkiezingsuitslag
+            </AuLink>
+          {{/each}}
+        </AuDropdown>
+      </li>
+    </div>
+  </AuModal>
+
   <AuModal
     @title={{this.modalTitle}}
     @modalOpen={{this.isModalOpen}}

--- a/app/templates/verkiezingen/installatievergadering.hbs
+++ b/app/templates/verkiezingen/installatievergadering.hbs
@@ -49,10 +49,9 @@
     <Group>
       <AuLink
         @route="verkiezingen.verkiezingsuitslag"
-        @model={{@model.selectedPeriod.id}}
+        @model={{@model.verkiezing.id}}
         @skin="button-secondary"
       >Bekijk verkiezingsuitslag
-        {{this.model.selectedPeriod.start}}
       </AuLink>
 
       <Shared::Tooltip

--- a/app/templates/verkiezingen/installatievergadering.hbs
+++ b/app/templates/verkiezingen/installatievergadering.hbs
@@ -47,12 +47,17 @@
       </div>
     </Group>
     <Group>
-      <AuLink
-        @route="verkiezingen.verkiezingsuitslag"
-        @model={{@model.verkiezing.id}}
-        @skin="button-secondary"
-      >Bekijk verkiezingsuitslag
-      </AuLink>
+      {{#if (eq @model.verkiezingen.length 1)}}
+        <AuLink
+          @route="verkiezingen.verkiezingsuitslag"
+          @model={{get (get @model.verkiezingen 0) "id"}}
+          @skin="button-secondary"
+        >Bekijk verkiezingsuitslag
+        </AuLink>
+      {{else}}
+        <AuButton @skin="button-secondary">Bekijk verkiezingsuitslag
+        </AuButton>
+      {{/if}}
 
       <Shared::Tooltip
         @showTooltip={{this.statusIsDisabled}}

--- a/app/templates/verkiezingen/verkiezingsuitslag.hbs
+++ b/app/templates/verkiezingen/verkiezingsuitslag.hbs
@@ -10,7 +10,9 @@
   <div
     class="au-u-flex au-u-flex--between au-u-padding au-u-padding-bottom-none"
   >
-    <AuHeading @skin="2">Verkiezingsuitslag {{this.getYear}}</AuHeading>
+    <AuHeading @skin="2">Verkiezingsuitslag
+      {{this.model.verkiezing.getType}}
+      {{this.getYear}}</AuHeading>
     <AuLinkExternal
       href={{this.downloadLink}}
       download="verkiezingsresultaten"

--- a/app/templates/verkiezingen/verkiezingsuitslag.hbs
+++ b/app/templates/verkiezingen/verkiezingsuitslag.hbs
@@ -1,16 +1,16 @@
 {{page-title "Verkiezingsuitslag"}}
 {{breadcrumb
   "Verkiezingsuitslag "
-  this.model.selectedPeriod.start
+  this.getYear
   route="verkiezingen.verkiezingsuitslag"
-  model=this.model.selectedPeriod.id
+  model=this.model.verkiezing.id
 }}
 
 <div class="au-c-body-container">
   <div
     class="au-u-flex au-u-flex--between au-u-padding au-u-padding-bottom-none"
   >
-    <AuHeading @skin="2">Verkiezingsuitslag</AuHeading>
+    <AuHeading @skin="2">Verkiezingsuitslag {{this.getYear}}</AuHeading>
     <AuLinkExternal
       href={{this.downloadLink}}
       download="verkiezingsresultaten"

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -77,3 +77,18 @@ export const INSTALLATIEVERGADERING_TE_BEHANDELEN_STATUS =
   'http://data.lblod.info/id/concept/InstallatievergaderingStatus/b54dbe98-d618-4af7-9f01-791aa90774e4';
 export const INSTALLATIEVERGADERING_KLAAR_VOOR_VERGADERING_STATUS =
   'http://data.lblod.info/id/concept/InstallatievergaderingStatus/a40b8f8a-8de2-4710-8d9b-3fc43a4b740e';
+
+export const KANDIDATENLIJST_GEMEENTERAAD =
+  'http://data.vlaanderen.be/id/concept/KandidatenlijstLijsttype/95de36e5-8c7a-4308-af7b-75afbd943dd2';
+export const KANDIDATENLIJST_OCMW =
+  'http://data.vlaanderen.be/id/concept/KandidatenlijstLijsttype/967a4dd2-53d7-48e8-becd-16a354580623';
+export const KANDIDATENLIJST_DISTRICTSRAAD =
+  'http://data.vlaanderen.be/id/concept/KandidatenlijstLijsttype/44aa08d2-fa02-42a3-8ae2-7dbfb23afdcc';
+export const KANDIDATENLIJST_PROVINCIERAAD =
+  'http://data.vlaanderen.be/id/concept/KandidatenlijstLijsttype/90e3b7d0-2fae-43a1-957e-6daa8d072be1';
+export const KANDIDATENLIJST_VLAAMS_PARLEMENT =
+  'http://data.vlaanderen.be/id/concept/KandidatenlijstLijsttype/33c0d12e-3588-41b9-90f1-05690ea7d8f6';
+export const KANDIDATENLIJST_SENAAT =
+  'http://data.vlaanderen.be/id/concept/KandidatenlijstLijsttype/af845873-f8fa-4c7e-b67c-10e44957c40e';
+export const KANDIDATENLIJST_KAMER_VOLKSVERTEGENWOORDIGING =
+  'http://data.vlaanderen.be/id/concept/KandidatenlijstLijsttype/83b89937-84e1-4e6c-a070-83b0fda51871';


### PR DESCRIPTION
## Description

For faciliteitengemeentes, the prepare iv can have multiple verkiezingsresultaten. If the iv has one type of verkiezingsresultaat (e.g. gemeenteraadsverkiezingen) you will go to that url immediately, if there are more, you have to select which one you want to go to.

![Screenshot 2024-11-12 at 14 10 17](https://github.com/user-attachments/assets/f060c56e-0758-486e-afba-2a0704a83893)

Not that happy with the UI, but don't care enough to waste too much time on it.

I made a mapping of kandidatenlijsten to types of verkiezingen, which is probably a bit too extensive (we only need ocmw and gemeente), but I would rather match all than miss something.

## How to test

Go to a normal gemeente, check if you go to the results of the elections immediately. Go to a faciliteitsgemeente (e.g. Drogenbos) and check if you get the modal and it works.