### PR TITLE
LMB-1078 simplify get besluit uri

### DIFF
--- a/app/components/mandaat/publicatie-status-pill.js
+++ b/app/components/mandaat/publicatie-status-pill.js
@@ -1,10 +1,6 @@
 import Component from '@glimmer/component';
 
-import { service } from '@ember/service';
-
 export default class MandaatPublicatieStatusPillComponent extends Component {
-  @service('mandataris-api') mandatarisApi;
-
   get isMandatarisBekrachtigd() {
     return this.args.mandataris.get('publicationStatus')
       ? this.args.mandataris.get('publicationStatus').get('isBekrachtigd')
@@ -16,10 +12,7 @@ export default class MandaatPublicatieStatusPillComponent extends Component {
   }
 
   async getLink() {
-    const link = await this.mandatarisApi.findDecisionUri(
-      this.args.mandataris.id
-    );
-
+    const link = this.args.mandataris.besluitUri;
     return link ?? this.args.mandataris.linkToBesluit;
   }
 }

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -108,6 +108,16 @@ export default class MandatarisModel extends Model {
     return this.bekleedt.get('isVoorzitter');
   }
 
+  get besluitUri() {
+    if (this.ontslagBekrachtigdDoor) {
+      return this.ontslagBekrachtigdDoor.get('uri');
+    }
+    if (this.aanstellingBekrachtigdDoor) {
+      return this.aanstellingBekrachtigdDoor.get('uri');
+    }
+    return null;
+  }
+
   async getUnique(people) {
     const vervangers = new Map();
     const allPeople = (await people).slice();

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -71,10 +71,18 @@ export default class MandatarisModel extends Model {
   })
   contactPoints;
 
-  @belongsTo('rechtsgrond', { async: true, inverse: null, polymorphic: true })
+  @belongsTo('rechtsgrond', {
+    async: true,
+    inverse: 'bekrachtigtAanstellingVan',
+    polymorphic: true,
+  })
   aanstellingBekrachtigdDoor;
 
-  @belongsTo('rechtsgrond', { async: true, inverse: null, polymorphic: true })
+  @belongsTo('rechtsgrond', {
+    async: true,
+    inverse: 'bekrachtigtOntslagVan',
+    polymorphic: true,
+  })
   ontslagBekrachtigdDoor;
 
   get generatedFromGelinktNotuleren() {

--- a/app/models/rechtsgrond.js
+++ b/app/models/rechtsgrond.js
@@ -1,8 +1,17 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class RechtsgrondModel extends Model {
   @attr uri;
 
-  @attr bekrachtigtAanstellingVan;
-  @attr bekrachtigtOntslagVan;
+  @belongsTo('mandataris', {
+    async: true,
+    inverse: 'aanstellingBekrachtigdDoor',
+  })
+  bekrachtigtAanstellingVan;
+
+  @belongsTo('mandataris', {
+    async: true,
+    inverse: 'ontslagBekrachtigdDoor',
+  })
+  bekrachtigtOntslagVan;
 }

--- a/app/services/mandataris-api.js
+++ b/app/services/mandataris-api.js
@@ -34,23 +34,6 @@ export default class MandatarisApiService extends Service {
     await timeout(RESOURCE_CACHE_TIMEOUT);
   }
 
-  async findDecisionUri(mandatarisId) {
-    const response = await fetch(
-      `${API.MANDATARIS_SERVICE}/mandatarissen/${mandatarisId}/decision`
-    );
-    const jsonReponse = await response.json();
-
-    if (response.status !== STATUS_CODE.OK) {
-      console.error(jsonReponse.message);
-      throw {
-        status: response.status,
-        message: jsonReponse.message,
-      };
-    }
-
-    return jsonReponse.decisionUri;
-  }
-
   async bulkSetPublicationStatus(mandatarissen, status, decision) {
     const response = await fetch(
       `${API.MANDATARIS_SERVICE}/mandatarissen/bulk-set-publication-status`,


### PR DESCRIPTION
## Description

There is no need to get the besluit uri from the mandataris-service, this is in our data model. So we can fetch it ourselves.

## How to test

Add a link to a besluit and also add an actual besluit in the mandataris-service. See that both are accessible in the mandataris page.

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/69
- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/290
