### PR TITLE
disable count warnings for now

### DIFF
--- a/app/components/min-max-mandataris-warning.js
+++ b/app/components/min-max-mandataris-warning.js
@@ -12,6 +12,7 @@ import {
 
 export default class MinMaxMandatarisWarningComponent extends Component {
   @service store;
+  @service features;
   @tracked warningMessages;
   @tracked currentIndex = 0;
 
@@ -38,6 +39,9 @@ export default class MinMaxMandatarisWarningComponent extends Component {
   }
 
   get currentWarningMessage() {
+    if (!this.features.isEnabled('enable-mandataris-count-warnings')) {
+      return null;
+    }
     return this.warningMessages?.[this.currentIndex];
   }
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -34,6 +34,7 @@ module.exports = function (environment) {
     },
     features: {
       'show-forms-module': false,
+      'enable-mandataris-count-warnings': false,
     },
     lpdcUrl: '{{LPDC_URL}}',
     worshipDecisionsDatabaseUrl: '{{WORSHIP_DECISIONS_DATABASE_URL}}',
@@ -59,6 +60,7 @@ module.exports = function (environment) {
   if (environment === 'development') {
     ENV.APP.DISABLE_RELOAD_WARNINGS = true;
     ENV.APP.SHOW_FORM_CONTENT = true;
+    ENV.features['enable-mandataris-count-warnings'] = true;
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;


### PR DESCRIPTION
## Description

disable count warnings for now using feature flag.
## How to test

Disable the feature flag in dev and check kraainem's rmw. You should not see a warning. Enable the feature flag and restart the ember server and you should see it.