### PR TITLE
Ben/lmb 1037 hide duplicate kandidatenlijsten

### DIFF
--- a/app/routes/verkiezingen/installatievergadering.js
+++ b/app/routes/verkiezingen/installatievergadering.js
@@ -137,17 +137,13 @@ export default class PrepareInstallatievergaderingRoute extends Route {
       include: ['resulterende-fracties', 'lijsttype'].join(','),
     };
     const results = await this.store.query('kandidatenlijst', queryParams);
-    return (
-      await Promise.all(
-        results.map(async (lijst) => {
-          if (
-            (await lijst.get('lijsttype')).get('uri') !== KANDIDATENLIJST_OCMW
-          ) {
-            return lijst;
-          }
-          return null;
-        })
-      )
-    ).filter(Boolean);
+    return results
+      .map((lijst) => {
+        if (lijst.get('lijsttype').get('uri') !== KANDIDATENLIJST_OCMW) {
+          return lijst;
+        }
+        return null;
+      })
+      .filter(Boolean);
   }
 }

--- a/app/routes/verkiezingen/installatievergadering.js
+++ b/app/routes/verkiezingen/installatievergadering.js
@@ -137,13 +137,8 @@ export default class PrepareInstallatievergaderingRoute extends Route {
       include: ['resulterende-fracties', 'lijsttype'].join(','),
     };
     const results = await this.store.query('kandidatenlijst', queryParams);
-    return results
-      .map((lijst) => {
-        if (lijst.get('lijsttype').get('uri') !== KANDIDATENLIJST_OCMW) {
-          return lijst;
-        }
-        return null;
-      })
-      .filter(Boolean);
+    return results.filter((lijst) => {
+      return lijst.get('lijsttype').get('uri') !== KANDIDATENLIJST_OCMW;
+    });
   }
 }

--- a/app/routes/verkiezingen/installatievergadering.js
+++ b/app/routes/verkiezingen/installatievergadering.js
@@ -11,6 +11,7 @@ import {
   CBS_BESTUURSORGAAN_URI,
   GEMEENTERAAD_BESTUURSORGAAN_URI,
   INSTALLATIEVERGADERING_BEHANDELD_STATUS,
+  KANDIDATENLIJST_OCMW,
   RMW_BESTUURSORGAAN_URI,
   VAST_BUREAU_BESTUURSORGAAN_URI,
 } from 'frontend-lmb/utils/well-known-uris';
@@ -133,9 +134,20 @@ export default class PrepareInstallatievergaderingRoute extends Route {
     const queryParams = {
       'filter[verkiezing][bestuursorganen-in-tijd][heeft-bestuursperiode][:id:]':
         bestuursperiode.id,
-      include: 'resulterende-fracties',
+      include: ['resulterende-fracties', 'lijsttype'].join(','),
     };
-
-    return await this.store.query('kandidatenlijst', queryParams);
+    const results = await this.store.query('kandidatenlijst', queryParams);
+    return (
+      await Promise.all(
+        results.map(async (lijst) => {
+          if (
+            (await lijst.get('lijsttype')).get('uri') !== KANDIDATENLIJST_OCMW
+          ) {
+            return lijst;
+          }
+          return null;
+        })
+      )
+    ).filter(Boolean);
   }
 }


### PR DESCRIPTION
## Description

In faciliteitsgemeentes, kandidatenlijsten were shown for gemeente and ocmw. Hide those for the OCMW, we don't really care about them.

## How to test

Go to faciliteitsgemeente, check if kandidatenlijsten are only shown once and check if the flow of iv and syncing still works as expected.
