### PR TITLE
Ben/lmb 1153 improve burgemeester selector

### DIFF
--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -52,6 +52,10 @@
             {{#if this.persoon}}
               <AuButton
                 @skin="link"
+                {{on "click" (fn (mut this.editBurgemeester) true)}}
+              >Bewerk</AuButton>
+              <AuButton
+                @skin="link"
                 @alert={{true}}
                 {{on "click" this.removeBurgemeester}}
               >Verwijder</AuButton>
@@ -147,5 +151,33 @@
         </AuButtonGroup>
       </Group>
     </AuToolbar>
+  </div>
+</AuModal>
+
+<AuModal
+  @title={{(concat "Bewerk Burgemeester")}}
+  @modalOpen={{this.editBurgemeester}}
+  @closable={{true}}
+  @closeModal={{this.closeEditBurgemeesterModal}}
+>
+
+  <div class="au-o-box">
+    <AuAlert @skin="warning" @icon="alert-triangle" @closable={{false}}>
+      Bij het aanpassen van de burgemeester zal de voorzitter van het vast
+      bureau niet aangepast worden, indien u de wijzigingen daar ook wenst door
+      te voeren dient u dit manueel te doen.
+    </AuAlert>
+    <SemanticForms::Instance
+      @hideDescriptionModalOnSave={{true}}
+      @instanceId={{this.aangewezenBurgemeester.id}}
+      @form={{@form}}
+      @onSave={{this.saveBurgemeesterChanges}}
+      @onCancel={{this.closeEditBurgemeesterModal}}
+      @buildMetaTtl={{@buildMetaTtl}}
+      @formInitialized={{fn (mut this.isEditFormInitialized) true}}
+    />
+    {{#unless this.isEditFormInitialized}}
+      <Skeleton::Forms::MandatarisCorrect />
+    {{/unless}}
   </div>
 </AuModal>

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -33,6 +33,7 @@
         <th class="au-u-padding-small">Voornaam</th>
         <th>Familienaam</th>
         <th>Fractie</th>
+        <th>Start</th>
         <th>Beleidsomeinen</th>
         {{#unless @readOnly}}
           <th>
@@ -44,6 +45,7 @@
         <td>{{row.isBestuurlijkeAliasVan.gebruikteVoornaam}}</td>
         <td>{{row.isBestuurlijkeAliasVan.achternaam}}</td>
         <td>{{row.heeftLidmaatschap.binnenFractie.naam}}</td>
+        <td>{{moment-format row.start "DD-MM-YYYY"}}</td>
         <td><Beleidsdomeinen @mandataris={{row}} /></td>
         {{#unless @readOnly}}
           <td class="au-u-text-right">

--- a/app/components/mandaat/burgemeester-selector.hbs
+++ b/app/components/mandaat/burgemeester-selector.hbs
@@ -94,6 +94,16 @@
     </div>
 
     {{#if this.persoon}}
+      <div>
+        <DateInput
+          @label="Start"
+          @value={{this.date}}
+          @from={{this.bestuursorgaanStart}}
+          @to={{this.bestuursorgaanEinde}}
+          @onChange={{fn (mut this.date)}}
+          @isRequired={{true}}
+        />
+      </div>
       <Mandatarissen::FractieSelector
         @fractie={{this.selectedFractie}}
         @isRequired={{true}}

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -17,6 +17,7 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   @service store;
   @service installatievergadering;
   @service('mandataris') mandatarisService;
+  @service fractieApi;
 
   @tracked persoon = null;
   @tracked aangewezenBurgemeesters;
@@ -25,6 +26,9 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   @tracked selectedFractie = null;
   @tracked selectedBeleidsdomeinen = [];
   @tracked date;
+
+  @tracked editBurgemeester = false;
+  @tracked isEditFormInitialized;
 
   // no need to track these
   burgemeesterMandate = null;
@@ -205,5 +209,20 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
 
   get toolTipText() {
     return this.persoon ? 'Er is reeds een burgemeester geselecteerd.' : '';
+  }
+
+  @action
+  closeEditBurgemeesterModal() {
+    this.editBurgemeester = false;
+    this.isEditFormInitialized = false;
+  }
+
+  @action
+  async saveBurgemeesterChanges({ instanceId }) {
+    await this.fractieApi.updateCurrentFractie(instanceId);
+    this.closeEditBurgemeesterModal();
+    if (this.args.onUpdateBurgemeester) {
+      setTimeout(() => this.args.onUpdateBurgemeester(), 1000);
+    }
   }
 }

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -145,6 +145,7 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
     await Promise.all(
       this.targetMandatarisses.map(async (target) => {
         target.isBestuurlijkeAliasVan = this.persoon;
+        target.start = this.date;
         if (this.selectedFractie) {
           await this.mandatarisService.createNewLidmaatschap(
             target,

--- a/app/components/mandaat/burgemeester-selector.js
+++ b/app/components/mandaat/burgemeester-selector.js
@@ -24,6 +24,7 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   @tracked isModalOpen;
   @tracked selectedFractie = null;
   @tracked selectedBeleidsdomeinen = [];
+  @tracked date;
 
   // no need to track these
   burgemeesterMandate = null;
@@ -33,6 +34,13 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   get disabled() {
     return !this.persoon || !this.selectedFractie;
   }
+  get bestuursorgaanStart() {
+    return this.args.bestuursorgaanInTijd.bindingStart;
+  }
+
+  get bestuursorgaanEinde() {
+    return this.args.bestuursorgaanInTijd.bindingEinde;
+  }
 
   constructor() {
     super(...arguments);
@@ -40,6 +48,7 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   }
 
   @action async setup() {
+    this.date = this.args.bestuursorgaanInTijd.bindingStart;
     await this.loadBurgemeesterMandates();
     await this.loadBurgemeesterMandatarissen();
     await this.loadBurgemeesterPerson();
@@ -79,7 +88,7 @@ export default class MandaatBurgemeesterSelectorComponent extends Component {
   async createMandataris(burgemeesterMandaat) {
     const newMandataris = this.store.createRecord('mandataris', {
       rangorde: null,
-      start: this.args.bestuursorgaanInTijd.bindingStart,
+      start: this.date,
       einde: this.args.bestuursorgaanInTijd.bindingEinde,
       bekleedt: burgemeesterMandaat,
       isBestuurlijkeAliasVan: null,

--- a/app/components/verkiezingen/draft-mandataris-list.hbs
+++ b/app/components/verkiezingen/draft-mandataris-list.hbs
@@ -18,6 +18,9 @@
           {{#if @showFunctie}}
             <th>Mandaat</th>
           {{/if}}
+          {{#if @showStart}}
+            <th>Start</th>
+          {{/if}}
           {{#if @showRangorde}}
             <th>Rangorde</th>
           {{/if}}
@@ -49,6 +52,9 @@
             <td>
               {{row.bekleedt.bestuursfunctie.label}}
             </td>
+          {{/if}}
+          {{#if @showStart}}
+            <td>{{moment-format row.start "DD-MM-YYYY"}}</td>
           {{/if}}
           {{#if @showRangorde}}
             <td>

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -115,6 +115,7 @@
       @title=""
       @showFractie={{true}}
       @showFunctie={{true}}
+      @showStart={{true}}
       @showRangorde={{or
         (eq
           @bestuursorgaan.isTijdsspecialisatieVan.classificatie.uri

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -5,6 +5,8 @@
     @onUpdateBurgemeester={{@onUpdateBurgemeester}}
     @bestuursperiode={{@bestuursperiode}}
     @bestuurseenheid={{@bestuurseenheid}}
+    @form={{@form}}
+    @buildMetaTtl={{this.buildMetaTtl}}
   />
 {{else}}
   <div class="au-u-flex au-u-flex--column au-u-flex--row-when-medium">

--- a/app/controllers/verkiezingen/installatievergadering.js
+++ b/app/controllers/verkiezingen/installatievergadering.js
@@ -30,6 +30,7 @@ export default class PrepareInstallatievergaderingController extends Controller 
   queryParams = ['bestuursperiode'];
   @service store;
   @service router;
+  @service installatievergadering;
 
   @tracked bestuursperiode;
   @tracked statusPillSkin = 'info';
@@ -153,6 +154,7 @@ export default class PrepareInstallatievergaderingController extends Controller 
 
   @action
   onUpdateBurgemeester() {
+    this.installatievergadering.forceRecomputeBCSD();
     this.router.refresh();
   }
 }


### PR DESCRIPTION
## Description

Update burgemeester selector to be more user friendly. Three things should have happened:
- You can now edit the burgemeester in the prepare legislature page
- You can now select a start date in the modal when selecting a burgemeester
- In the tables the startdate is know shown as well.

## How to test

Go to the prepare legislature page and play around with the burgemeester selector.
