### PR TITLE
better loading during change iv status

### DIFF
--- a/app/controllers/verkiezingen/installatievergadering.js
+++ b/app/controllers/verkiezingen/installatievergadering.js
@@ -37,23 +37,23 @@ export default class PrepareInstallatievergaderingController extends Controller 
   @tracked nextStatus;
   @tracked isModalOpen = false;
   @tracked verkiezingsUitslagModal = false;
+  @tracked nextStatusSetting = false;
 
   @action
   async selectStatus(status) {
-    this.isModalOpen = false;
+    this.nextStatusSetting = true;
     const installatievergadering = this.model.installatievergadering;
-    installatievergadering.status = status;
-    await installatievergadering.save();
 
-    if (
-      installatievergadering.get('status.uri') ===
-      INSTALLATIEVERGADERING_BEHANDELD_STATUS
-    ) {
+    if (status.uri === INSTALLATIEVERGADERING_BEHANDELD_STATUS) {
       await fetch(
         `/installatievergadering-api/${installatievergadering.id}/move-ocmw-organs`,
         { method: 'POST' }
       );
     }
+    this.isModalOpen = false;
+    installatievergadering.status = status;
+    await installatievergadering.save();
+    this.nextStatusSetting = false;
 
     this.router.refresh();
   }

--- a/app/templates/verkiezingen/installatievergadering.hbs
+++ b/app/templates/verkiezingen/installatievergadering.hbs
@@ -173,6 +173,8 @@
               Annuleer
             </AuButton>
             <AuButton
+              @loading={{this.nextStatusSetting}}
+              @loadingMessage="Status wijzigen"
               {{on "click" (fn this.selectStatus this.nextStatus.status)}}
             >
               Bevestigen


### PR DESCRIPTION
## Description

Keep the change status modal open and make the button go to a loading state. 
Also only update the status if everything happened successfully, that way they can try again if it fails.

## How to test

I'll not insult you by typing it out.