### PR TITLE
add tooltip to bulk bekrachtig when no mandataris is selected

### DIFF
--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -44,6 +44,13 @@ export default class BulkBekrachtigingController extends Controller {
     return false;
   }
 
+  get tooltipText() {
+    if (this.hasMandatarissenToEdit) {
+      return 'Gelieve mandatarissen te selecteren.';
+    }
+    return 'Alle mandatarissen hebben hun finale publicatiestatus';
+  }
+
   @action
   updateStatus(status) {
     this.status = status;
@@ -116,6 +123,7 @@ export default class BulkBekrachtigingController extends Controller {
     );
     this.closeModal();
     this.checked.clear();
+    this.setSize = 0;
     setTimeout(() => this.router.refresh(), 1000);
   }
 

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -14,8 +14,8 @@
   </Group>
   <Group>
     <Shared::Tooltip
-      @showTooltip={{not this.hasMandatarissenToEdit}}
-      @tooltipText="Al de mandatarissen staan in hun eindstatus"
+      @showTooltip={{this.openModalDisabled}}
+      @tooltipText={{this.tooltipText}}
     >
       <AuButton
         {{on "click" this.openModal}}


### PR DESCRIPTION
## Description

Add tooltip to bulk bekrachtig when no mandataris is selected.
![Screenshot 2025-01-22 at 16 37 19](https://github.com/user-attachments/assets/f0d239ce-2d53-4349-9445-3ecd8130ecd1)

## How to test

Go to a bulk bekrachtig route, bekrachtig every mandataris or make them effectief (for VB and RMW). And check there is a tooltip that you have no mandatarissen selected. 
