### PR TITLE
allow changing field order

### DIFF
--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -6,6 +6,8 @@
     @onSave={{@onSave}}
     @formInitialized={{@formInitialized}}
     @customHistoryMessage={{@customHistoryMessage}}
+    @buildMetaTtl={{@buildMetaTtl}}
+    @saveTitle={{@saveTitle}}
   >
     {{#if this.editableFormsEnabled}}
       <AuButton

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -142,7 +142,7 @@
     </AuAlert>
   {{/if}}
   <div class="au-o-box">
-    <SemanticForms::Instance
+    <EditableForm
       @instanceId={{this.model.mandataris.id}}
       @form={{this.model.mandatarisEditForm}}
       @onSave={{this.onSave}}


### PR DESCRIPTION
## Description

Allow chaning field order. Up and down is done with ugly buttons. I think we need a hamburger menu that includes up, down, edit, remove. But we can do that later.

![image](https://github.com/user-attachments/assets/880922af-e0a8-498b-9d73-5b227afe3288)

added a cancel button to the modal because i kept clicking 'verwijder' to close

## How to test

Move a field up and down all the way and across existing (unmodifiable) form fields
## Links to other PR's

- https://github.com/lblod/form-content-service/pull/66