### PR TITLE
LMB-1164 optimise rangorde

### DIFF
--- a/app/components/download-mandatarissen-from-table.hbs
+++ b/app/components/download-mandatarissen-from-table.hbs
@@ -1,10 +1,12 @@
 <Shared::Tooltip
   @showTooltip={{true}}
+  role={{@role}}
   @tooltipText="Exporteer mandatarissen naar CSV formaat"
 >
   <AuLinkExternal
+    role={{@role}}
     href={{await this.downloadLink}}
     download="mandatarissen"
-    @skin="button-secondary"
+    @skin={{@skin}}
   >Download</AuLinkExternal>
 </Shared::Tooltip>

--- a/app/components/organen/edit-mandataris-rangorde-table.hbs
+++ b/app/components/organen/edit-mandataris-rangorde-table.hbs
@@ -60,6 +60,7 @@
           @mandatarisStruct={{row}}
           @mandatarissen={{@mandatarissen}}
           @updateMandatarisList={{@updateMandatarisList}}
+          @trackUpdatedRangorde={{@trackUpdatedRangorde}}
         />
       </td>
     </c.body>

--- a/app/components/organen/edit-mandataris-rangorde-table.hbs
+++ b/app/components/organen/edit-mandataris-rangorde-table.hbs
@@ -54,7 +54,7 @@
       <td class={{if (is-in-past row.mandataris.einde) "au-u-muted"}}>
         {{moment-format row.mandataris.start "DD-MM-YYYY"}}</td>
       <td class={{if (is-in-past row.mandataris.einde) "au-u-muted"}}>
-        {{moment-format row.mandataris.einde "DD-MM-YYYY"}}</td>
+        {{moment-format row.mandataris.displayEinde "DD-MM-YYYY"}}</td>
       <td>
         <Organen::RangordeInput
           @mandatarisStruct={{row}}

--- a/app/components/organen/edit-mandataris-rangorde-table.hbs
+++ b/app/components/organen/edit-mandataris-rangorde-table.hbs
@@ -1,5 +1,5 @@
 <AuDataTable
-  @content={{@content}}
+  @content={{@orderedMandatarissen}}
   @noDataMessage="Geen mandatarissen gevonden"
   as |t|
 >
@@ -58,7 +58,7 @@
       <td>
         <Verkiezingen::RangordeInput
           @mandataris={{row}}
-          @mandatarissen={{@content}}
+          @mandatarissen={{@mandatarissen}}
         />
       </td>
     </c.body>

--- a/app/components/organen/edit-mandataris-rangorde-table.hbs
+++ b/app/components/organen/edit-mandataris-rangorde-table.hbs
@@ -1,0 +1,66 @@
+<AuDataTable
+  @content={{@content}}
+  @noDataMessage="Geen mandatarissen gevonden"
+  as |t|
+>
+  <t.content as |c|>
+    <c.header>
+      <th>
+        Mandaat
+      </th>
+      <th>
+        Voornaam
+      </th>
+      <th>
+        Familienaam
+      </th>
+      <th>
+        Fractie
+      </th>
+      <th>
+        Status
+      </th>
+      <th>
+        Start mandaat
+      </th>
+      <th>
+        Einde mandaat
+      </th>
+      <th>
+        Rangorde
+      </th>
+    </c.header>
+
+    <c.body as |row|>
+      <td>
+        {{row.bekleedt.bestuursfunctie.label}}
+      </td>
+      <td>
+        {{row.isBestuurlijkeAliasVan.gebruikteVoornaam}}
+      </td>
+      <td>
+        {{row.isBestuurlijkeAliasVan.achternaam}}
+      </td>
+      <td>
+        {{if
+          row.heeftLidmaatschap.binnenFractie
+          row.heeftLidmaatschap.binnenFractie.naam
+          "Niet beschikbaar"
+        }}
+      </td>
+      <td>
+        <Mandaat::MandatarisStatusPill @mandataris={{row}} />
+      </td>
+      <td class={{if (is-in-past row.einde) "au-u-muted"}}>
+        {{moment-format row.start "DD-MM-YYYY"}}</td>
+      <td class={{if (is-in-past row.einde) "au-u-muted"}}>
+        {{moment-format row.einde "DD-MM-YYYY"}}</td>
+      <td>
+        <Verkiezingen::RangordeInput
+          @mandataris={{row}}
+          @mandatarissen={{@content}}
+        />
+      </td>
+    </c.body>
+  </t.content>
+</AuDataTable>

--- a/app/components/organen/edit-mandataris-rangorde-table.hbs
+++ b/app/components/organen/edit-mandataris-rangorde-table.hbs
@@ -33,31 +33,31 @@
 
     <c.body as |row|>
       <td>
-        {{row.bekleedt.bestuursfunctie.label}}
+        {{row.mandataris.bekleedt.bestuursfunctie.label}}
       </td>
       <td>
-        {{row.isBestuurlijkeAliasVan.gebruikteVoornaam}}
+        {{row.mandataris.isBestuurlijkeAliasVan.gebruikteVoornaam}}
       </td>
       <td>
-        {{row.isBestuurlijkeAliasVan.achternaam}}
+        {{row.mandataris.isBestuurlijkeAliasVan.achternaam}}
       </td>
       <td>
         {{if
-          row.heeftLidmaatschap.binnenFractie
-          row.heeftLidmaatschap.binnenFractie.naam
+          row.mandataris.heeftLidmaatschap.binnenFractie
+          row.mandataris.heeftLidmaatschap.binnenFractie.naam
           "Niet beschikbaar"
         }}
       </td>
       <td>
-        <Mandaat::MandatarisStatusPill @mandataris={{row}} />
+        <Mandaat::MandatarisStatusPill @mandataris={{row.mandataris}} />
       </td>
-      <td class={{if (is-in-past row.einde) "au-u-muted"}}>
-        {{moment-format row.start "DD-MM-YYYY"}}</td>
-      <td class={{if (is-in-past row.einde) "au-u-muted"}}>
-        {{moment-format row.einde "DD-MM-YYYY"}}</td>
+      <td class={{if (is-in-past row.mandataris.einde) "au-u-muted"}}>
+        {{moment-format row.mandataris.start "DD-MM-YYYY"}}</td>
+      <td class={{if (is-in-past row.mandataris.einde) "au-u-muted"}}>
+        {{moment-format row.mandataris.einde "DD-MM-YYYY"}}</td>
       <td>
         <Organen::RangordeInput
-          @mandataris={{row}}
+          @mandataris={{row.mandataris}}
           @mandatarissen={{@mandatarissen}}
         />
       </td>

--- a/app/components/organen/edit-mandataris-rangorde-table.hbs
+++ b/app/components/organen/edit-mandataris-rangorde-table.hbs
@@ -56,7 +56,7 @@
       <td class={{if (is-in-past row.einde) "au-u-muted"}}>
         {{moment-format row.einde "DD-MM-YYYY"}}</td>
       <td>
-        <Verkiezingen::RangordeInput
+        <Organen::RangordeInput
           @mandataris={{row}}
           @mandatarissen={{@mandatarissen}}
         />

--- a/app/components/organen/edit-mandataris-rangorde-table.hbs
+++ b/app/components/organen/edit-mandataris-rangorde-table.hbs
@@ -57,8 +57,9 @@
         {{moment-format row.mandataris.einde "DD-MM-YYYY"}}</td>
       <td>
         <Organen::RangordeInput
-          @mandataris={{row.mandataris}}
+          @mandatarisStruct={{row}}
           @mandatarissen={{@mandatarissen}}
+          @updateMandatarisList={{@updateMandatarisList}}
         />
       </td>
     </c.body>

