### PR TITLE
lmb-1302 | Date input will also show a warning on end date

### DIFF
--- a/app/components/date-input.hbs
+++ b/app/components/date-input.hbs
@@ -3,6 +3,7 @@
     <AuLabel
       for={{(or @id this.elementId)}}
       @error={{(or this.errorMessage this.invalidErrorMessage)}}
+      @warning={{this.warningMessage}}
       @required={{@isRequired}}
     >{{@label}}</AuLabel>
   {{/if}}
@@ -16,6 +17,7 @@
     <AuInput
       {{did-insert this.setupDateValue}}
       @error={{(or this.errorMessage this.invalidErrorMessage)}}
+      @warning={{this.warningMessage}}
       value={{this.dateInputString}}
       id={{(or @id this.elementId)}}
       placeholder="dd-mm-yyyy"
@@ -32,5 +34,8 @@
 
   {{#if (or this.errorMessage this.invalidErrorMessage)}}
     <AuHelpText @error={{true}}>{{this.errorMessages}}</AuHelpText>
+  {{/if}}
+  {{#if this.warningMessage}}
+    <AuHelpText @warning={{true}}>{{this.warningMessage}}</AuHelpText>
   {{/if}}
 </div>

--- a/app/components/date-input.js
+++ b/app/components/date-input.js
@@ -13,6 +13,7 @@ export default class DateInputComponent extends Component {
   elementId = `date-${guidFor(this)}`;
 
   @tracked dateInputString;
+  @tracked warningMessage;
   @tracked errorMessage;
   @tracked invalidErrorMessage;
 
@@ -58,6 +59,7 @@ export default class DateInputComponent extends Component {
     if (!isValidDate(date)) {
       this.invalidErrorMessage = `Datum is ongeldig.`;
       this.errorMessage = null;
+      this.warningMessage = null;
 
       return date;
     }
@@ -78,12 +80,12 @@ export default class DateInputComponent extends Component {
         ? moment(maxDate).format('DD-MM-YYYY')
         : null;
 
-      this.errorMessage = this.getErrorMessageForDateRange(
+      this.warningMessage = this.getErrorMessageForDateRange(
         stringMinDate,
         stringMaxDate
       );
     } else {
-      this.errorMessage = null;
+      this.warningMessage = null;
     }
 
     return date;

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -15,7 +15,6 @@ import {
   burgemeesterOnlyStates,
   notBurgemeesterStates,
 } from 'frontend-lmb/utils/well-known-uris';
-import { isDateInRange } from '../date-input';
 import { isRequiredForBestuursorgaan } from 'frontend-lmb/utils/is-fractie-selector-required';
 
 export default class MandatarissenUpdateState extends Component {

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -151,12 +151,7 @@ export default class MandatarissenUpdateState extends Component {
       !this.date ||
       this.inValidReplacement ||
       !this.hasChanges ||
-      (this.isFractieSelectorRequired && !this.selectedFractie) ||
-      !isDateInRange(
-        this.date,
-        this.bestuursorgaanStartDate,
-        this.bestuursorgaanEndDate
-      )
+      (this.isFractieSelectorRequired && !this.selectedFractie)
     );
   }
 

--- a/app/components/rdf-input-fields/rdf-date-input.js
+++ b/app/components/rdf-input-fields/rdf-date-input.js
@@ -11,7 +11,7 @@ import {
 } from '@lblod/submission-form-helpers';
 
 import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
-import { EXT } from 'frontend-lmb/rdf/namespaces';
+import { EXT, SHACL } from 'frontend-lmb/rdf/namespaces';
 import { loadBestuursorgaanPeriodFromContext } from 'frontend-lmb/utils/form-context/application-context-meta-ttl';
 
 export default class RdfDateInputComponent extends InputFieldComponent {
@@ -35,11 +35,15 @@ export default class RdfDateInputComponent extends InputFieldComponent {
       this.date = new Date(datestring);
     }
 
-    const validations = validationResultsForField(
-      this.args.field.uri,
-      this.storeOptions
-    );
-    const hasMandatarisDateValidation = validations.some(
+    const errors = validationResultsForField(this.args.field.uri, {
+      severity: SHACL('Violation'),
+      ...this.storeOptions,
+    });
+    const warnings = validationResultsForField(this.args.field.uri, {
+      severity: SHACL('Warning'),
+      ...this.storeOptions,
+    });
+    const hasMandatarisDateValidation = [...errors, ...warnings].some(
       (validation) =>
         validation.validationType === EXT('ValidMandatarisDate').value
     );

--- a/app/rdf/namespaces.js
+++ b/app/rdf/namespaces.js
@@ -1,6 +1,13 @@
 import { Namespace } from 'rdflib';
 
-export { MU, FORM, RDF, XSD, SKOS } from '@lblod/submission-form-helpers';
+export {
+  MU,
+  FORM,
+  RDF,
+  XSD,
+  SKOS,
+  SHACL,
+} from '@lblod/submission-form-helpers';
 
 export const EXT = new Namespace('http://mu.semte.ch/vocabularies/ext/');
 export const ORG = new Namespace('http://www.w3.org/ns/org#');


### PR DESCRIPTION
## Description

Change the severity of the min and max date to Warning instead of violation 

## How to test

- Go to a bestuursperiode 2019 -2024
- correct a mandataris 
- a warning should pop up when changing it to a date outside the period
- when wijzig mandataris is opened the save button should not be disabled because of the date

![image](https://github.com/user-attachments/assets/0bbb4ef5-e5e0-41b4-b40a-ddba1bbe0281)

![image](https://github.com/user-attachments/assets/2d4ec073-0539-457c-86a7-567db8be5765)



## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/357
