### PR TITLE
lmb-1322 | update endpoint call to fetch nbMembers

### DIFF
--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -182,18 +182,16 @@ export default class BestuursorgaanModel extends Model {
       return null;
     }
 
-    return Promise.all([
-      fetch(
-        `${API.MANDATARIS_SERVICE}/organen/${currentOrgaan.id}/activeMembers`
-      )
-        .then(async (response) => {
-          const result = await response.json();
-          return result?.count;
-        })
-        .catch(() => {
-          return 0;
-        }),
-    ]);
+    return await fetch(
+      `${API.MANDATARIS_SERVICE}/organen/${currentOrgaan.id}/activeMembers`
+    )
+      .then(async (response) => {
+        const result = await response.json();
+        return result?.count;
+      })
+      .catch(() => {
+        return 0;
+      });
   }
 
   rdfaBindings = {


### PR DESCRIPTION
## Description

We are now showing the amount of mandatarissen in the orgaan at "Aantal leden" this should be the amount of persons with an active mandaat.

## How to test

1. use the updated mandataris service
2. Go to organen
3. End a mandataris
4. The amount should have droppped by 1

Note: When you add a mandataris to an orgaan without mandatarissen this should be the easiest to see that it counts people.

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/91
