### PR TITLE
lmb-1184: link to the derived from for the besluit

### DIFF
--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -120,10 +120,10 @@ export default class MandatarisModel extends Model {
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve) => {
       if (await this.ontslagBekrachtigdDoor) {
-        resolve(this.ontslagBekrachtigdDoor.get('uri'));
+        resolve(this.ontslagBekrachtigdDoor.get('gepubliceerdVanuit'));
       }
       if (await this.aanstellingBekrachtigdDoor) {
-        resolve(this.aanstellingBekrachtigdDoor.get('uri'));
+        resolve(this.aanstellingBekrachtigdDoor.get('gepubliceerdVanuit'));
       }
 
       resolve(null);

--- a/app/models/rechtsgrond.js
+++ b/app/models/rechtsgrond.js
@@ -2,6 +2,7 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class RechtsgrondModel extends Model {
   @attr uri;
+  @attr gepubliceerdVanuit;
 
   @belongsTo('mandataris', {
     async: true,


### PR DESCRIPTION
## Description

We want to show the originin of the besluit when a user clicks on go to besluit. Now it show the uri of the besluit.

## How to test

Let the fetch-bekrachtigingen run of mandataris service and go to zuienkerke. When going to a bekrachtigd besluit it should go to a new tab where the besluit was published (origin where the harvester initally got it)

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/329
- https://github.com/lblod/app-mandatees-decisions/pull/13