### PR TITLE
Ben/lmb 1052 create people ocmw

### DIFF
--- a/app/components/person/selector.js
+++ b/app/components/person/selector.js
@@ -50,7 +50,7 @@ export default class PersonSelectorComponent extends Component {
     this.closeModal();
     this.persoonApi.putPersonInRightGraph(
       instanceId,
-      this.args.bestuursorgaanIT
+      this.args.bestuursorgaanIT.id
     );
     this.args.onUpdate(this.person);
   }

--- a/app/components/person/selector.js
+++ b/app/components/person/selector.js
@@ -48,11 +48,11 @@ export default class PersonSelectorComponent extends Component {
     const persoon = await this.store.findRecord('persoon', instanceId);
     this.person = persoon;
     this.closeModal();
-    this.persoonApi.putPersonInRightGraph(
+    await this.persoonApi.putPersonInRightGraph(
       instanceId,
       this.args.bestuursorgaanIT.id
     );
-    this.args.onUpdate(this.person);
+    await this.args.onUpdate(this.person);
   }
 
   @action

--- a/app/components/person/selector.js
+++ b/app/components/person/selector.js
@@ -14,6 +14,7 @@ export default class PersonSelectorComponent extends Component {
   inputId = 'input-' + guidFor(this);
 
   @service store;
+  @service persoonApi;
 
   @tracked person = null;
   @tracked selectNewPerson = false;
@@ -47,6 +48,10 @@ export default class PersonSelectorComponent extends Component {
     const persoon = await this.store.findRecord('persoon', instanceId);
     this.person = persoon;
     this.closeModal();
+    this.persoonApi.putPersonInRightGraph(
+      instanceId,
+      this.args.bestuursorgaanIT
+    );
     this.args.onUpdate(this.person);
   }
 

--- a/app/services/persoon-api.js
+++ b/app/services/persoon-api.js
@@ -57,4 +57,22 @@ export default class PersoonApiService extends Service {
 
     await timeout(RESOURCE_CACHE_TIMEOUT);
   }
+
+  async putPersonInRightGraph(persoonId, bestuursorgaanID) {
+    const response = await fetch(
+      `${API.MANDATARIS_SERVICE}/personen/${persoonId}/put-person-in-right-graph/${bestuursorgaanID}`,
+      {
+        method: 'POST',
+      }
+    );
+    const jsonReponse = await response.json();
+
+    if (response.status !== STATUS_CODE.OK) {
+      console.error(jsonReponse.message);
+      throw {
+        status: response.status,
+        message: jsonReponse.message,
+      };
+    }
+  }
 }

--- a/app/services/persoon-api.js
+++ b/app/services/persoon-api.js
@@ -65,14 +65,12 @@ export default class PersoonApiService extends Service {
         method: 'POST',
       }
     );
-    const jsonReponse = await response.json();
+    const jsonResponse = await response.json();
 
     if (response.status !== STATUS_CODE.OK) {
-      console.error(jsonReponse.message);
-      throw {
-        status: response.status,
-        message: jsonReponse.message,
-      };
+      let error = new Error(jsonResponse.message);
+      error.status = response.status;
+      throw error;
     }
   }
 }


### PR DESCRIPTION
## Description

If people get created that belong to an orgaan that does not really belong in the bestuurseenheid of that graph, the person information is copied to the correct graph. 
An example is bcsd, if a person is created in the installatievergadering for the bcsd, this person is also copied to the ocmw.

## How to test

Two things should be tested:
- Create a person which should not be copied (e.g. in a custom orgaan such as Jeugdraad), and check that the person is not copied to the OCMW or any other graph for that matter.
- Create a person in the bcsd in the iv and check that this person is copied correctly to the ocmw. His mandate shouldn't be there yet, but the person data should.

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/67

## Remarks
This copy function (`movePersons`) also exists in the move-ocmw-organs call, which is called whenever the iv is concluded. I left it there for completeness and because it can be gemeente people should be copied which didn't exist in the ocmw yet (although, this is all election data, which should be in both). But this shouldn't result in any issues as this data shouldn't be copied since it already exists.
