### PR TITLE
Ben/lmb 957 linked mandate warning

### DIFF
--- a/app/controllers/mandatarissen/persoon/mandataris.js
+++ b/app/controllers/mandatarissen/persoon/mandataris.js
@@ -141,9 +141,10 @@ export default class MandatarissenPersoonMandatarisController extends Controller
   }
 
   get warningTextOCMWLinkToGemeente() {
-    return `Let op! Bij het wijzigen van deze gegevens worden mogelijke koppelingen
-      verbroken. Het doorstromen van gegevens van de gemeente naar OCMW zal
+    return `Let op! Deze mandataris heeft een gelinkte mandataris in de gemeente.
+      Bij het aanpassen van deze gegevens wordt deze koppeling verbroken.
+      Het doorstromen van gegevens van de gemeente naar OCMW zal
       hierdoor ook niet meer gebeuren. Om een wijziging aan beide mandaten te
-      maken, gelieve dit te doen bij de Gemeente.`;
+      maken, gelieve dit te doen in de gemeente.`;
   }
 }

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -32,6 +32,8 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
     const selectedBestuursperiode = (await bestuursorganen)[0]
       .heeftBestuursperiode;
     const isDistrict = this.currentSession.isDistrict;
+    const showOCMWLinkedMandatarisWarning =
+      await this.showOCMWLinkedMandatarisWarning(bestuurseenheid, mandataris);
 
     return RSVP.hash({
       bestuurseenheid,
@@ -42,6 +44,7 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
       bestuursorganen,
       selectedBestuursperiode,
       isDistrictEenheid: isDistrict,
+      showOCMWLinkedMandatarisWarning,
     });
   }
 
@@ -82,5 +85,9 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
     };
 
     return await this.store.query('mandataris', queryParams);
+  }
+
+  async showOCMWLinkedMandatarisWarning(bestuurseenheid, mandataris) {
+    return bestuurseenheid.isOCMW;
   }
 }

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -33,7 +33,10 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
       .heeftBestuursperiode;
     const isDistrict = this.currentSession.isDistrict;
     const showOCMWLinkedMandatarisWarning =
-      await this.showOCMWLinkedMandatarisWarning(bestuurseenheid, mandataris);
+      await this.showOCMWLinkedMandatarisWarning(
+        bestuurseenheid,
+        params.mandataris_id
+      );
 
     return RSVP.hash({
       bestuurseenheid,
@@ -88,6 +91,24 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
   }
 
   async showOCMWLinkedMandatarisWarning(bestuurseenheid, mandataris) {
-    return bestuurseenheid.isOCMW;
+    const isOCMW = bestuurseenheid.isOCMW;
+    if (!isOCMW) {
+      return false;
+    }
+
+    const response = await fetch(
+      `/mandataris-api/mandatarissen/${mandataris}/check-possible-double`
+    );
+    const jsonReponse = await response.json();
+
+    if (response.status !== 200) {
+      console.error(jsonReponse.message);
+      throw jsonReponse.message;
+    }
+
+    if (jsonReponse.duplicateMandate && jsonReponse.hasDouble) {
+      return true;
+    }
+    return false;
   }
 }

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -100,7 +100,7 @@
       mandaat aan te passen. Dit zal een nieuw mandaat starten met de gewijzigde
       situatie.</p>
   </AuAlert>
-  {{#if @model.bestuurseenheid.isOCMW}}
+  {{#if @model.showOCMWLinkedMandatarisWarning}}
     <AuAlert
       @skin="warning"
       @icon="alert-triangle"
@@ -134,7 +134,7 @@
       gebruik
       <span class="au-u-medium">Wijzig huidig mandaat</span>.</p>
   </AuAlert>
-  {{#if @model.bestuurseenheid.isOCMW}}
+  {{#if @model.showOCMWLinkedMandatarisWarning}}
     <AuAlert
       @skin="warning"
       @icon="alert-triangle"


### PR DESCRIPTION
## Description

If you open the update state or corrigeer fouten in the OCMW. There was always a warning about linked mandatarissen. This warning is now only shown whenever there is a link and you are editing an ocmw mandataris.

![Screenshot 2024-11-18 at 16 16 30](https://github.com/user-attachments/assets/ec9e4f38-d837-4794-8626-6f3b169a9bd9)

## How to test

Check a few mandatarissen in the gemeente, this warning should never show up.
Check a few existing mandatarissen in the ocmw, this warning should also not show up (except if you added linked mandatarissen in the past)
Add a mandataris in the gemeente with a linked mandate. Then check that linked mandataris in the OCMW and see the warning does show now.