--- a/app/components/organen/mandataris-table.hbs
+++ b/app/components/organen/mandataris-table.hbs
@@ -44,13 +44,11 @@
         @label="Einde mandaat"
       />
       {{#if @showRangorde}}
-        {{! Needs custom sort... }}
-        {{!-- <AuDataTableThSortable
+        <AuDataTableThSortable
           @field="rangorde"
           @currentSorting={{@sort}}
           @label="Rangorde"
-        /> --}}
-        <th>Rangorde</th>
+        />
       {{/if}}
       {{#unless @hidePublicationStatus}}
         <AuDataTableThSortable

--- a/app/components/organen/mandataris-table.hbs
+++ b/app/components/organen/mandataris-table.hbs
@@ -100,7 +100,14 @@
         {{moment-format row.foldedEnd "DD-MM-YYYY"}}</td>
       {{#if @showRangorde}}
         <td>
-          {{row.mandataris.rangorde}}
+          {{#if @editRangorde}}
+            <Verkiezingen::RangordeInput
+              @mandataris={{row.mandataris}}
+              @mandatarissen={{@content}}
+            />
+          {{else}}
+            {{row.mandataris.rangorde}}
+          {{/if}}
         </td>
       {{/if}}
       {{#unless @hidePublicationStatus}}

--- a/app/components/organen/mandataris-table.hbs
+++ b/app/components/organen/mandataris-table.hbs
@@ -43,6 +43,15 @@
         @currentSorting={{@sort}}
         @label="Einde mandaat"
       />
+      {{#if @showRangorde}}
+        {{! Needs custom sort... }}
+        {{!-- <AuDataTableThSortable
+          @field="rangorde"
+          @currentSorting={{@sort}}
+          @label="Rangorde"
+        /> --}}
+        <th>Rangorde</th>
+      {{/if}}
       {{#unless @hidePublicationStatus}}
         <AuDataTableThSortable
           @field="publicationStatus"
@@ -91,6 +100,11 @@
         {{moment-format row.foldedStart "DD-MM-YYYY"}}</td>
       <td class={{if (is-in-past row.foldedEnd) "au-u-muted"}}>
         {{moment-format row.foldedEnd "DD-MM-YYYY"}}</td>
+      {{#if @showRangorde}}
+        <td>
+          {{row.mandataris.rangorde}}
+        </td>
+      {{/if}}
       {{#unless @hidePublicationStatus}}
         <td>
           <Mandaat::PublicatieStatusPill

--- a/app/components/organen/rangorde-input.hbs
+++ b/app/components/organen/rangorde-input.hbs
@@ -1,0 +1,30 @@
+<div>
+  <div class="order-input-as-string">
+    <AuButton
+      hideText={{true}}
+      @icon="chevron-up"
+      @skin="secondary"
+      class="order-input-as-string--minus"
+      @disabled={{this.isMinusDisabled}}
+      {{on "click" this.rangordeDown}}
+    />
+    <AuInput
+      value={{this.rangorde}}
+      placeholder={{this.rangordePlaceholder}}
+      @warning={{this.inputWarningMessage}}
+      {{on "blur" this.onUpdateRangorde}}
+      {{on "keyup" this.onEnterInRangorde}}
+    />
+    <AuButton
+      hideText={{true}}
+      @skin="secondary"
+      @icon="chevron-down"
+      class="order-input-as-string--plus"
+      @disabled={{this.isPlusDisabled}}
+      {{on "click" this.rangordeUp}}
+    />
+  </div>
+  <AuHelpText @warning={{this.inputWarningMessage}}>
+    {{this.inputWarningMessage}}
+  </AuHelpText>
+</div>

--- a/app/components/organen/rangorde-input.hbs
+++ b/app/components/organen/rangorde-input.hbs
@@ -23,6 +23,14 @@
       @disabled={{this.isPlusDisabled}}
       {{on "click" this.rangordeUp}}
     />
+    <div class="au-u-margin-left-tiny">
+      {{#if this.rangordeMovedUp}}
+        <AuBadge @icon="chevron-up" @skin="success" @size="small" />
+      {{/if}}
+      {{#if this.rangordeMovedDown}}
+        <AuBadge @icon="chevron-down" @skin="error" @size="small" />
+      {{/if}}
+    </div>
   </div>
   <AuHelpText @warning={{this.inputWarningMessage}}>
     {{this.inputWarningMessage}}

--- a/app/components/organen/rangorde-input.js
+++ b/app/components/organen/rangorde-input.js
@@ -47,12 +47,14 @@ export default class OrganenRangordeInputComponent extends Component {
     const previousHolder = this.getMandatarisWithRangorde(newRangorde);
 
     this.args.mandatarisStruct.rangorde = newRangorde;
+    this.args.trackUpdatedRangorde(newRangorde);
 
     if (
       previousHolder &&
       previousHolder !== this.args.mandatarisStruct.mandataris
     ) {
       previousHolder.rangorde = oldRangorde;
+      this.args.trackUpdatedRangorde(oldRangorde);
     }
 
     this.args.updateMandatarisList();

--- a/app/components/organen/rangorde-input.js
+++ b/app/components/organen/rangorde-input.js
@@ -3,8 +3,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
-import { keepLatestTask, timeout } from 'ember-concurrency';
-import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
+import { keepLatestTask } from 'ember-concurrency';
 import {
   orderMandatarisStructByRangorde,
   rangordeNumberMapping,
@@ -47,24 +46,15 @@ export default class OrganenRangordeInputComponent extends Component {
     const newRangorde = value;
     const previousHolder = this.getMandatarisWithRangorde(newRangorde);
 
-    // This should happen in the mandatarissen list ...
-    this.args.mandatarisStruct.mandataris.rangorde = newRangorde;
     this.args.mandatarisStruct.rangorde = newRangorde;
-
-    const promises = [this.args.mandatarisStruct.mandataris.save()];
 
     if (
       previousHolder &&
       previousHolder !== this.args.mandatarisStruct.mandataris
     ) {
-      // This should happen in the mandatarissen list ...
-      previousHolder.mandataris.rangorde = oldRangorde;
       previousHolder.rangorde = oldRangorde;
-      promises.push(previousHolder.mandataris.save());
     }
 
-    await Promise.all(promises);
-    await timeout(SEARCH_TIMEOUT);
     this.args.updateMandatarisList();
   });
 

--- a/app/components/organen/rangorde-input.js
+++ b/app/components/organen/rangorde-input.js
@@ -32,6 +32,22 @@ export default class OrganenRangordeInputComponent extends Component {
     return this.findOrderInString(this.args.mandatarisStruct.rangorde);
   }
 
+  get rangordeMovedUp() {
+    const currentNumber = this.rangordeInteger || 0;
+    const oldNumber = this.findOrderInString(
+      this.args.mandatarisStruct.mandataris.oldRangorde
+    );
+    return currentNumber < oldNumber;
+  }
+
+  get rangordeMovedDown() {
+    const currentNumber = this.rangordeInteger || 0;
+    const oldNumber = this.findOrderInString(
+      this.args.mandatarisStruct.mandataris.oldRangorde
+    );
+    return currentNumber > oldNumber;
+  }
+
   get rangorde() {
     return this.args.mandatarisStruct.rangorde;
   }

--- a/app/components/organen/rangorde-input.js
+++ b/app/components/organen/rangorde-input.js
@@ -1,0 +1,159 @@
+import Component from '@glimmer/component';
+
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+import { keepLatestTask, timeout } from 'ember-concurrency';
+import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
+import {
+  orderMandatarissenByRangorde,
+  rangordeNumberMapping,
+  rangordeStringMapping,
+  rangordeStringToNumber,
+} from 'frontend-lmb/utils/rangorde';
+
+export default class VerkiezingenRangordeInputComponent extends Component {
+  @tracked rangordePlaceholder;
+
+  constructor() {
+    super(...arguments);
+    this.setPlaceholder();
+  }
+
+  get inputWarningMessage() {
+    const order = this.rangordeInteger;
+    if (order == null) {
+      return 'Opgelet! Dit is geen gekende rangorde!';
+    } else {
+      return null;
+    }
+  }
+
+  get rangordeInteger() {
+    return this.findOrderInString(this.args.mandataris.rangorde);
+  }
+
+  get rangorde() {
+    return this.args.mandataris.rangorde;
+  }
+
+  async setPlaceholder() {
+    const mandaat = await this.args.mandataris.bekleedt;
+    this.rangordePlaceholder = `Vul de rangorde in, bv. “Eerste ${mandaat.rangordeLabel}”`;
+  }
+
+  updateMandatarisRangorde = keepLatestTask(async (value) => {
+    const oldRangorde = this.args.mandataris.rangorde;
+    const newRangorde = value;
+    const previousHolder = this.getMandatarisWithRangorde(newRangorde);
+    this.args.mandataris.rangorde = newRangorde;
+
+    const promises = [this.args.mandataris.save()];
+
+    if (previousHolder && previousHolder !== this.args.mandataris) {
+      previousHolder.rangorde = oldRangorde;
+      promises.push(previousHolder.save());
+    }
+    await Promise.all(promises);
+    await timeout(SEARCH_TIMEOUT);
+  });
+
+  setRangorde(value) {
+    this.updateMandatarisRangorde.perform(value);
+  }
+
+  async getMandaatLabel() {
+    const mandaat = await this.args.mandataris.get('bekleedt');
+    return mandaat?.rangordeLabel;
+  }
+
+  findOrderInString(possibleString) {
+    if (!possibleString || typeof possibleString != 'string') {
+      return null;
+    }
+    let foundNumber = null;
+    Object.keys(rangordeStringMapping).forEach((key) => {
+      if (possibleString.startsWith(key)) {
+        foundNumber = rangordeStringMapping[key];
+      }
+    });
+    return foundNumber;
+  }
+
+  findFirstWordOfString(string) {
+    // eslint-disable-next-line no-useless-escape
+    const regex = new RegExp(/^([\w\-]+)/);
+    if (regex.test(string)) {
+      return `${string}`.match(regex);
+    }
+    return null;
+  }
+
+  get isMinusDisabled() {
+    return this.rangordeInteger <= 1;
+  }
+
+  get isPlusDisabled() {
+    return this.rangordeInteger >= Object.keys(rangordeStringMapping).length;
+  }
+
+  getMandatarisWithRangorde(targetRangorde) {
+    return this.args.mandatarissen.find((mandataris) => {
+      return mandataris.rangorde === targetRangorde;
+    });
+  }
+
+  getNextAvailableRangorde() {
+    const sortedMandatarissen = orderMandatarissenByRangorde([
+      ...this.args.mandatarissen,
+    ]);
+    const lastNumber = rangordeStringToNumber(
+      sortedMandatarissen[sortedMandatarissen.length - 1].rangorde
+    );
+    if (lastNumber) {
+      return rangordeNumberMapping[lastNumber + 1];
+    }
+    return rangordeNumberMapping[1];
+  }
+
+  @action
+  onUpdateRangorde(event) {
+    this.setRangorde(event.currentTarget.value);
+  }
+
+  @action
+  async rangordeUp() {
+    const currentNumber = this.rangordeInteger || 0;
+    const newOrder = rangordeNumberMapping[currentNumber + 1];
+
+    if (this.rangordeInteger == null) {
+      this.setRangorde(
+        `${this.getNextAvailableRangorde()} ${await this.getMandaatLabel()}`
+      );
+    } else {
+      const currentOrder = rangordeNumberMapping[currentNumber];
+      this.setRangorde(this.rangorde.replace(currentOrder, newOrder));
+    }
+  }
+  @action
+  async rangordeDown() {
+    const currentNumber = this.rangordeInteger || 2;
+    const newOrder = rangordeNumberMapping[currentNumber - 1];
+
+    if (this.rangordeInteger == null) {
+      this.setRangorde(
+        `${this.getNextAvailableRangorde()} ${await this.getMandaatLabel()}`
+      );
+    } else {
+      const currentOrder = rangordeNumberMapping[currentNumber];
+      this.setRangorde(this.rangorde.replace(currentOrder, newOrder));
+    }
+  }
+
+  @action
+  onEnterInRangorde(event) {
+    if (event.key === 'Enter') {
+      this.setRangorde(event.currentTarget.value);
+    }
+  }
+}

--- a/app/components/organen/rangorde-input.js
+++ b/app/components/organen/rangorde-input.js
@@ -35,7 +35,7 @@ export default class OrganenRangordeInputComponent extends Component {
   get rangordeMovedUp() {
     const currentNumber = this.rangordeInteger || 0;
     const oldNumber = this.findOrderInString(
-      this.args.mandatarisStruct.mandataris.oldRangorde
+      this.args.mandatarisStruct.mandataris.rangorde
     );
     return currentNumber < oldNumber;
   }
@@ -43,7 +43,7 @@ export default class OrganenRangordeInputComponent extends Component {
   get rangordeMovedDown() {
     const currentNumber = this.rangordeInteger || 0;
     const oldNumber = this.findOrderInString(
-      this.args.mandatarisStruct.mandataris.oldRangorde
+      this.args.mandatarisStruct.mandataris.rangorde
     );
     return currentNumber > oldNumber;
   }
@@ -63,14 +63,12 @@ export default class OrganenRangordeInputComponent extends Component {
     const previousHolder = this.getMandatarisWithRangorde(newRangorde);
 
     this.args.mandatarisStruct.rangorde = newRangorde;
-    this.args.trackUpdatedRangorde(newRangorde);
 
     if (
       previousHolder &&
       previousHolder !== this.args.mandatarisStruct.mandataris
     ) {
       previousHolder.rangorde = oldRangorde;
-      this.args.trackUpdatedRangorde(oldRangorde);
     }
 
     this.args.updateMandatarisList();

--- a/app/components/organen/rangorde-input.js
+++ b/app/components/organen/rangorde-input.js
@@ -49,6 +49,7 @@ export default class OrganenRangordeInputComponent extends Component {
 
     // This should happen in the mandatarissen list ...
     this.args.mandatarisStruct.mandataris.rangorde = newRangorde;
+    this.args.mandatarisStruct.rangorde = newRangorde;
 
     const promises = [this.args.mandatarisStruct.mandataris.save()];
 
@@ -58,6 +59,7 @@ export default class OrganenRangordeInputComponent extends Component {
     ) {
       // This should happen in the mandatarissen list ...
       previousHolder.mandataris.rangorde = oldRangorde;
+      previousHolder.rangorde = oldRangorde;
       promises.push(previousHolder.mandataris.save());
     }
 

--- a/app/components/shared/tooltip.hbs
+++ b/app/components/shared/tooltip.hbs
@@ -1,4 +1,4 @@
-<div class="tooltip-container">
+<div class="tooltip-container" ...attributes>
   {{yield}}
   {{#if this.shouldRender}}
     <div class="tooltip-text {{this.alignment}}">

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -120,8 +120,8 @@
       @showFractie={{true}}
       @showFunctie={{true}}
       @showStart={{true}}
-      @showRangorde={{@bestuursorgaan.hasRangorde}}
-      @showBeleidsdomein={{@bestuursorgaan.isCBS}}
+      @showRangorde={{await @bestuursorgaan.hasRangorde}}
+      @showBeleidsdomein={{await @bestuursorgaan.isCBS}}
       @showStartEndDate={{false}}
       @form={{@form}}
       @buildMetaTtl={{this.buildMetaTtl}}

--- a/app/components/verkiezingen/prepare-legislatuur-section.hbs
+++ b/app/components/verkiezingen/prepare-legislatuur-section.hbs
@@ -120,20 +120,8 @@
       @showFractie={{true}}
       @showFunctie={{true}}
       @showStart={{true}}
-      @showRangorde={{or
-        (eq
-          @bestuursorgaan.isTijdsspecialisatieVan.classificatie.uri
-          this.CBSClassification
-        )
-        (eq
-          @bestuursorgaan.isTijdsspecialisatieVan.classificatie.uri
-          this.gemeenteRaadClassification
-        )
-      }}
-      @showBeleidsdomein={{eq
-        @bestuursorgaan.isTijdsspecialisatieVan.classificatie.uri
-        this.CBSClassification
-      }}
+      @showRangorde={{@bestuursorgaan.hasRangorde}}
+      @showBeleidsdomein={{@bestuursorgaan.isCBS}}
       @showStartEndDate={{false}}
       @form={{@form}}
       @buildMetaTtl={{this.buildMetaTtl}}

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -76,13 +76,6 @@ export default class PrepareLegislatuurSectionComponent extends Component {
     return this.editMode === CREATE_MODE;
   }
 
-  get CBSClassification() {
-    return CBS_BESTUURSORGAAN_URI;
-  }
-  get gemeenteRaadClassification() {
-    return GEMEENTERAAD_BESTUURSORGAAN_URI;
-  }
-
   mirrorTable = restartableTask(async () => {
     this.skeletonRowsOfMirror = null;
     let syncId = null;

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -10,6 +10,8 @@ export default class EditRangordeController extends Controller {
   @service router;
 
   @tracked modalOpen = false;
+  @tracked correcting = false;
+  @tracked date = null;
   @tracked orderedMandatarissen = [];
   @tracked interceptedTransition = null;
   updatedRangordes = new Set();
@@ -29,13 +31,16 @@ export default class EditRangordeController extends Controller {
   }
 
   @action
-  openModal() {
-    this.modalOpen = true;
-  }
-
-  @action
   closeModal() {
     this.modalOpen = false;
+  }
+
+  get modalTitle() {
+    if (this.correcting) {
+      return 'Corrigeer Rangorde';
+    } else {
+      return 'Wijzig Rangorde';
+    }
   }
 
   get openModalDisabled() {
@@ -44,6 +49,10 @@ export default class EditRangordeController extends Controller {
 
   get tooltipText() {
     return 'Er werden nog geen wijzigingen gevonden.';
+  }
+
+  get confirmDisabled() {
+    return !this.correcting && !this.date;
   }
 
   getChangedEntries() {
@@ -60,9 +69,9 @@ export default class EditRangordeController extends Controller {
     return mandatarissen;
   }
 
-  async changeRangorde(asCorrection) {
+  async changeRangorde() {
     const diff = this.getChangedEntries();
-    await this.rangordeApi.updateRangordes(diff, asCorrection);
+    await this.rangordeApi.updateRangordes(diff, this.correcting);
     this.closeModal();
     this.updatedRangordes.clear();
     this.hasChanges = false;
@@ -84,5 +93,14 @@ export default class EditRangordeController extends Controller {
 
   @action cancelLoseChanges() {
     this.interceptedTransition = null;
+  }
+  @action startCorrectingRangorde() {
+    this.modalOpen = true;
+    this.correcting = true;
+  }
+
+  @action startChangeRangorde() {
+    this.modalOpen = true;
+    this.correcting = false;
   }
 }

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { orderMandatarisStructByRangorde } from 'frontend-lmb/utils/rangorde';
+import moment from 'moment';
 
 export default class EditRangordeController extends Controller {
   queryParams = ['date'];
@@ -42,6 +43,10 @@ export default class EditRangordeController extends Controller {
     } else {
       return 'Wijzig Rangorde';
     }
+  }
+
+  get momentizedDate() {
+    return moment(this.date).toDate();
   }
 
   get openModalDisabled() {

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -3,12 +3,17 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { orderMandatarissenByRangorde } from 'frontend-lmb/utils/rangorde';
 
 export default class EditRangordeController extends Controller {
   @service mandatarisApi;
   @service router;
 
   @tracked modalOpen = false;
+
+  get orderedMandatarissen() {
+    return orderMandatarissenByRangorde([...this.model.mandatarissen]);
+  }
 
   @action
   openModal() {

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -1,0 +1,37 @@
+import Controller from '@ember/controller';
+
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class EditRangordeController extends Controller {
+  @service mandatarisApi;
+  @service router;
+
+  @tracked modalOpen = false;
+
+  @action
+  openModal() {
+    this.modalOpen = true;
+  }
+
+  @action
+  closeModal() {
+    this.modalOpen = false;
+  }
+
+  get openModalDisabled() {
+    return true;
+  }
+
+  get tooltipText() {
+    return 'Er werden nog geen wijzigingen gevonden.';
+  }
+
+  @action confirmEditRangorde() {
+    // Call mandataris-service
+    this.closeModal();
+    // Reset values
+    setTimeout(() => this.router.refresh(), 1000);
+  }
+}

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -3,7 +3,7 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { orderMandatarissenByRangorde } from 'frontend-lmb/utils/rangorde';
+import { orderMandatarisStructByRangorde } from 'frontend-lmb/utils/rangorde';
 
 export default class EditRangordeController extends Controller {
   @service mandatarisApi;
@@ -12,7 +12,7 @@ export default class EditRangordeController extends Controller {
   @tracked modalOpen = false;
 
   get orderedMandatarissen() {
-    return orderMandatarissenByRangorde([...this.model.mandatarissen]);
+    return orderMandatarisStructByRangorde([...this.model.mandatarisStruct]);
   }
 
   @action

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -10,9 +10,13 @@ export default class EditRangordeController extends Controller {
   @service router;
 
   @tracked modalOpen = false;
+  @tracked orderedMandatarissen = [];
 
-  get orderedMandatarissen() {
-    return orderMandatarisStructByRangorde([...this.model.mandatarisStruct]);
+  @action
+  updateOrderedMandatarisList() {
+    this.orderedMandatarissen = orderMandatarisStructByRangorde([
+      ...this.model.mandatarisStruct,
+    ]);
   }
 
   @action

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -59,12 +59,12 @@ export default class EditRangordeController extends Controller {
     return mandatarissen;
   }
 
-  @action confirmEditRangorde() {
+  @action async confirmEditRangorde() {
     const diff = this.getChangedEntries();
-    this.rangordeApi.updateRangordes(diff);
+    await this.rangordeApi.updateRangordes(diff);
     this.closeModal();
     this.updatedRangordes.clear();
     this.hasChanges = false;
-    setTimeout(() => this.router.refresh(), 1000);
+    this.router.refresh();
   }
 }

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -45,7 +45,23 @@ export default class EditRangordeController extends Controller {
     return 'Er werden nog geen wijzigingen gevonden.';
   }
 
+  getChangedEntries() {
+    const mandatarissen = this.orderedMandatarissen
+      .filter((struct) => {
+        return this.updatedRangordes.has(struct.rangorde);
+      })
+      .map((struct) => {
+        return {
+          mandatarisId: struct.mandataris.id,
+          rangorde: struct.rangorde,
+        };
+      });
+    return mandatarissen;
+  }
+
   @action confirmEditRangorde() {
+    // Compute entries that changed
+    const diff = this.getChangedEntries();
     // Call mandataris-service
     this.closeModal();
     // Reset values

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -11,6 +11,7 @@ export default class EditRangordeController extends Controller {
   @service rangordeApi;
   @service router;
 
+  @tracked loading = false;
   @tracked modalOpen = false;
   @tracked correcting = false;
   @tracked date = new Date();
@@ -77,11 +78,13 @@ export default class EditRangordeController extends Controller {
 
   @action
   async changeRangorde() {
+    this.loading = true;
     const diff = this.changedEntries;
     await this.rangordeApi.updateRangordes(diff, this.correcting, this.date);
     this.closeModal();
     this.updatedRangordes.clear();
     this.hasChanges = false;
+    this.loading = false;
     this.router.refresh();
   }
 

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -17,8 +17,7 @@ export default class EditRangordeController extends Controller {
   @tracked date = new Date();
   @tracked orderedMandatarissen = [];
   @tracked interceptedTransition = null;
-  updatedRangordes = new Set();
-  @tracked hasChanges = false;
+  @tracked updatedRangordeAt = new Date();
 
   @action
   updateOrderedMandatarisList() {
@@ -28,9 +27,12 @@ export default class EditRangordeController extends Controller {
   }
 
   @action
-  trackUpdatedRangorde(rangorde) {
-    this.updatedRangordes.add(rangorde);
-    this.hasChanges = true;
+  trackUpdatedRangorde() {
+    this.updatedRangordeAt = new Date();
+  }
+
+  get hasChanges() {
+    return this.changedEntries.length > 0;
   }
 
   @action
@@ -64,9 +66,7 @@ export default class EditRangordeController extends Controller {
 
   get changedEntries() {
     const mandatarissen = this.orderedMandatarissen
-      .filter((struct) => {
-        return this.updatedRangordes.has(struct.rangorde);
-      })
+      .filter((struct) => struct.mandataris.oldRangorde !== struct.rangorde)
       .map((struct) => {
         return {
           mandatarisId: struct.mandataris.id,
@@ -82,9 +82,9 @@ export default class EditRangordeController extends Controller {
     const diff = this.changedEntries;
     await this.rangordeApi.updateRangordes(diff, this.correcting, this.date);
     this.closeModal();
-    this.updatedRangordes.clear();
-    this.hasChanges = false;
     this.loading = false;
+    // so we can tell the route it's ok to refresh now
+    this.saved = true;
     this.router.refresh();
   }
 

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -6,7 +6,7 @@ import { service } from '@ember/service';
 import { orderMandatarisStructByRangorde } from 'frontend-lmb/utils/rangorde';
 
 export default class EditRangordeController extends Controller {
-  @service mandatarisApi;
+  @service rangordeApi;
   @service router;
 
   @tracked modalOpen = false;
@@ -60,11 +60,11 @@ export default class EditRangordeController extends Controller {
   }
 
   @action confirmEditRangorde() {
-    // Compute entries that changed
     const diff = this.getChangedEntries();
-    // Call mandataris-service
+    this.rangordeApi.updateRangordes(diff);
     this.closeModal();
-    // Reset values
+    this.updatedRangordes.clear();
+    this.hasChanges = false;
     setTimeout(() => this.router.refresh(), 1000);
   }
 }

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -6,12 +6,13 @@ import { service } from '@ember/service';
 import { orderMandatarisStructByRangorde } from 'frontend-lmb/utils/rangorde';
 
 export default class EditRangordeController extends Controller {
+  queryParams = ['date'];
   @service rangordeApi;
   @service router;
 
   @tracked modalOpen = false;
   @tracked correcting = false;
-  @tracked date = null;
+  @tracked date = new Date();
   @tracked orderedMandatarissen = [];
   @tracked interceptedTransition = null;
   updatedRangordes = new Set();
@@ -55,7 +56,7 @@ export default class EditRangordeController extends Controller {
     return !this.correcting && !this.date;
   }
 
-  getChangedEntries() {
+  get changedEntries() {
     const mandatarissen = this.orderedMandatarissen
       .filter((struct) => {
         return this.updatedRangordes.has(struct.rangorde);
@@ -69,21 +70,14 @@ export default class EditRangordeController extends Controller {
     return mandatarissen;
   }
 
+  @action
   async changeRangorde() {
-    const diff = this.getChangedEntries();
-    await this.rangordeApi.updateRangordes(diff, this.correcting);
+    const diff = this.changedEntries;
+    await this.rangordeApi.updateRangordes(diff, this.correcting, this.date);
     this.closeModal();
     this.updatedRangordes.clear();
     this.hasChanges = false;
     this.router.refresh();
-  }
-
-  @action async confirmCorrectRangorde() {
-    this.changeRangorde(true);
-  }
-
-  @action async confirmChangeRangorde() {
-    this.changeRangorde(false);
   }
 
   @action confirmLoseChanges() {

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -11,6 +11,7 @@ export default class EditRangordeController extends Controller {
 
   @tracked modalOpen = false;
   @tracked orderedMandatarissen = [];
+  @tracked interceptedTransition = null;
   updatedRangordes = new Set();
   @tracked hasChanges = false;
 
@@ -59,12 +60,29 @@ export default class EditRangordeController extends Controller {
     return mandatarissen;
   }
 
-  @action async confirmEditRangorde() {
+  async changeRangorde(asCorrection) {
     const diff = this.getChangedEntries();
-    await this.rangordeApi.updateRangordes(diff);
+    await this.rangordeApi.updateRangordes(diff, asCorrection);
     this.closeModal();
     this.updatedRangordes.clear();
     this.hasChanges = false;
     this.router.refresh();
+  }
+
+  @action async confirmCorrectRangorde() {
+    this.changeRangorde(true);
+  }
+
+  @action async confirmChangeRangorde() {
+    this.changeRangorde(false);
+  }
+
+  @action confirmLoseChanges() {
+    this.interceptedTransition.retry();
+    this.interceptedTransition = null;
+  }
+
+  @action cancelLoseChanges() {
+    this.interceptedTransition = null;
   }
 }

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -11,12 +11,18 @@ export default class EditRangordeController extends Controller {
 
   @tracked modalOpen = false;
   @tracked orderedMandatarissen = [];
+  updatedRangordes = new Set();
 
   @action
   updateOrderedMandatarisList() {
     this.orderedMandatarissen = orderMandatarisStructByRangorde([
       ...this.model.mandatarisStruct,
     ]);
+  }
+
+  @action
+  trackUpdatedRangorde(rangorde) {
+    this.updatedRangordes.add(rangorde);
   }
 
   @action

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -17,18 +17,12 @@ export default class EditRangordeController extends Controller {
   @tracked date = new Date();
   @tracked orderedMandatarissen = [];
   @tracked interceptedTransition = null;
-  @tracked updatedRangordeAt = new Date();
 
   @action
   updateOrderedMandatarisList() {
     this.orderedMandatarissen = orderMandatarisStructByRangorde([
       ...this.model.mandatarisStruct,
     ]);
-  }
-
-  @action
-  trackUpdatedRangorde() {
-    this.updatedRangordeAt = new Date();
   }
 
   get hasChanges() {
@@ -66,7 +60,7 @@ export default class EditRangordeController extends Controller {
 
   get changedEntries() {
     const mandatarissen = this.orderedMandatarissen
-      .filter((struct) => struct.mandataris.oldRangorde !== struct.rangorde)
+      .filter((struct) => struct.mandataris.rangorde !== struct.rangorde)
       .map((struct) => {
         return {
           mandatarisId: struct.mandataris.id,

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -12,6 +12,7 @@ export default class EditRangordeController extends Controller {
   @tracked modalOpen = false;
   @tracked orderedMandatarissen = [];
   updatedRangordes = new Set();
+  @tracked hasChanges = false;
 
   @action
   updateOrderedMandatarisList() {
@@ -23,6 +24,7 @@ export default class EditRangordeController extends Controller {
   @action
   trackUpdatedRangorde(rangorde) {
     this.updatedRangordes.add(rangorde);
+    this.hasChanges = true;
   }
 
   @action
@@ -36,7 +38,7 @@ export default class EditRangordeController extends Controller {
   }
 
   get openModalDisabled() {
-    return true;
+    return !this.hasChanges;
   }
 
   get tooltipText() {

--- a/app/controllers/organen/orgaan/mandatarissen.js
+++ b/app/controllers/organen/orgaan/mandatarissen.js
@@ -13,6 +13,7 @@ export default class OrganenMandatarissenController extends Controller {
 
   @service fractieApi;
   @service toaster;
+  @service bestuursperioden;
   @service('mandataris') mandatarisService;
 
   queryParams = ['activeOnly'];
@@ -79,21 +80,9 @@ export default class OrganenMandatarissenController extends Controller {
   }
 
   get selectedPeriodIsCurrent() {
-    if (!this.model?.selectedBestuursperiode) {
-      return false;
-    }
-
-    let isCurrent = false;
-    const currentYear = new Date().getFullYear();
-    if (
-      currentYear >= this.model.selectedBestuursperiode.start &&
-      (!this.model.selectedBestuursperiode.einde ||
-        currentYear < this.model.selectedBestuursperiode.einde)
-    ) {
-      isCurrent = true;
-    }
-
-    return isCurrent;
+    return this.bestuursperioden.isCurrentPeriod(
+      this.model?.selectedBestuursperiode
+    );
   }
 
   get personCount() {

--- a/app/controllers/organen/orgaan/mandatarissen.js
+++ b/app/controllers/organen/orgaan/mandatarissen.js
@@ -28,7 +28,6 @@ export default class OrganenMandatarissenController extends Controller {
   size = 900000;
 
   @tracked newestMandatarisId = null;
-  @tracked editRangorde = false;
 
   search = task({ restartable: true }, async (searchData) => {
     await timeout(SEARCH_TIMEOUT);
@@ -43,11 +42,6 @@ export default class OrganenMandatarissenController extends Controller {
   @action
   setIsCreatingMandataris(toggleTo) {
     this.isCreatingMandataris = toggleTo;
-  }
-
-  @action
-  toggleEditRangorde() {
-    this.editRangorde = !this.editRangorde;
   }
 
   @action

--- a/app/controllers/organen/orgaan/mandatarissen.js
+++ b/app/controllers/organen/orgaan/mandatarissen.js
@@ -28,6 +28,7 @@ export default class OrganenMandatarissenController extends Controller {
   size = 900000;
 
   @tracked newestMandatarisId = null;
+  @tracked editRangorde = false;
 
   search = task({ restartable: true }, async (searchData) => {
     await timeout(SEARCH_TIMEOUT);
@@ -42,6 +43,11 @@ export default class OrganenMandatarissenController extends Controller {
   @action
   setIsCreatingMandataris(toggleTo) {
     this.isCreatingMandataris = toggleTo;
+  }
+
+  @action
+  toggleEditRangorde() {
+    this.editRangorde = !this.editRangorde;
   }
 
   @action

--- a/app/controllers/organen/orgaan/mandatarissen.js
+++ b/app/controllers/organen/orgaan/mandatarissen.js
@@ -57,7 +57,7 @@ export default class OrganenMandatarissenController extends Controller {
   @action
   async buildMetaTtl() {
     const metaTtl = await getApplicationContextMetaTtl([
-      this.model.currentBestuursorgaan,
+      this.model.bestuursorgaanInTijd,
     ]);
     return `${metaTtl}
     <http://mu.semte.ch/vocabularies/ext/applicationContext> <http://mu.semte.ch/vocabularies/ext/limitPersonFractions> true .

--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -150,6 +150,10 @@ export default class BestuursorgaanModel extends Model {
     return this.hasBestuursorgaanClassificatie(BURGEMEESTER_BESTUURSORGAAN_URI);
   }
 
+  get hasRangorde() {
+    return this.isCBS || this.isGR;
+  }
+
   get hasVoorzitter() {
     return [
       GEMEENTERAAD_BESTUURSORGAAN_URI,

--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -151,7 +151,9 @@ export default class BestuursorgaanModel extends Model {
   }
 
   get hasRangorde() {
-    return this.isCBS || this.isGR;
+    return Promise.all([this.isCBS, this.isGR]).then((promise) => {
+      return promise.some((value) => value);
+    });
   }
 
   get hasVoorzitter() {

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -4,8 +4,11 @@ import moment from 'moment';
 import { MANDATARIS_EDIT_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import { JSON_API_TYPE } from 'frontend-lmb/utils/constants';
 import { displayEndOfDay } from 'frontend-lmb/utils/date-manipulation';
+import { tracked } from '@glimmer/tracking';
 
 export default class MandatarisModel extends Model {
+  @tracked oldRangorde;
+
   @attr rangorde;
   @attr('datetime') start;
   @attr('datetime') einde;

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -4,11 +4,8 @@ import moment from 'moment';
 import { MANDATARIS_EDIT_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import { JSON_API_TYPE } from 'frontend-lmb/utils/constants';
 import { displayEndOfDay } from 'frontend-lmb/utils/date-manipulation';
-import { tracked } from '@glimmer/tracking';
 
 export default class MandatarisModel extends Model {
-  @tracked oldRangorde;
-
   @attr rangorde;
   @attr('datetime') start;
   @attr('datetime') einde;

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -112,6 +112,16 @@ export default class MandatarisModel extends Model {
     return false;
   }
 
+  isActiveAt(date) {
+    if (!this.einde) {
+      return moment(this.start).isSameOrBefore(date);
+    }
+    return (
+      moment(this.start).isSameOrBefore(date) &&
+      moment(this.einde).isAfter(date)
+    );
+  }
+
   get uniqueVervangersDoor() {
     return this.getUnique(this.tijdelijkeVervangingen);
   }

--- a/app/router.js
+++ b/app/router.js
@@ -33,6 +33,7 @@ Router.map(function () {
     this.route('orgaan', { path: '/:id' }, function () {
       this.route('mandatarissen');
       this.route('bulk-bekrachtiging');
+      this.route('edit-rangorde');
       this.route('mandataris', function () {
         this.route('new');
       });

--- a/app/routes/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/routes/organen/orgaan/bulk-bekrachtiging.js
@@ -10,6 +10,7 @@ import {
 export default class BulkBekrachtigingRoute extends Route {
   @service store;
   @service installatievergadering;
+  @service('mandatarissen') mandatarissenService;
 
   queryParams = {
     page: { refreshModel: true },
@@ -27,9 +28,10 @@ export default class BulkBekrachtigingRoute extends Route {
     let mandatarissen;
     let mandatarissenMap;
     if (currentBestuursorgaan) {
-      const options = this.getOptions(params, currentBestuursorgaan);
-
-      mandatarissen = await this.store.query('mandataris', options);
+      mandatarissen = await this.mandatarissenService.getMandatarissen(
+        params,
+        currentBestuursorgaan
+      );
       mandatarissenMap = await Promise.all(
         mandatarissen.map(async (mandataris) => {
           const uri = (await mandataris.publicationStatus).uri;
@@ -57,33 +59,5 @@ export default class BulkBekrachtigingRoute extends Route {
       selectedBestuursperiode: parentModel.selectedBestuursperiode,
       currentBestuursorgaan: currentBestuursorgaan,
     };
-  }
-
-  getOptions(params, bestuursOrgaan) {
-    const queryParams = {
-      sort: params.sort,
-      page: {
-        number: params.page,
-        size: params.size,
-      },
-      filter: {
-        bekleedt: {
-          'bevat-in': {
-            id: bestuursOrgaan.id,
-          },
-        },
-        ':has:is-bestuurlijke-alias-van': true,
-      },
-      include: [
-        'is-bestuurlijke-alias-van',
-        'bekleedt.bestuursfunctie',
-        'heeft-lidmaatschap',
-        'heeft-lidmaatschap.binnen-fractie',
-        'status',
-        'publication-status',
-      ].join(','),
-    };
-
-    return queryParams;
   }
 }

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -34,7 +34,6 @@ export default class EditRangordeRoute extends Route {
       return mandataris.get('bekleedt.hasRangorde');
     });
     const mandatarisStruct = mandatarissen.map((mandataris) => {
-      mandataris.oldRangorde = mandataris.rangorde;
       return { mandataris: mandataris, rangorde: mandataris.rangorde };
     });
 
@@ -50,7 +49,6 @@ export default class EditRangordeRoute extends Route {
     super.setupController(...arguments);
     controller.modalOpen = false;
     controller.interceptedTransition = null;
-    controller.updatedRangordes = new Set();
     controller.loading = false;
     controller.saved = false;
     controller.updateOrderedMandatarisList();

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -31,4 +31,9 @@ export default class EditRangordeRoute extends Route {
       mandatarisStruct,
     };
   }
+
+  setupController(controller) {
+    super.setupController(...arguments);
+    controller.updateOrderedMandatarisList();
+  }
 }

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -20,12 +20,15 @@ export default class EditRangordeRoute extends Route {
         parentModel.selectedBestuursperiode
       );
     }
+    const mandatarisStruct = mandatarissen.map((mandataris) => {
+      return { mandataris: mandataris, rangorde: mandataris.rangorde };
+    });
 
     return {
       bestuursorgaan: parentModel.bestuursorgaan,
       bestuursorgaanInTijd,
       selectedBestuursperiode: parentModel.selectedBestuursperiode,
-      mandatarissen,
+      mandatarisStruct,
     };
   }
 }

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -13,9 +13,10 @@ export default class EditRangordeRoute extends Route {
     let mandatarissen;
 
     if (bestuursorgaanInTijd) {
-      mandatarissen = await this.mandatarissenService.getMandatarissen(
+      mandatarissen = await this.mandatarissenService.getActiveMandatarissen(
         params,
-        bestuursorgaanInTijd
+        bestuursorgaanInTijd,
+        parentModel.selectedBestuursperiode
       );
     }
 

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -7,6 +7,12 @@ export default class EditRangordeRoute extends Route {
   @service store;
   @service('mandatarissen') mandatarissenService;
 
+  queryParams = {
+    date: {
+      refreshModel: true,
+    },
+  };
+
   async model(params) {
     const parentModel = this.modelFor('organen.orgaan');
     const bestuursorgaanInTijd = await parentModel.currentBestuursorgaan;
@@ -15,11 +21,13 @@ export default class EditRangordeRoute extends Route {
 
     if (bestuursorgaanInTijd) {
       params.size = 9999;
-      mandatarissen = await this.mandatarissenService.getActiveMandatarissen(
-        params,
-        bestuursorgaanInTijd,
-        parentModel.selectedBestuursperiode
-      );
+      mandatarissen =
+        await this.mandatarissenService.getActiveMandatarissenAtTime(
+          params,
+          bestuursorgaanInTijd,
+          parentModel.selectedBestuursperiode,
+          params.date
+        );
     }
     mandatarissen = mandatarissen.filter((mandataris) => {
       return mandataris.get('bekleedt.hasRangorde');
@@ -42,7 +50,6 @@ export default class EditRangordeRoute extends Route {
     controller.interceptedTransition = null;
     controller.updatedRangordes = new Set();
     controller.hasChanges = false;
-    controller.date = null;
     controller.updateOrderedMandatarisList();
   }
 
@@ -52,7 +59,7 @@ export default class EditRangordeRoute extends Route {
     // eslint-disable-next-line ember/no-controller-access-in-routes
     const controller = this.controller;
     if (
-      controller.getChangedEntries().length > 0 &&
+      controller.changedEntries.length > 0 &&
       !controller.interceptedTransition
     ) {
       controller.interceptedTransition = transition;

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 
 import { service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class EditRangordeRoute extends Route {
   @service store;
@@ -20,6 +21,9 @@ export default class EditRangordeRoute extends Route {
         parentModel.selectedBestuursperiode
       );
     }
+    mandatarissen = mandatarissen.filter((mandataris) => {
+      return mandataris.get('bekleedt.hasRangorde');
+    });
     const mandatarisStruct = mandatarissen.map((mandataris) => {
       return { mandataris: mandataris, rangorde: mandataris.rangorde };
     });
@@ -34,6 +38,24 @@ export default class EditRangordeRoute extends Route {
 
   setupController(controller) {
     super.setupController(...arguments);
+    controller.modalOpen = false;
+    controller.interceptedTransition = null;
+    controller.updatedRangordes = new Set();
+    controller.hasChanges = false;
     controller.updateOrderedMandatarisList();
+  }
+
+  @action
+  willTransition(transition) {
+    // dude, the ember api docs say to do it like this wtf.
+    // eslint-disable-next-line ember/no-controller-access-in-routes
+    const controller = this.controller;
+    if (
+      controller.getChangedEntries().length > 0 &&
+      !controller.interceptedTransition
+    ) {
+      controller.interceptedTransition = transition;
+      transition.abort();
+    }
   }
 }

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -42,6 +42,7 @@ export default class EditRangordeRoute extends Route {
     controller.interceptedTransition = null;
     controller.updatedRangordes = new Set();
     controller.hasChanges = false;
+    controller.date = null;
     controller.updateOrderedMandatarisList();
   }
 

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -13,6 +13,8 @@ export default class EditRangordeRoute extends Route {
     let mandatarissen;
 
     if (bestuursorgaanInTijd) {
+      params.sort = 'rangorde';
+      params.size = 9999;
       mandatarissen = await this.mandatarissenService.getActiveMandatarissen(
         params,
         bestuursorgaanInTijd,

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -18,7 +18,6 @@ export default class EditRangordeRoute extends Route {
         bestuursorgaanInTijd
       );
     }
-    console.log(mandatarissen);
 
     return {
       bestuursorgaan: parentModel.bestuursorgaan,

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 
 import { service } from '@ember/service';
 import { action } from '@ember/object';
+import { endOfDay } from 'frontend-lmb/utils/date-manipulation';
 
 export default class EditRangordeRoute extends Route {
   @service store;
@@ -26,7 +27,7 @@ export default class EditRangordeRoute extends Route {
           params,
           bestuursorgaanInTijd,
           parentModel.selectedBestuursperiode,
-          params.date
+          endOfDay(params.date)
         );
     }
     mandatarissen = mandatarissen.filter((mandataris) => {

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -1,0 +1,30 @@
+import Route from '@ember/routing/route';
+
+import { service } from '@ember/service';
+
+export default class EditRangordeRoute extends Route {
+  @service store;
+  @service('mandatarissen') mandatarissenService;
+
+  async model(params) {
+    const parentModel = this.modelFor('organen.orgaan');
+    const bestuursorgaanInTijd = await parentModel.currentBestuursorgaan;
+
+    let mandatarissen;
+
+    if (bestuursorgaanInTijd) {
+      mandatarissen = await this.mandatarissenService.getMandatarissen(
+        params,
+        bestuursorgaanInTijd
+      );
+    }
+    console.log(mandatarissen);
+
+    return {
+      bestuursorgaan: parentModel.bestuursorgaan,
+      bestuursorgaanInTijd,
+      selectedBestuursperiode: parentModel.selectedBestuursperiode,
+      mandatarissen,
+    };
+  }
+}

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -13,7 +13,6 @@ export default class EditRangordeRoute extends Route {
     let mandatarissen;
 
     if (bestuursorgaanInTijd) {
-      params.sort = 'rangorde';
       params.size = 9999;
       mandatarissen = await this.mandatarissenService.getActiveMandatarissen(
         params,

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -34,6 +34,7 @@ export default class EditRangordeRoute extends Route {
       return mandataris.get('bekleedt.hasRangorde');
     });
     const mandatarisStruct = mandatarissen.map((mandataris) => {
+      mandataris.oldRangorde = mandataris.rangorde;
       return { mandataris: mandataris, rangorde: mandataris.rangorde };
     });
 
@@ -50,8 +51,8 @@ export default class EditRangordeRoute extends Route {
     controller.modalOpen = false;
     controller.interceptedTransition = null;
     controller.updatedRangordes = new Set();
-    controller.hasChanges = false;
     controller.loading = false;
+    controller.saved = false;
     controller.updateOrderedMandatarisList();
   }
 
@@ -61,6 +62,7 @@ export default class EditRangordeRoute extends Route {
     // eslint-disable-next-line ember/no-controller-access-in-routes
     const controller = this.controller;
     if (
+      !controller.saved &&
       controller.changedEntries.length > 0 &&
       !controller.interceptedTransition
     ) {

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -50,6 +50,7 @@ export default class EditRangordeRoute extends Route {
     controller.interceptedTransition = null;
     controller.updatedRangordes = new Set();
     controller.hasChanges = false;
+    controller.loading = false;
     controller.updateOrderedMandatarisList();
   }
 

--- a/app/routes/organen/orgaan/mandatarissen.js
+++ b/app/routes/organen/orgaan/mandatarissen.js
@@ -9,6 +9,7 @@ export default class OrganenMandatarissenRoute extends Route {
   @service currentSession;
   @service store;
   @service installatievergadering;
+  @service bestuursperioden;
   @service semanticFormRepository;
   @service('mandatarissen') mandatarissenService;
 
@@ -34,6 +35,11 @@ export default class OrganenMandatarissenRoute extends Route {
       );
     }
     const folded = await foldMandatarisses(params, mandatarissen);
+    const filtered = this.getFilteredMandatarissen(
+      folded,
+      params,
+      parentModel.selectedBestuursperiode
+    );
     const mandatarisNewForm =
       await this.semanticFormRepository.getFormDefinition(
         MANDATARIS_NEW_FORM_ID
@@ -47,7 +53,7 @@ export default class OrganenMandatarissenRoute extends Route {
 
     return {
       bestuurseenheid,
-      mandatarissen: this.getFilteredMandatarissen(folded, params),
+      mandatarissen: filtered,
       bestuursorgaan: parentModel.bestuursorgaan,
       bestuursorgaanInTijd,
       selectedBestuursperiode: parentModel.selectedBestuursperiode,
@@ -56,11 +62,11 @@ export default class OrganenMandatarissenRoute extends Route {
     };
   }
 
-  getFilteredMandatarissen(mandatarissen, params) {
+  getFilteredMandatarissen(mandatarissen, params, bestuursperiode) {
     let filteredMandatarissen = mandatarissen;
-    // eslint-disable-next-line ember/no-controller-access-in-routes
-    const controller = this.controllerFor('organen.orgaan.mandatarissen');
-    if (params.activeOnly && controller.selectedPeriodIsCurrent) {
+    const isCurrentBestuursperiode =
+      this.bestuursperioden.isCurrentPeriod(bestuursperiode);
+    if (params.activeOnly && isCurrentBestuursperiode) {
       filteredMandatarissen = mandatarissen.filter(
         (mandataris) => mandataris.mandataris.isActive
       );

--- a/app/routes/organen/orgaan/mandatarissen.js
+++ b/app/routes/organen/orgaan/mandatarissen.js
@@ -3,6 +3,7 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 import { foldMandatarisses } from 'frontend-lmb/utils/fold-mandatarisses';
+import { orderMandatarissenByRangorde } from 'frontend-lmb/utils/rangorde';
 import { MANDATARIS_NEW_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 
 export default class OrganenMandatarissenRoute extends Route {
@@ -27,9 +28,7 @@ export default class OrganenMandatarissenRoute extends Route {
 
     let mandatarissen;
     if (bestuursorgaanInTijd) {
-      const options = this.getOptions(params, bestuursorgaanInTijd);
-
-      mandatarissen = await this.store.query('mandataris', options);
+      mandatarissen = await this.getMandatarissen(params, bestuursorgaanInTijd);
     }
     const folded = await foldMandatarisses(params, mandatarissen);
     const mandatarisNewForm =
@@ -52,6 +51,16 @@ export default class OrganenMandatarissenRoute extends Route {
       mandatarisNewForm: mandatarisNewForm,
       legislatuurInBehandeling: isDistrict ? false : legislatuurInBehandeling,
     };
+  }
+
+  async getMandatarissen(params, bestuursorgaanInTijd) {
+    const options = this.getOptions(params, bestuursorgaanInTijd);
+    const mandatarissen = await this.store.query('mandataris', options);
+    if (params.sort && params.sort.endsWith('rangorde')) {
+      const reverse = params.sort[0] == '-';
+      return orderMandatarissenByRangorde([...mandatarissen], null, reverse);
+    }
+    return mandatarissen;
   }
 
   getOptions(params, bestuursOrgaan) {

--- a/app/routes/organen/orgaan/mandatarissen.js
+++ b/app/routes/organen/orgaan/mandatarissen.js
@@ -21,13 +21,13 @@ export default class OrganenMandatarissenRoute extends Route {
 
   async model(params) {
     const parentModel = this.modelFor('organen.orgaan');
-    const currentBestuursorgaan = await parentModel.currentBestuursorgaan;
+    const bestuursorgaanInTijd = await parentModel.currentBestuursorgaan;
 
     const bestuurseenheid = this.currentSession.group;
 
     let mandatarissen;
-    if (currentBestuursorgaan) {
-      const options = this.getOptions(params, currentBestuursorgaan);
+    if (bestuursorgaanInTijd) {
+      const options = this.getOptions(params, bestuursorgaanInTijd);
 
       mandatarissen = await this.store.query('mandataris', options);
     }
@@ -42,40 +42,16 @@ export default class OrganenMandatarissenRoute extends Route {
         parentModel.selectedBestuursperiode
       );
     const isDistrict = this.currentSession.isDistrict;
-    const bestuursorgaanInTijdId = await this.getBestuursorgaanInTijdId(
-      parentModel.selectedBestuursperiode,
-      parentModel.bestuursorgaan
-    );
 
     return {
       bestuurseenheid,
       mandatarissen: this.getFilteredMandatarissen(folded, params),
       bestuursorgaan: parentModel.bestuursorgaan,
-      bestuursorgaanInTijdId,
-      bestuursorgaanInTijd: await this.store.findRecord(
-        'bestuursorgaan',
-        bestuursorgaanInTijdId
-      ),
+      bestuursorgaanInTijd,
       selectedBestuursperiode: parentModel.selectedBestuursperiode,
       mandatarisNewForm: mandatarisNewForm,
-      currentBestuursorgaan: currentBestuursorgaan,
       legislatuurInBehandeling: isDistrict ? false : legislatuurInBehandeling,
     };
-  }
-
-  async getBestuursorgaanInTijdId(selectedBestuursperiode, bestuursorgaan) {
-    const bestuursorganenInTijdFromPeriod =
-      (await selectedBestuursperiode.heeftBestuursorganenInTijd) ?? [];
-    const bestuursorganenInTijd =
-      (await bestuursorgaan?.heeftTijdsspecialisaties) ?? [];
-    const fromPeriodIds = bestuursorganenInTijdFromPeriod.map((boi) => boi.id);
-    const boiIds = bestuursorganenInTijd.map((boi) => boi.id);
-    const boiInPeriod = boiIds.filter((id) => fromPeriodIds.includes(id));
-
-    if (boiInPeriod.length >= 1) {
-      return boiInPeriod.at(0);
-    }
-    return null;
   }
 
   getOptions(params, bestuursOrgaan) {

--- a/app/services/bestuursperioden.js
+++ b/app/services/bestuursperioden.js
@@ -49,4 +49,21 @@ export default class BestuursperiodenService extends Service {
 
     return currentPeriod || firstfuturePeriod || firstPreviousPeriod;
   }
+
+  isCurrentPeriod(period) {
+    if (!period) {
+      return false;
+    }
+
+    let isCurrent = false;
+    const currentYear = new Date().getFullYear();
+    if (
+      currentYear >= period.start &&
+      (!period.einde || currentYear < period.einde)
+    ) {
+      isCurrent = true;
+    }
+
+    return isCurrent;
+  }
 }

--- a/app/services/mandatarissen.js
+++ b/app/services/mandatarissen.js
@@ -5,6 +5,20 @@ import { orderMandatarissenByRangorde } from 'frontend-lmb/utils/rangorde';
 
 export default class MandatarissenService extends Service {
   @service store;
+  @service bestuursperioden;
+
+  async getActiveMandatarissen(params, bestuursorgaanInTijd, bestuursperiode) {
+    let mandatarissen = await this.getMandatarissen(
+      params,
+      bestuursorgaanInTijd
+    );
+    const isCurrentBestuursperiode =
+      this.bestuursperioden.isCurrentPeriod(bestuursperiode);
+    if (isCurrentBestuursperiode) {
+      return mandatarissen.filter((mandataris) => mandataris.isActive);
+    }
+    return mandatarissen;
+  }
 
   async getMandatarissen(params, bestuursorgaanInTijd) {
     const options = this.getOptions(params, bestuursorgaanInTijd);

--- a/app/services/mandatarissen.js
+++ b/app/services/mandatarissen.js
@@ -1,0 +1,50 @@
+import Service from '@ember/service';
+
+import { service } from '@ember/service';
+import { orderMandatarissenByRangorde } from 'frontend-lmb/utils/rangorde';
+
+export default class MandatarissenService extends Service {
+  @service store;
+
+  async getMandatarissen(params, bestuursorgaanInTijd) {
+    const options = this.getOptions(params, bestuursorgaanInTijd);
+    const mandatarissen = await this.store.query('mandataris', options);
+    if (params.sort && params.sort.endsWith('rangorde')) {
+      const reverse = params.sort[0] == '-';
+      return orderMandatarissenByRangorde([...mandatarissen], null, reverse);
+    }
+    return mandatarissen;
+  }
+
+  getOptions(params, bestuursOrgaan) {
+    const queryParams = {
+      sort: params.sort,
+      page: {
+        number: params.page,
+        size: params.size,
+      },
+      filter: {
+        bekleedt: {
+          'bevat-in': {
+            id: bestuursOrgaan.id,
+          },
+        },
+        ':has:is-bestuurlijke-alias-van': true,
+      },
+      include: [
+        'is-bestuurlijke-alias-van',
+        'bekleedt.bestuursfunctie',
+        'heeft-lidmaatschap',
+        'heeft-lidmaatschap.binnen-fractie',
+        'status',
+        'publication-status',
+      ].join(','),
+    };
+
+    if (params.filter) {
+      queryParams['filter']['is-bestuurlijke-alias-van'] = params.filter;
+    }
+
+    return queryParams;
+  }
+}

--- a/app/services/mandatarissen.js
+++ b/app/services/mandatarissen.js
@@ -20,6 +20,26 @@ export default class MandatarissenService extends Service {
     return mandatarissen;
   }
 
+  async getActiveMandatarissenAtTime(
+    params,
+    bestuursorgaanInTijd,
+    bestuursperiode,
+    date
+  ) {
+    let mandatarissen = await this.getMandatarissen(
+      params,
+      bestuursorgaanInTijd
+    );
+    const isCurrentBestuursperiode =
+      this.bestuursperioden.isCurrentPeriod(bestuursperiode);
+    if (isCurrentBestuursperiode) {
+      return mandatarissen.filter((mandataris) => {
+        return mandataris.isActiveAt(date);
+      });
+    }
+    return mandatarissen;
+  }
+
   async getMandatarissen(params, bestuursorgaanInTijd) {
     const options = this.getOptions(params, bestuursorgaanInTijd);
     const mandatarissen = await this.store.query('mandataris', options);

--- a/app/services/mandatarissen.js
+++ b/app/services/mandatarissen.js
@@ -7,19 +7,6 @@ export default class MandatarissenService extends Service {
   @service store;
   @service bestuursperioden;
 
-  async getActiveMandatarissen(params, bestuursorgaanInTijd, bestuursperiode) {
-    let mandatarissen = await this.getMandatarissen(
-      params,
-      bestuursorgaanInTijd
-    );
-    const isCurrentBestuursperiode =
-      this.bestuursperioden.isCurrentPeriod(bestuursperiode);
-    if (isCurrentBestuursperiode) {
-      return mandatarissen.filter((mandataris) => mandataris.isActive);
-    }
-    return mandatarissen;
-  }
-
   async getActiveMandatarissenAtTime(
     params,
     bestuursorgaanInTijd,

--- a/app/services/rangorde-api.js
+++ b/app/services/rangorde-api.js
@@ -2,6 +2,7 @@ import Service from '@ember/service';
 
 import { service } from '@ember/service';
 import { API, JSON_API_TYPE, STATUS_CODE } from 'frontend-lmb/utils/constants';
+import { endOfDay } from 'frontend-lmb/utils/date-manipulation';
 import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
 
 export default class RangordeApiService extends Service {
@@ -18,7 +19,7 @@ export default class RangordeApiService extends Service {
         },
         body: JSON.stringify({
           mandatarissen: mandatarissen,
-          date,
+          date: endOfDay(date),
         }),
       }
     );

--- a/app/services/rangorde-api.js
+++ b/app/services/rangorde-api.js
@@ -8,7 +8,7 @@ export default class RangordeApiService extends Service {
   @service store;
   @service toaster;
 
-  async updateRangordes(mandatarissen, asCorrection) {
+  async updateRangordes(mandatarissen, asCorrection, date) {
     const response = await fetch(
       `${API.MANDATARIS_SERVICE}/rangorde/update-rangordes?asCorrection=${asCorrection}`,
       {
@@ -18,6 +18,7 @@ export default class RangordeApiService extends Service {
         },
         body: JSON.stringify({
           mandatarissen: mandatarissen,
+          date,
         }),
       }
     );
@@ -29,7 +30,8 @@ export default class RangordeApiService extends Service {
         this.toaster,
         'Er ging iets mis bij het updaten van de rangordes'
       );
+    } else {
+      showSuccessToast(this.toaster, `De rangordes werden succesvol geüpdatet`);
     }
-    showSuccessToast(this.toaster, `De rangordes werden succesvol geüpdatet`);
   }
 }

--- a/app/services/rangorde-api.js
+++ b/app/services/rangorde-api.js
@@ -8,9 +8,9 @@ export default class RangordeApiService extends Service {
   @service store;
   @service toaster;
 
-  async updateRangordes(mandatarissen) {
+  async updateRangordes(mandatarissen, asCorrection) {
     const response = await fetch(
-      `${API.MANDATARIS_SERVICE}/rangorde/update-rangordes`,
+      `${API.MANDATARIS_SERVICE}/rangorde/update-rangordes?asCorrection=${asCorrection}`,
       {
         method: 'POST',
         headers: {

--- a/app/services/rangorde-api.js
+++ b/app/services/rangorde-api.js
@@ -1,0 +1,35 @@
+import Service from '@ember/service';
+
+import { service } from '@ember/service';
+import { API, JSON_API_TYPE, STATUS_CODE } from 'frontend-lmb/utils/constants';
+import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
+
+export default class RangordeApiService extends Service {
+  @service store;
+  @service toaster;
+
+  async updateRangordes(mandatarissen) {
+    const response = await fetch(
+      `${API.MANDATARIS_SERVICE}/rangorde/update-rangordes`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': JSON_API_TYPE,
+        },
+        body: JSON.stringify({
+          mandatarissen: mandatarissen,
+        }),
+      }
+    );
+    const jsonReponse = await response.json();
+
+    if (response.status !== STATUS_CODE.OK) {
+      console.error(jsonReponse.message);
+      showErrorToast(
+        this.toaster,
+        'Er ging iets mis bij het updaten van de rangordes'
+      );
+    }
+    showSuccessToast(this.toaster, `De rangordes werden succesvol geüpdatet`);
+  }
+}

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -302,6 +302,7 @@
 // Tooltips
 .tooltip-container {
   position: relative;
+  overflow: visible !important;
 }
 
 .tooltip-container .tooltip-text {

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -250,6 +250,7 @@
 .order-input-as-string {
   display: flex;
   flex-direction: row;
+  align-items: center;
   gap: 0px;
 
   input {

--- a/app/templates/mandatarissen/search.hbs
+++ b/app/templates/mandatarissen/search.hbs
@@ -95,6 +95,7 @@
             @fracties={{this.selectedFracties}}
             @bestuursFunctieCodes={{this.selectedBestuursfuncties}}
             @sort={{this.sort}}
+            @skin="button-secondary"
           />
           <Shared::Tooltip
             @showTooltip={{true}}

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -125,7 +125,7 @@
   @title="Wijzigingen niet opgeslagen"
   @modalOpen={{this.interceptedTransition}}
   @closable={{true}}
-  @closeModal={{this.confirmLoseChanges}}
+  @closeModal={{this.cancelLoseChanges}}
 ><div class="au-o-box au-o-flow">
     <div>
       Je wijzigingen zijn niet opgeslagen en gaan verloren als je verder gaat!

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -61,7 +61,7 @@
     <AuToolbar class="au-u-margin-top" as |Group|>
       <Group>
         <AuButtonGroup>
-          <AuButton {{on "click" this.confirmEditRangorde}} @disabled="true">
+          <AuButton {{on "click" this.confirmEditRangorde}}>
             Bevestig
           </AuButton>
           <AuButton {{on "click" this.closeModal}} @skin="secondary">

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -39,6 +39,7 @@
 <Organen::EditMandatarisRangordeTable
   @mandatarissen={{@model.mandatarisStruct}}
   @orderedMandatarissen={{this.orderedMandatarissen}}
+  @updateMandatarisList={{this.updateOrderedMandatarisList}}
   @bestuursperiode={{@model.selectedBestuursperiode}}
 />
 

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -1,0 +1,71 @@
+{{breadcrumb
+  "Wijzig rangorde mandatarissen"
+  route="organen.orgaan.edit-rangorde"
+}}
+<AuToolbar
+  @size="large"
+  class="au-u-padding-bottom-none au-u-margin-bottom-none"
+  as |Group|
+>
+  <Group class="au-u-margin-bottom-none">
+    <AuHeading @skin="2">
+      Wijzig rangorde mandatarissen
+    </AuHeading>
+  </Group>
+  <Group>
+    <Shared::Tooltip
+      @showTooltip={{this.openModalDisabled}}
+      @tooltipText={{this.tooltipText}}
+    >
+      <AuButton
+        {{on "click" this.openModal}}
+        @disabled={{this.openModalDisabled}}
+      >
+        Wijzig rangordes
+      </AuButton>
+    </Shared::Tooltip>
+  </Group>
+</AuToolbar>
+
+<AuHeading @skin="3" class="au-u-regular au-u-padding-left au-u-padding-bottom">
+  {{this.model.bestuursorgaan.naam}}
+  {{this.model.selectedBestuursperiode.label}}
+</AuHeading>
+
+<AuAlert @icon="info-circle" @closable={{false}}>
+  Verlaat deze pagina niet alvorens je de wijzigingen opgeslagen hebt.
+</AuAlert>
+
+<Organen::EditMandatarisRangordeTable
+  @content={{@model.mandatarissen}}
+  @bestuursperiode={{@model.selectedBestuursperiode}}
+/>
+
+{{outlet}}
+
+<AuModal
+  @title="Bevestig wijziging rangorde"
+  @modalOpen={{this.modalOpen}}
+  @closable={{true}}
+  @closeModal={{this.closeModal}}
+>
+  <div class="au-o-box au-o-flow">
+    <div>
+      <Tmp::todo>
+        Add some filler text here.
+      </Tmp::todo>
+    </div>
+    <AuToolbar class="au-u-margin-top" as |Group|>
+      <Group>
+        <AuButtonGroup>
+          <AuButton {{on "click" this.confirmEditRangorde}} @disabled="true">
+            Bevestig
+          </AuButton>
+          <AuButton {{on "click" this.closeModal}} @skin="secondary">
+            Annuleer
+          </AuButton>
+        </AuButtonGroup>
+      </Group>
+    </AuToolbar>
+  </div>
+</AuModal>

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -37,7 +37,7 @@
 </AuAlert>
 
 <Organen::EditMandatarisRangordeTable
-  @mandatarissen={{@model.mandatarissen}}
+  @mandatarissen={{@model.mandatarisStruct}}
   @orderedMandatarissen={{this.orderedMandatarissen}}
   @bestuursperiode={{@model.selectedBestuursperiode}}
 />

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -60,7 +60,6 @@
   @orderedMandatarissen={{this.orderedMandatarissen}}
   @updateMandatarisList={{this.updateOrderedMandatarisList}}
   @bestuursperiode={{@model.selectedBestuursperiode}}
-  @trackUpdatedRangorde={{this.trackUpdatedRangorde}}
 />
 
 {{outlet}}

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -19,6 +19,7 @@
     >
       <AuButton
         {{on "click" this.openModal}}
+        size="large"
         @disabled={{this.openModalDisabled}}
       >
         Wijzig rangordes
@@ -32,10 +33,6 @@
   {{this.model.selectedBestuursperiode.label}}
 </AuHeading>
 
-<AuAlert @icon="info-circle" @closable={{false}}>
-  Verlaat deze pagina niet alvorens je de wijzigingen opgeslagen hebt.
-</AuAlert>
-
 <Organen::EditMandatarisRangordeTable
   @mandatarissen={{@model.mandatarisStruct}}
   @orderedMandatarissen={{this.orderedMandatarissen}}
@@ -47,22 +44,36 @@
 {{outlet}}
 
 <AuModal
-  @title="Bevestig wijziging rangorde"
+  @title="Hoe wil je de rangorde aanpassen?"
   @modalOpen={{this.modalOpen}}
   @closable={{true}}
   @closeModal={{this.closeModal}}
 >
   <div class="au-o-box au-o-flow">
     <div>
-      <Tmp::todo>
-        Add some filler text here.
-      </Tmp::todo>
+      Je kan de rangorde van deze mandatarissen aanpassen als
+      <strong>"correctie"</strong>
+      of als
+      <strong>"wijziging van de rangorde"</strong>. Bij een "correctie" zet je
+      een fout recht die verkeerd in het systeem geregistreerd was. Bij een
+      "wijziging" van de rangorde geef je aan dat de rangorde van de
+      mandatarissen
+      <strong>doorheen het verloop van de bestuursperiode</strong>
+      daadwerkelijk veranderd is, bijvoorbeeld nadat een mandataris verhinderd
+      werd en er een vervanger werd aangesteld.
     </div>
     <AuToolbar class="au-u-margin-top" as |Group|>
       <Group>
         <AuButtonGroup>
-          <AuButton {{on "click" this.confirmEditRangorde}}>
-            Bevestig
+          <AuButton
+            @skin="secondary"
+            @alert={{true}}
+            {{on "click" this.confirmCorrectRangorde}}
+          >
+            Corrigeer rangorde
+          </AuButton>
+          <AuButton {{on "click" this.confirmChangeRangorde}}>
+            Wijzig rangorde
           </AuButton>
           <AuButton {{on "click" this.closeModal}} @skin="secondary">
             Annuleer
@@ -71,4 +82,29 @@
       </Group>
     </AuToolbar>
   </div>
+</AuModal>
+
+<AuModal
+  @title="Wijzigingen niet opgeslagen"
+  @modalOpen={{this.interceptedTransition}}
+  @closable={{true}}
+  @closeModal={{this.confirmLoseChanges}}
+><div class="au-o-box au-o-flow">
+    <div>
+      Je wijzigingen zijn niet opgeslagen en gaan verloren als je verder gaat!
+    </div>
+    <AuToolbar class="au-u-margin-top" as |Group|>
+      <Group>
+        <AuButtonGroup>
+          <AuButton @alert={{true}} {{on "click" this.confirmLoseChanges}}>
+            Verwerp aanpassingen
+          </AuButton>
+          <AuButton {{on "click" this.cancelLoseChanges}} @skin="secondary">
+            Annuleer
+          </AuButton>
+        </AuButtonGroup>
+      </Group>
+    </AuToolbar>
+  </div>
+
 </AuModal>

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -105,6 +105,8 @@
       <Group>
         <AuButtonGroup>
           <AuButton
+            @loading={{this.loading}}
+            @loadingMessage="Bezig met opslaan"
             {{on "click" this.changeRangorde}}
             @disabled={{this.confirmDisabled}}
           >

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -41,6 +41,7 @@
   @orderedMandatarissen={{this.orderedMandatarissen}}
   @updateMandatarisList={{this.updateOrderedMandatarisList}}
   @bestuursperiode={{@model.selectedBestuursperiode}}
+  @trackUpdatedRangorde={{this.trackUpdatedRangorde}}
 />
 
 {{outlet}}

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -37,7 +37,8 @@
 </AuAlert>
 
 <Organen::EditMandatarisRangordeTable
-  @content={{@model.mandatarissen}}
+  @mandatarissen={{@model.mandatarissen}}
+  @orderedMandatarissen={{this.orderedMandatarissen}}
   @bestuursperiode={{@model.selectedBestuursperiode}}
 />
 

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -18,11 +18,18 @@
       @tooltipText={{this.tooltipText}}
     >
       <AuButton
-        {{on "click" this.openModal}}
-        size="large"
+        @skin="secondary"
+        @alert={{true}}
+        @disabled={{this.openModalDisabled}}
+        {{on "click" this.startCorrectingRangorde}}
+      >
+        Corrigeer rangorde
+      </AuButton>
+      <AuButton
+        {{on "click" this.startChangeRangorde}}
         @disabled={{this.openModalDisabled}}
       >
-        Wijzig rangordes
+        Wijzig rangorde
       </AuButton>
     </Shared::Tooltip>
   </Group>
@@ -44,36 +51,56 @@
 {{outlet}}
 
 <AuModal
-  @title="Hoe wil je de rangorde aanpassen?"
+  @title={{this.modalTitle}}
   @modalOpen={{this.modalOpen}}
   @closable={{true}}
   @closeModal={{this.closeModal}}
 >
   <div class="au-o-box au-o-flow">
-    <div>
-      Je kan de rangorde van deze mandatarissen aanpassen als
-      <strong>"correctie"</strong>
-      of als
-      <strong>"wijziging van de rangorde"</strong>. Bij een "correctie" zet je
-      een fout recht die verkeerd in het systeem geregistreerd was. Bij een
-      "wijziging" van de rangorde geef je aan dat de rangorde van de
-      mandatarissen
-      <strong>doorheen het verloop van de bestuursperiode</strong>
-      daadwerkelijk veranderd is, bijvoorbeeld nadat een mandataris verhinderd
-      werd en er een vervanger werd aangesteld.
-    </div>
+    {{#if this.correcting}}
+      <div>
+        Een
+        <strong>correctie</strong>
+        van de rangorde betekent dat de rangorde van deze mandatarissen verkeerd
+        geregisteerd stond. Je aanpassing corrigeert dan deze mandatarissen. Als
+        er een
+        <strong>wissel is in de rangordes van verschillende mandatarissen</strong>
+        gebruik dan
+        <strong>wijzig rangorde</strong>.
+      </div>
+
+    {{else}}
+      <div>
+        Een
+        <strong>wijziging</strong>
+        van de rangorde betekent dat de rangorde van deze mandatarissen
+        <strong>doorheen de bestuursperiode</strong>
+        aangepast moet worden, bijvoorbeeld nadat een mandataris verhinderd werd
+        en er een vervanger werd aangesteld met een andere rangorde.
+      </div>
+      <div>
+        In dit geval moet je een datum selecteren vanaf wanneer de rangorde
+        aangepast moet worden. Mandatarissen zonder rangorde krijgen
+        onmiddellijk de juiste rangorde.
+      </div>
+      <DateInput
+        @label="Vanaf"
+        @value={{this.date}}
+        @from={{this.model.bestuursorgaanInTijd.bindingStart}}
+        @to={{this.model.bestuursorgaanInTijd.bindingEinde}}
+        @onChange={{fn (mut this.date)}}
+        @isRequired={{true}}
+      />
+    {{/if}}
+
     <AuToolbar class="au-u-margin-top" as |Group|>
       <Group>
         <AuButtonGroup>
           <AuButton
-            @skin="secondary"
-            @alert={{true}}
-            {{on "click" this.confirmCorrectRangorde}}
+            {{on "click" this.changeRangorde}}
+            @disabled={{this.confirmDisabled}}
           >
-            Corrigeer rangorde
-          </AuButton>
-          <AuButton {{on "click" this.confirmChangeRangorde}}>
-            Wijzig rangorde
+            Bevestig
           </AuButton>
           <AuButton {{on "click" this.closeModal}} @skin="secondary">
             Annuleer

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -47,7 +47,7 @@
   </p>
   <DateInput
     @label="Datum van aanpassing"
-    @value={{this.date}}
+    @value={{this.momentizedDate}}
     @from={{this.model.bestuursorgaanInTijd.bindingStart}}
     @to={{this.model.bestuursorgaanInTijd.bindingEinde}}
     @onChange={{fn (mut this.date)}}
@@ -77,8 +77,8 @@
         Een
         <strong>correctie</strong>
         van de rangorde betekent dat de rangorde van deze mandatarissen verkeerd
-        geregisteerd stond. Je aanpassing corrigeert dan deze mandatarissen. Als
-        er een
+        ingevuld stond. Je aanpassing corrigeert dan deze mandatarissen. Als er
+        een
         <strong>wissel is in de rangordes van verschillende mandatarissen</strong>
         gebruik dan
         <strong>wijzig rangorde</strong>.
@@ -86,17 +86,18 @@
 
     {{else}}
       <div>
-        Een
-        <strong>wijziging</strong>
-        van de rangorde betekent dat de rangorde van deze mandatarissen
-        <strong>doorheen de bestuursperiode</strong>
-        aangepast moet worden, bijvoorbeeld nadat een mandataris verhinderd werd
-        en er een vervanger werd aangesteld met een andere rangorde.
-      </div>
-      <div>
-        In dit geval moet je een datum selecteren vanaf wanneer de rangorde
-        aangepast moet worden. Mandatarissen zonder rangorde krijgen
-        onmiddellijk de juiste rangorde.
+        <p>
+          Een
+          <strong>wijziging</strong>
+          van de rangorde betekent dat de rangorde van deze mandatarissen
+          <strong>doorheen de bestuursperiode</strong>
+          aangepast moet worden, bijvoorbeeld nadat een mandataris verhinderd
+          werd en er een vervanger werd aangesteld met een andere rangorde.</p>
+        <p>
+          Als dit niet de aanpassing is die je wil doen, maar je een fout wil
+          rechtzetten, gebruik dan
+          <strong>corrigeer rangorde</strong>.
+        </p>
       </div>
     {{/if}}
 

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -40,6 +40,21 @@
   {{this.model.selectedBestuursperiode.label}}
 </AuHeading>
 
+<div class="au-u-padding au-u-padding-top-none">
+  <p class="au-u-margin-bottom">
+    Deze pagina laat je toe om de rangorde van de mandatarissen aan te passen.
+    Selecteer hier de datum waarop je de rangorde wil aanpassen.
+  </p>
+  <DateInput
+    @label="Datum van aanpassing"
+    @value={{this.date}}
+    @from={{this.model.bestuursorgaanInTijd.bindingStart}}
+    @to={{this.model.bestuursorgaanInTijd.bindingEinde}}
+    @onChange={{fn (mut this.date)}}
+    @isRequired={{true}}
+  />
+</div>
+
 <Organen::EditMandatarisRangordeTable
   @mandatarissen={{@model.mandatarisStruct}}
   @orderedMandatarissen={{this.orderedMandatarissen}}
@@ -83,14 +98,6 @@
         aangepast moet worden. Mandatarissen zonder rangorde krijgen
         onmiddellijk de juiste rangorde.
       </div>
-      <DateInput
-        @label="Vanaf"
-        @value={{this.date}}
-        @from={{this.model.bestuursorgaanInTijd.bindingStart}}
-        @to={{this.model.bestuursorgaanInTijd.bindingEinde}}
-        @onChange={{fn (mut this.date)}}
-        @isRequired={{true}}
-      />
     {{/if}}
 
     <AuToolbar class="au-u-margin-top" as |Group|>

--- a/app/templates/organen/orgaan/mandatarissen.hbs
+++ b/app/templates/organen/orgaan/mandatarissen.hbs
@@ -30,7 +30,7 @@
       @bestuursperiode={{@model.selectedBestuursperiode}}
       @activeOnly={{this.activeOnly}}
       @bestuursorgaan={{this.model.bestuursorgaan}}
-      @bestuursorgaanInTijdId={{this.model.bestuursorgaanInTijdId}}
+      @bestuursorgaanInTijdId={{this.model.bestuursorgaanInTijd.id}}
       @sort={{this.sort}}
     />
     <Shared::Tooltip

--- a/app/templates/organen/orgaan/mandatarissen.hbs
+++ b/app/templates/organen/orgaan/mandatarissen.hbs
@@ -10,45 +10,71 @@
     </AuHeading>
   </Group>
   <Group>
-    {{#if this.isDisabled}}
-      <Shared::Tooltip
-        @showTooltip={{true}}
-        @tooltipText="Het is niet mogelijk de rangorde van mandatarissen te wijzigen in een bestuursperiode waarvan de voorbereiding van de legislatuur nog actief is."
-      >
-        <AuButton @disabled={{true}}>
-          Wijzig rangorde
-        </AuButton>
-      </Shared::Tooltip>
-    {{else}}
-      <AuLink
-        @route="organen.orgaan.edit-rangorde"
-        @skin="button-secondary"
-      >Wijzig rangorde
-      </AuLink>
-    {{/if}}
-    {{#if this.isDisabled}}
-      <Shared::Tooltip
-        @showTooltip={{true}}
-        @tooltipText="Het is niet mogelijk mandatarissen te bekrachtingen in een bestuursperiode waarvan de voorbereiding van de legislatuur nog actief is."
-      >
-        <AuButton @disabled={{true}}>
-          Bekrachtig mandatarissen
-        </AuButton>
-      </Shared::Tooltip>
-    {{else}}
-      <AuLink
-        @route="organen.orgaan.bulk-bekrachtiging"
-        @skin="button-secondary"
-      >Bekrachtig mandatarissen
-      </AuLink>
-    {{/if}}
-    <DownloadMandatarissenFromTable
-      @bestuursperiode={{@model.selectedBestuursperiode}}
-      @activeOnly={{this.activeOnly}}
-      @bestuursorgaan={{this.model.bestuursorgaan}}
-      @bestuursorgaanInTijdId={{this.model.bestuursorgaanInTijd.id}}
-      @sort={{this.sort}}
-    />
+    {{! template-lint-disable require-context-role }}
+    <AuDropdown
+      @title="Meer Acties"
+      @skin="secondary"
+      @icon="three-dots"
+      @iconAlignment="right"
+    >
+      {{#if this.isDisabled}}
+        <Shared::Tooltip
+          role="menuitem"
+          @showTooltip={{true}}
+          @tooltipText="Het is niet mogelijk de rangorde van mandatarissen te wijzigen in een bestuursperiode waarvan de voorbereiding van de legislatuur nog actief is."
+        >
+          <AuButton @disabled={{true}} @skin="link" role="menuitem">
+            Wijzig rangorde
+          </AuButton>
+        </Shared::Tooltip>
+      {{else}}
+        <Shared::Tooltip
+          role="menuitem"
+          @showTooltip={{true}}
+          @tooltipText="Pas de rangorde aan van meerdere mandatarissen tegelijkertijd."
+        >
+          <AuLink
+            role="menuitem"
+            @route="organen.orgaan.edit-rangorde"
+            @skin="link"
+          >Wijzig rangorde
+          </AuLink>
+        </Shared::Tooltip>
+      {{/if}}
+      {{#if this.isDisabled}}
+        <Shared::Tooltip
+          @showTooltip={{true}}
+          role="menuitem"
+          @tooltipText="Het is niet mogelijk mandatarissen te bekrachtingen in een bestuursperiode waarvan de voorbereiding van de legislatuur nog actief is."
+        >
+          <AuButton @disabled={{true}} @skin="link" role="menuitem">
+            Bekrachtig mandatarissen
+          </AuButton>
+        </Shared::Tooltip>
+      {{else}}
+        <Shared::Tooltip
+          role="menuitem"
+          @showTooltip={{true}}
+          @tooltipText="Bekrachtig meerdere mandatarissen tegelijkertijd."
+        >
+          <AuLink
+            role="menuitem"
+            @skin="link"
+            @route="organen.orgaan.bulk-bekrachtiging"
+          >Bekrachtig mandatarissen
+          </AuLink>
+        </Shared::Tooltip>
+      {{/if}}
+      <DownloadMandatarissenFromTable
+        @bestuursperiode={{@model.selectedBestuursperiode}}
+        @activeOnly={{this.activeOnly}}
+        @bestuursorgaan={{this.model.bestuursorgaan}}
+        @bestuursorgaanInTijdId={{this.model.bestuursorgaanInTijd.id}}
+        @sort={{this.sort}}
+        @skin="link"
+        @role="menuitem"
+      />
+    </AuDropdown>
     <Shared::Tooltip
       @showTooltip={{this.isDisabled}}
       @tooltipText="Het is niet mogelijk mandatarissen toe te voegen aan een bestuursperiode terwijl de voorbereiding van de legislatuur actief is."

--- a/app/templates/organen/orgaan/mandatarissen.hbs
+++ b/app/templates/organen/orgaan/mandatarissen.hbs
@@ -87,6 +87,7 @@
   @personRoute="mandatarissen.persoon.mandaten"
   @mandaatRoute="mandatarissen.persoon.mandataris"
   @hidePublicationStatus={{not (await this.model.bestuursorgaan.isDecretaal)}}
+  @showRangorde={{await @model.bestuursorgaan.hasRangorde}}
 />
 
 {{outlet}}

--- a/app/templates/organen/orgaan/mandatarissen.hbs
+++ b/app/templates/organen/orgaan/mandatarissen.hbs
@@ -10,6 +10,9 @@
     </AuHeading>
   </Group>
   <Group>
+    <AuButton @skin="secondary" {{on "click" this.toggleEditRangorde}}>
+      Wijzig rangorde
+    </AuButton>
     {{#if this.isDisabled}}
       <Shared::Tooltip
         @showTooltip={{true}}
@@ -88,6 +91,7 @@
   @mandaatRoute="mandatarissen.persoon.mandataris"
   @hidePublicationStatus={{not (await this.model.bestuursorgaan.isDecretaal)}}
   @showRangorde={{await @model.bestuursorgaan.hasRangorde}}
+  @editRangorde={{this.editRangorde}}
 />
 
 {{outlet}}

--- a/app/templates/organen/orgaan/mandatarissen.hbs
+++ b/app/templates/organen/orgaan/mandatarissen.hbs
@@ -10,9 +10,22 @@
     </AuHeading>
   </Group>
   <Group>
-    <AuButton @skin="secondary" {{on "click" this.toggleEditRangorde}}>
-      Wijzig rangorde
-    </AuButton>
+    {{#if this.isDisabled}}
+      <Shared::Tooltip
+        @showTooltip={{true}}
+        @tooltipText="Het is niet mogelijk de rangorde van mandatarissen te wijzigen in een bestuursperiode waarvan de voorbereiding van de legislatuur nog actief is."
+      >
+        <AuButton @disabled={{true}}>
+          Wijzig rangorde
+        </AuButton>
+      </Shared::Tooltip>
+    {{else}}
+      <AuLink
+        @route="organen.orgaan.edit-rangorde"
+        @skin="button-secondary"
+      >Wijzig rangorde
+      </AuLink>
+    {{/if}}
     {{#if this.isDisabled}}
       <Shared::Tooltip
         @showTooltip={{true}}
@@ -91,7 +104,6 @@
   @mandaatRoute="mandatarissen.persoon.mandataris"
   @hidePublicationStatus={{not (await this.model.bestuursorgaan.isDecretaal)}}
   @showRangorde={{await @model.bestuursorgaan.hasRangorde}}
-  @editRangorde={{this.editRangorde}}
 />
 
 {{outlet}}

--- a/app/utils/rangorde.js
+++ b/app/utils/rangorde.js
@@ -117,15 +117,16 @@ export const rangordeStringToNumber = (rangordeString) => {
 
 export const orderMandatarissenByRangorde = (
   mandatarissen,
-  allMandatarissenInIv
+  allMandatarissenInIv,
+  reverse
 ) => {
   return mandatarissen.sort((a, b) => {
     const classRankA = a.bekleedt.get('bestuursfunctie.rankForSorting');
     const classRankB = b.bekleedt.get('bestuursfunctie.rankForSorting');
     if (classRankA < classRankB) {
-      return 1;
+      return reverse ? -1 : 1;
     } else if (classRankA > classRankB) {
-      return -1;
+      return reverse ? 1 : -1;
     }
 
     const noRangorde = !a.rangorde && !b.rangorde;
@@ -136,12 +137,12 @@ export const orderMandatarissenByRangorde = (
     const aNumber = rangordeStringToNumber(a.rangorde);
     const bNumber = rangordeStringToNumber(b.rangorde);
     if (aNumber == null) {
-      return -1;
+      return reverse ? 1 : -1;
     }
     if (bNumber == null) {
-      return 1;
+      return reverse ? -1 : 1;
     }
-    return aNumber - bNumber;
+    return reverse ? bNumber - aNumber : aNumber - bNumber;
   });
 };
 

--- a/app/utils/rangorde.js
+++ b/app/utils/rangorde.js
@@ -146,6 +146,32 @@ export const orderMandatarissenByRangorde = (
   });
 };
 
+export const orderMandatarisStructByRangorde = (mandatarissen) => {
+  return mandatarissen.sort((a, b) => {
+    const classRankA = a.mandataris.bekleedt.get(
+      'bestuursfunctie.rankForSorting'
+    );
+    const classRankB = b.mandataris.bekleedt.get(
+      'bestuursfunctie.rankForSorting'
+    );
+    if (classRankA < classRankB) {
+      return 1;
+    } else if (classRankA > classRankB) {
+      return -1;
+    }
+
+    const aNumber = rangordeStringToNumber(a.rangorde);
+    const bNumber = rangordeStringToNumber(b.rangorde);
+    if (aNumber == null) {
+      return -1;
+    }
+    if (bNumber == null) {
+      return 1;
+    }
+    return aNumber - bNumber;
+  });
+};
+
 const findCorrespondingMandatarisIndex = (mandataris, allMandatarissenInIv) => {
   const correspondingMandateUris = mandataris.bekleedt.get(
     'bestuursfunctie.correspondingMandateCodesIV'


### PR DESCRIPTION
## Description

Add interface to update rangordes. Both as update state and correct mistakes.

![image](https://github.com/user-attachments/assets/91322725-c760-4f8d-bcf2-22b44b60ec2e)

![image](https://github.com/user-attachments/assets/2718c6bb-f64e-4196-84c6-7ccc2b7da370)
![image](https://github.com/user-attachments/assets/77dc5152-3cd1-48ec-bce4-dedad237c6fe)
![image](https://github.com/user-attachments/assets/658672af-71dd-427b-a3e8-c385e930aff8)


## How to test

Go to the edit rangorde page and check if you can update rangordes and if it actually persists. Do the same for 'wijzig' and 'corrigeer'. Make sure to check the mandatarissen on the side of the ocmw too.

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/89
