### PR TITLE
lmb-1314: remove the disabled options for the bestuursperiode selector

### DIFF
--- a/app/controllers/mandatarissen/search.js
+++ b/app/controllers/mandatarissen/search.js
@@ -57,8 +57,8 @@ export default class MandatarissenSearchController extends Controller {
   }
 
   @action
-  selectPeriod(periodMap) {
-    this.bestuursperiode = periodMap.period.id;
+  selectPeriod(period) {
+    this.bestuursperiode = period.id;
   }
 
   @action
@@ -83,7 +83,7 @@ export default class MandatarissenSearchController extends Controller {
     if (this.onafhankelijkeFractie) {
       const onafhankelijkeFracties =
         await this.fractieApi.onafhankelijkForBestuursperiode(
-          this.model.selectedPeriod.period.id
+          this.model.selectedPeriod.id
         );
       fracties.push(...onafhankelijkeFracties);
     }

--- a/app/routes/mandatarissen/search.js
+++ b/app/routes/mandatarissen/search.js
@@ -26,7 +26,7 @@ export default class MandatarissenSearchRoute extends Route {
   };
 
   async model(params) {
-    const allBestuursperiode = await this.store.query('bestuursperiode', {
+    const allBestuursperioden = await this.store.query('bestuursperiode', {
       sort: 'label',
       include: [
         'installatievergaderingen',
@@ -34,7 +34,7 @@ export default class MandatarissenSearchRoute extends Route {
       ].join(','),
     });
     let selectedPeriod = this.bestuursperioden.getRelevantPeriod(
-      allBestuursperiode,
+      allBestuursperioden,
       params.bestuursperiode
     );
     const personenWithMandatarissen = await this.getPersoonWithMandatarissen(
@@ -56,7 +56,7 @@ export default class MandatarissenSearchRoute extends Route {
 
     return {
       personenWithMandatarissen,
-      allBestuursperiode,
+      allBestuursperioden,
       selectedPeriod,
       bestuursfuncties: [...new Set(allBestuurfunctieCodes)],
       selectedBestuurfunctieIds: params.bestuursfunctie,

--- a/app/routes/mandatarissen/search.js
+++ b/app/routes/mandatarissen/search.js
@@ -26,7 +26,7 @@ export default class MandatarissenSearchRoute extends Route {
   };
 
   async model(params) {
-    const bestuursPeriods = await this.store.query('bestuursperiode', {
+    const allBestuursperiode = await this.store.query('bestuursperiode', {
       sort: 'label',
       include: [
         'installatievergaderingen',
@@ -34,26 +34,9 @@ export default class MandatarissenSearchRoute extends Route {
       ].join(','),
     });
     let selectedPeriod = this.bestuursperioden.getRelevantPeriod(
-      bestuursPeriods,
+      allBestuursperiode,
       params.bestuursperiode
     );
-
-    const isDistrict = this.currentSession.isDistrict;
-    // This map is made for disabling certain options in the powerselect
-    const periodMap = await Promise.all(
-      bestuursPeriods.map(async (period) => {
-        const ivs = await period.installatievergaderingen;
-        if (ivs.length < 1) {
-          return { period, disabled: false };
-        }
-        const isBehandeld = await ivs.at(0).isBehandeld;
-        if (isBehandeld) {
-          return { period, disabled: false };
-        }
-        return { period, disabled: isDistrict ? false : true };
-      })
-    );
-
     const personenWithMandatarissen = await this.getPersoonWithMandatarissen(
       params,
       selectedPeriod
@@ -73,8 +56,8 @@ export default class MandatarissenSearchRoute extends Route {
 
     return {
       personenWithMandatarissen,
-      bestuursPeriods: periodMap,
-      selectedPeriod: { period: selectedPeriod, disabled: false },
+      allBestuursperiode,
+      selectedPeriod,
       bestuursfuncties: [...new Set(allBestuurfunctieCodes)],
       selectedBestuurfunctieIds: params.bestuursfunctie,
       fracties: [

--- a/app/routes/mandatarissen/search.js
+++ b/app/routes/mandatarissen/search.js
@@ -26,7 +26,7 @@ export default class MandatarissenSearchRoute extends Route {
   };
 
   async model(params) {
-    const allBestuursperioden = await this.store.query('bestuursperiode', {
+    const allBestuursperiodes = await this.store.query('bestuursperiode', {
       sort: 'label',
       include: [
         'installatievergaderingen',
@@ -34,7 +34,7 @@ export default class MandatarissenSearchRoute extends Route {
       ].join(','),
     });
     let selectedPeriod = this.bestuursperioden.getRelevantPeriod(
-      allBestuursperioden,
+      allBestuursperiodes,
       params.bestuursperiode
     );
     const personenWithMandatarissen = await this.getPersoonWithMandatarissen(
@@ -56,7 +56,7 @@ export default class MandatarissenSearchRoute extends Route {
 
     return {
       personenWithMandatarissen,
-      allBestuursperioden,
+      allBestuursperiodes,
       selectedPeriod,
       bestuursfuncties: [...new Set(allBestuurfunctieCodes)],
       selectedBestuurfunctieIds: params.bestuursfunctie,

--- a/app/templates/mandatarissen/search.hbs
+++ b/app/templates/mandatarissen/search.hbs
@@ -11,7 +11,7 @@
             <PowerSelect
               @renderInPlace={{true}}
               @selected={{this.model.selectedPeriod}}
-              @options={{this.model.allBestuursperiode}}
+              @options={{this.model.allBestuursperioden}}
               class="is-optional"
               @onChange={{this.selectPeriod}}
               @searchEnabled={{false}}

--- a/app/templates/mandatarissen/search.hbs
+++ b/app/templates/mandatarissen/search.hbs
@@ -11,7 +11,7 @@
             <PowerSelect
               @renderInPlace={{true}}
               @selected={{this.model.selectedPeriod}}
-              @options={{this.model.allBestuursperioden}}
+              @options={{this.model.allBestuursperiodes}}
               class="is-optional"
               @onChange={{this.selectPeriod}}
               @searchEnabled={{false}}

--- a/app/templates/mandatarissen/search.hbs
+++ b/app/templates/mandatarissen/search.hbs
@@ -11,20 +11,14 @@
             <PowerSelect
               @renderInPlace={{true}}
               @selected={{this.model.selectedPeriod}}
-              @options={{this.model.bestuursPeriods}}
+              @options={{this.model.allBestuursperiode}}
               class="is-optional"
               @onChange={{this.selectPeriod}}
               @searchEnabled={{false}}
               @noMatchesMessage="Geen bestuursperioden"
               as |period|
             >
-              {{#if period.disabled}}
-                {{period.period.label}}
-                <AuPill @icon="info-circle" @size="small">Voorbereiding
-                  legislatuur nog actief</AuPill>
-              {{else}}
-                {{period.period.label}}
-              {{/if}}
+              {{period.label}}
             </PowerSelect>
           </div>
           <div class="au-o-grid__item au-u-1-2 au-u-1-1@medium">


### PR DESCRIPTION
## Description

When going to mandatarissen module the current bestuursperiode will be selected. When opening this may not be disabled when IV is active

## How to test

- All options show
- Disabled pill is gone

## Attachments

![image](https://github.com/user-attachments/assets/8d15d0a4-f98e-41e6-b2de-738c525314a8)

