### PR TITLE
clean up session more explicitly when ending up on the session expired page

### DIFF
--- a/app/controllers/session-expired.js
+++ b/app/controllers/session-expired.js
@@ -21,15 +21,12 @@ export default class SessionExpiredController extends Controller {
   }
 }
 
-function buildLogoutUrl({ logoutUrl, clientId }) {
+function buildLogoutUrl({ logoutUrl, clientId, switchRedirectUrl }) {
   let switchUrl = new URL(logoutUrl);
   let searchParams = switchUrl.searchParams;
 
   searchParams.append('client_id', clientId);
-  searchParams.append(
-    'post_logout_redirect_uri',
-    `${window.location.protocol}//${window.location.host}/login`
-  );
+  searchParams.append('post_logout_redirect_uri', switchRedirectUrl);
 
   return switchUrl.href;
 }

--- a/app/controllers/session-expired.js
+++ b/app/controllers/session-expired.js
@@ -1,0 +1,35 @@
+import Controller from '@ember/controller';
+
+import { service } from '@ember/service';
+import { action } from '@ember/object';
+
+import ENV from 'frontend-lmb/config/environment';
+
+export default class SessionExpiredController extends Controller {
+  @service session;
+  @service router;
+
+  @action
+  async clearSessionAndLogin() {
+    let wasMockLoginSession = this.session.isMockLoginSession;
+    await this.session.invalidate();
+    let logoutUrl = wasMockLoginSession
+      ? this.router.urlFor('mock-login')
+      : buildLogoutUrl(ENV.acmidm);
+
+    window.location.replace(logoutUrl);
+  }
+}
+
+function buildLogoutUrl({ logoutUrl, clientId }) {
+  let switchUrl = new URL(logoutUrl);
+  let searchParams = switchUrl.searchParams;
+
+  searchParams.append('client_id', clientId);
+  searchParams.append(
+    'post_logout_redirect_uri',
+    `${window.location.protocol}//${window.location.host}/login`
+  );
+
+  return switchUrl.href;
+}

--- a/app/routes/session-expired.js
+++ b/app/routes/session-expired.js
@@ -1,10 +1,3 @@
 import Route from '@ember/routing/route';
-import { service } from '@ember/service';
 
-export default class SessionExpiredRoute extends Route {
-  @service session;
-
-  async beforeModel() {
-    await this.session.invalidate();
-  }
-}
+export default class SessionExpiredRoute extends Route {}

--- a/app/templates/session-expired.hbs
+++ b/app/templates/session-expired.hbs
@@ -4,7 +4,7 @@
   @statusMessage="Uw sessie is verlopen en u werd uitgelogd. Onze excuses voor het ongemak. Gelieve opnieuw aan te melden."
 >
   <div class="au-o-box">
-    <AuLink @route="login" @skin="button">Aanmelden</AuLink>
+    <AuButton {{on "click" this.clearSessionAndLogin}}>Aanmelden</AuButton>
   </div>
 </Error>
 {{outlet}}


### PR DESCRIPTION
## Description

When users end up here, log them out and redirect them to login when clicking the button. Else ACM/IDM remembers their session and they end up looping.

## How to test

Hard to tests without acm/idm. Try it in the test environment or by overriding your /etc/hosts