### PR TITLE
Ben/lmb 1339 fix fractie validation

### DIFF
--- a/app/components/rdf-input-fields/mandataris-fractie-selector.js
+++ b/app/components/rdf-input-fields/mandataris-fractie-selector.js
@@ -18,7 +18,7 @@ import { restartableTask, timeout } from 'ember-concurrency';
 
 /**
  * The reason that the FractieSelector is a specific component is that when linking a mandataris
- * to a fractie, the link is materialized through a Lidmaadschap class, with a start and end date.
+ * to a fractie, the link is materialized through a Lidmaatschap class, with a start and end date.
  * The start and end date for the Lidmaatschap are set to the to the start and end date of the
  * mandate, and needs to be kept in sync when the mandataris is updated.
  *

--- a/app/utils/form-context/application-context-meta-ttl.js
+++ b/app/utils/form-context/application-context-meta-ttl.js
@@ -17,6 +17,9 @@ export const getApplicationContextMetaTtl = async (bestuursorganen) => {
     .join(', ');
 
   const period = getBestuursperiodeForBestuursorganen(bestuursorganen);
+  const isFractieRequired = await isRequiredForBestuursorgaan(
+    bestuursorganen.at(0)
+  );
 
   return `
     @prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
@@ -24,13 +27,7 @@ export const getApplicationContextMetaTtl = async (bestuursorganen) => {
 
     ext:applicationContext ext:currentBestuursorgaan ${bestuursorgaanUris} .
 
-    ${
-      bestuursorganen.length === 1
-        ? `
-        <http://lblod.data.gift/vocabularies/lmb/component> <http://lblod.data.gift/vocabularies/lmb/isFractieRequired> ${await isRequiredForBestuursorgaan(bestuursorganen.at(0))}.
-      `
-        : ``
-    }
+    <http://lblod.data.gift/vocabularies/lmb/component> <http://lblod.data.gift/vocabularies/lmb/isFractieRequired> ${isFractieRequired}.
 
     ${
       period

--- a/app/utils/form-context/application-context-meta-ttl.js
+++ b/app/utils/form-context/application-context-meta-ttl.js
@@ -91,7 +91,11 @@ const getBestuursperiodeForBestuursorganen = (bestuursorganen) => {
 export const loadIsFractieRequiredFromContext = (storeOptions) => {
   const { store, metaGraph } = storeOptions;
 
-  return Literal.toJS(
-    store.any(LMB('component'), LMB('isFractieRequired'), null, metaGraph)
+  const isRequired = store.any(
+    LMB('component'),
+    LMB('isFractieRequired'),
+    null,
+    metaGraph
   );
+  return Literal.toJS(!!isRequired);
 };


### PR DESCRIPTION
## Description

The mandataris-fractie-selector component failed in the case where there were multiple bestuursorganen selected e.g. for burgemeester mandates (both burgemeester and CBS bestuursorganen are selected in this case). 
This failing only happened when no fractie was filled in. 

This PR adds some extra safety checks that should handle this.

## How to test

Go to any mandataris which has a mandate with multiple bestuursorganen but has no fractie. Open the edit mistakes form, this should no longer throw an error.
