### PR TITLE
Ben/lmb 1319 improve burgemeester bekrachtiging

### DIFF
--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -28,7 +28,7 @@
         {{else}}
           <div class="au-u-flex">
             <Shared::Tooltip
-              @showTooltip={{await this.effectiefIsLastStatus}}
+              @showTooltip={{this.isEffectiefLastStatus}}
               @tooltipText={{this.lastStatusTooltipText}}
             >
               <Mandaat::PublicatieStatusPill

--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -37,7 +37,7 @@
                 @showBekijkBewijs={{true}}
               />
             </Shared::Tooltip>
-            {{#if this.canEditPublicationStatus}}
+            {{#if this.showEditPublicationStatus}}
               <AuButton
                 {{on "click" this.editStatus}}
                 @icon="pencil"
@@ -45,6 +45,7 @@
                 @size="small"
                 class="au-u-maring-left-tiny"
                 @hideText={{true}}
+                @disabled={{not this.canEditPublicationStatus}}
               >
                 edit
               </AuButton>

--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -26,31 +26,32 @@
             @onUpdate={{this.stopEditingStatus}}
           />
         {{else}}
-          <div class="au-u-flex">
-            <Shared::Tooltip
-              @showTooltip={{this.isEffectiefLastStatus}}
-              @tooltipText={{this.lastStatusTooltipText}}
-            >
+          <Shared::Tooltip
+            @showTooltip={{not this.canEditPublicationStatus}}
+            @tooltipText={{this.lastStatusTooltipText}}
+            @alignment="left"
+          >
+            <div class="au-u-flex">
               <Mandaat::PublicatieStatusPill
                 @mandataris={{@mandataris}}
                 @showInfoText={{true}}
                 @showBekijkBewijs={{true}}
               />
-            </Shared::Tooltip>
-            {{#if this.showEditPublicationStatus}}
-              <AuButton
-                {{on "click" this.editStatus}}
-                @icon="pencil"
-                @skin="link-secondary"
-                @size="small"
-                class="au-u-maring-left-tiny"
-                @hideText={{true}}
-                @disabled={{not this.canEditPublicationStatus}}
-              >
-                edit
-              </AuButton>
-            {{/if}}
-          </div>
+              {{#if this.showEditPublicationStatus}}
+                <AuButton
+                  {{on "click" this.editStatus}}
+                  @icon="pencil"
+                  @skin="link-secondary"
+                  @size="small"
+                  class="au-u-maring-left-tiny"
+                  @hideText={{true}}
+                  @disabled={{not this.canEditPublicationStatus}}
+                >
+                  edit
+                </AuButton>
+              {{/if}}
+            </div>
+          </Shared::Tooltip>
         {{/if}}
       </div>
     </div>

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -78,7 +78,11 @@ export default class MandatarisCardComponent extends Component {
   }
 
   get lastStatusTooltipText() {
-    if (this.isEffectieLastStatus) {
+    if (this.args.legislatuurInBehandeling) {
+      return 'De publicatiestatus kan niet aangepast worden als de legislatuur nog in behandeling is.';
+    } else if (this.isEffectiefBurgemeester) {
+      return 'Een burgemeester kan enkel bekrachtigd worden via een benoeming.';
+    } else if (this.isEffectiefLastStatus) {
       return 'Deze mandataris moet niet bekrachtigd worden.';
     }
 

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -81,7 +81,7 @@ export default class MandatarisCardComponent extends Component {
     if (this.args.legislatuurInBehandeling) {
       return 'De publicatiestatus kan niet aangepast worden als de legislatuur nog in behandeling is.';
     } else if (this.isEffectiefBurgemeester) {
-      return 'Een burgemeester kan enkel bekrachtigd worden via een benoeming.';
+      return 'Een burgemeester kan enkel bekrachtigd worden via een benoeming, dit gebeurt automatisch.';
     } else if (this.isEffectiefLastStatus) {
       return 'Deze mandataris moet niet bekrachtigd worden.';
     }

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -37,12 +37,8 @@ export default class MandatarisCardComponent extends Component {
     return !statusId || statusId === MANDATARIS_EFFECTIEF_PUBLICATION_STATE;
   }
 
-  get isBurgemeester() {
-    return this.args.mandataris.bekleedt.get('isBurgemeester');
-  }
-
   get isEffectiefBurgemeester() {
-    return this.isEffectief && this.isBurgemeester;
+    return this.isEffectief && this.args.mandataris.isStrictBurgemeester;
   }
 
   get fractie() {

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -4,7 +4,10 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 
-import { MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE } from 'frontend-lmb/utils/well-known-uris';
+import {
+  MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE,
+  MANDATARIS_EFFECTIEF_PUBLICATION_STATE,
+} from 'frontend-lmb/utils/well-known-uris';
 import { getDraftPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
 import { showErrorToast } from 'frontend-lmb/utils/toasts';
 import { effectiefIsLastPublicationStatus } from 'frontend-lmb/utils/effectief-is-last-publication-status';
@@ -29,6 +32,19 @@ export default class MandatarisCardComponent extends Component {
     return !statusId || statusId === MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE;
   }
 
+  get isEffectief() {
+    const statusId = this.args.mandataris.publicationStatus?.get('uri');
+    return !statusId || statusId === MANDATARIS_EFFECTIEF_PUBLICATION_STATE;
+  }
+
+  get isBurgemeester() {
+    return this.args.mandataris.bekleedt.get('isBurgemeester');
+  }
+
+  get isEffectiefBurgemeester() {
+    return this.isEffectief && this.isBurgemeester;
+  }
+
   get fractie() {
     return this.args.mandataris.heeftLidmaatschap.get('binnenFractie')
       ? this.args.mandataris.heeftLidmaatschap.get('binnenFractie').get('naam')
@@ -36,7 +52,11 @@ export default class MandatarisCardComponent extends Component {
   }
 
   get canEditPublicationStatus() {
-    return !this.isBekrachtigd && !this.args.disableEdits;
+    return (
+      !this.isBekrachtigd &&
+      !this.args.disableEdits &&
+      !this.isEffectiefBurgemeester
+    );
   }
 
   get persoon() {

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -52,11 +52,16 @@ export default class MandatarisCardComponent extends Component {
       : '';
   }
 
+  get showEditPublicationStatus() {
+    return !this.isBekrachtigd;
+  }
+
   get canEditPublicationStatus() {
     return (
       !this.isBekrachtigd &&
-      !this.args.disableEdits &&
-      !this.isEffectiefBurgemeester
+      !this.args.legislatuurInBehandeling &&
+      !this.isEffectiefBurgemeester &&
+      !this.isEffectiefLastStatus
     );
   }
 

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -11,7 +11,6 @@ import {
 import { getDraftPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
 import { showErrorToast } from 'frontend-lmb/utils/toasts';
 import { effectiefIsLastPublicationStatus } from 'frontend-lmb/utils/effectief-is-last-publication-status';
-import { PUBLICATION_STATUS_EFFECTIEF_ID } from 'frontend-lmb/utils/well-known-ids';
 
 import { task } from 'ember-concurrency';
 
@@ -28,17 +27,23 @@ export default class MandatarisCardComponent extends Component {
   }
 
   get isBekrachtigd() {
-    const statusId = this.args.mandataris.publicationStatus?.get('uri');
-    return !statusId || statusId === MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE;
+    const status = this.args.mandataris.publicationStatus?.get('uri');
+    return !status || status === MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE;
   }
 
   get isEffectief() {
-    const statusId = this.args.mandataris.publicationStatus?.get('uri');
-    return !statusId || statusId === MANDATARIS_EFFECTIEF_PUBLICATION_STATE;
+    const status = this.args.mandataris.publicationStatus?.get('uri');
+    return !status || status === MANDATARIS_EFFECTIEF_PUBLICATION_STATE;
   }
 
   get isEffectiefBurgemeester() {
     return this.isEffectief && this.args.mandataris.isStrictBurgemeester;
+  }
+
+  get isEffectiefLastStatus() {
+    return (
+      this.isEffectief && effectiefIsLastPublicationStatus(this.args.mandataris)
+    );
   }
 
   get fractie() {
@@ -67,18 +72,8 @@ export default class MandatarisCardComponent extends Component {
     return this.args.mandataris.uniqueVervangersVan;
   }
 
-  get effectiefIsLastStatus() {
-    return effectiefIsLastPublicationStatus(this.args.mandataris);
-  }
-
   get lastStatusTooltipText() {
-    const publicatieStatusId =
-      this.args.mandataris.publicationStatus?.get('id');
-    if (
-      this.effectiefIsLastStatus &&
-      publicatieStatusId &&
-      publicatieStatusId === PUBLICATION_STATUS_EFFECTIEF_ID
-    ) {
+    if (this.isEffectieLastStatus) {
       return 'Deze mandataris moet niet bekrachtigd worden.';
     }
 

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -63,7 +63,10 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
   }
 
   get effectiefIsLastStatus() {
-    return effectiefIsLastPublicationStatus(this.mandataris);
+    return (
+      this.mandataris.isStrictBurgemeester ||
+      effectiefIsLastPublicationStatus(this.mandataris)
+    );
   }
 
   constructor() {

--- a/app/components/organen/bekrachtig-mandataris-table.hbs
+++ b/app/components/organen/bekrachtig-mandataris-table.hbs
@@ -60,7 +60,7 @@
         {{#if row.canShowCheckbox}}
           <AuCheckbox
             @checked={{@checkedByDefault}}
-            @onChange={{fn @onCheck row.mandataris.id}}
+            @onChange={{fn @onCheck row.mandataris}}
           />
         {{/if}}
       </td>

--- a/app/components/rdf-input-fields/mandataris-mandaat-selector.hbs
+++ b/app/components/rdf-input-fields/mandataris-mandaat-selector.hbs
@@ -1,3 +1,15 @@
+{{#if this.isStrictBurgemeester}}
+  <AuAlert @skin="info" @icon="info-circle" @size="small" @closable={{false}}>
+    <p>
+      De standaard procedure voor het toevoegen van een burgemeester is als
+      volgt: Voeg eerst een aangewezen burgemeester toe, eenmaal deze benoemt
+      wordt en het besluit doorgestroomd is naar deze applicatie zal automatisch
+      een corresponderende burgemeester aangemaakt worden. Idealiter hoeft u dus
+      zelf geen burgemeester toe te voegen.
+    </p>
+  </AuAlert>
+{{/if}}
+
 <AuLabel
   for="mandaat"
   @error={{this.hasErrors}}

--- a/app/components/rdf-input-fields/mandataris-mandaat-selector.js
+++ b/app/components/rdf-input-fields/mandataris-mandaat-selector.js
@@ -22,6 +22,7 @@ export default class MandatarisMandaatSelector extends InputFieldComponent {
   @service multiUriFetcher;
 
   @tracked mandaat = null;
+  @tracked isStrictBurgemeester = false;
   @tracked initialized = false;
   @tracked bestuursorganen = [];
   @tracked person;
@@ -78,6 +79,7 @@ export default class MandatarisMandaatSelector extends InputFieldComponent {
   @action
   async updateMandaat(mandate) {
     const uri = mandate?.uri;
+    this.isStrictBurgemeester = mandate?.isStrictBurgemeester;
 
     replaceSingleFormValue(this.storeOptions, uri ? new NamedNode(uri) : null);
     this.hasBeenFocused = true;

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -93,10 +93,10 @@ export default class BulkBekrachtigingController extends Controller {
 
   @action checkBox(mandataris, state) {
     if (state) {
-      this.checked.add(mandataris);
+      this.checked.add(mandataris.id);
       this.setSize += 1;
     } else {
-      this.checked.delete(mandataris);
+      this.checked.delete(mandataris.id);
       this.setSize -= 1;
     }
     if (mandataris.bekleedt.get('isBurgemeester')) {

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -27,6 +27,8 @@ export default class BulkBekrachtigingController extends Controller {
   @tracked linkToBesluit;
   @tracked invalidLink = false;
 
+  @tracked burgemeesterSelected = false;
+
   @action
   openModal() {
     this.modalOpen = true;
@@ -97,6 +99,9 @@ export default class BulkBekrachtigingController extends Controller {
       this.checked.delete(mandataris);
       this.setSize -= 1;
     }
+    if (mandataris.bekleedt.get('isBurgemeester')) {
+      this.burgemeesterSelected = true;
+    }
   }
 
   @action checkAll(state) {
@@ -105,6 +110,9 @@ export default class BulkBekrachtigingController extends Controller {
       this.model.mandatarissenMap.forEach((mapping) => {
         if (mapping.canShowCheckbox) {
           this.checked.add(mapping.mandataris.id);
+        }
+        if (mapping.mandataris.bekleedt.get('isBurgemeester')) {
+          this.burgemeesterSelected = true;
         }
       });
       this.setSize = this.checked.size;
@@ -123,6 +131,7 @@ export default class BulkBekrachtigingController extends Controller {
     );
     this.closeModal();
     this.checked.clear();
+    this.burgemeesterSelected = false;
     this.setSize = 0;
     setTimeout(() => this.router.refresh(), 1000);
   }
@@ -135,7 +144,7 @@ export default class BulkBekrachtigingController extends Controller {
   }
 
   get statusOptions() {
-    if (this.model.effectiefIsLastStatus) {
+    if (this.model.effectiefIsLastStatus || this.burgemeesterSelected) {
       return ['Effectief'];
     }
     return ['Effectief', 'Bekrachtigd'];

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -27,7 +27,7 @@ export default class BulkBekrachtigingController extends Controller {
   @tracked linkToBesluit;
   @tracked invalidLink = false;
 
-  @tracked burgemeesterSelected = false;
+  @tracked burgemeesterSelected = 0;
 
   @action
   openModal() {
@@ -95,12 +95,15 @@ export default class BulkBekrachtigingController extends Controller {
     if (state) {
       this.checked.add(mandataris.id);
       this.setSize += 1;
+      if (mandataris.isStrictBurgemeester) {
+        this.burgemeesterSelected += 1;
+      }
     } else {
       this.checked.delete(mandataris.id);
       this.setSize -= 1;
-    }
-    if (mandataris.isStrictBurgemeester) {
-      this.burgemeesterSelected = true;
+      if (mandataris.isStrictBurgemeester) {
+        this.burgemeesterSelected -= 1;
+      }
     }
   }
 
@@ -131,7 +134,7 @@ export default class BulkBekrachtigingController extends Controller {
     );
     this.closeModal();
     this.checked.clear();
-    this.burgemeesterSelected = false;
+    this.burgemeesterSelected = 0;
     this.setSize = 0;
     setTimeout(() => this.router.refresh(), 1000);
   }

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -99,7 +99,7 @@ export default class BulkBekrachtigingController extends Controller {
       this.checked.delete(mandataris.id);
       this.setSize -= 1;
     }
-    if (mandataris.bekleedt.get('isBurgemeester')) {
+    if (mandataris.isStrictBurgemeester) {
       this.burgemeesterSelected = true;
     }
   }
@@ -111,7 +111,7 @@ export default class BulkBekrachtigingController extends Controller {
         if (mapping.canShowCheckbox) {
           this.checked.add(mapping.mandataris.id);
         }
-        if (mapping.mandataris.bekleedt.get('isBurgemeester')) {
+        if (mapping.isStrictBurgemeester) {
           this.burgemeesterSelected = true;
         }
       });

--- a/app/models/mandaat.js
+++ b/app/models/mandaat.js
@@ -60,6 +60,10 @@ export default class MandaatModel extends Model {
     ].includes(this.bestuursfunctie.get('uri'));
   }
 
+  get isStrictBurgemeester() {
+    return this.bestuursfunctie.get('uri') === MANDAAT_BURGEMEESTER_CODE;
+  }
+
   get isSchepen() {
     return [
       MANDAAT_SCHEPEN_CODE,

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 import { MANDATARIS_EDIT_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import { JSON_API_TYPE } from 'frontend-lmb/utils/constants';
 import { displayEndOfDay } from 'frontend-lmb/utils/date-manipulation';
+import { MANDAAT_BURGEMEESTER_CODE } from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarisModel extends Model {
   @attr rangorde;
@@ -132,6 +133,13 @@ export default class MandatarisModel extends Model {
 
   get isVoorzitter() {
     return this.bekleedt.get('isVoorzitter');
+  }
+
+  get isStrictBurgemeester() {
+    return (
+      this.bekleedt.get('bestuursfunctie').get('uri') ===
+      MANDAAT_BURGEMEESTER_CODE
+    );
   }
 
   get besluitUri() {

--- a/app/routes/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/routes/organen/orgaan/bulk-bekrachtiging.js
@@ -43,6 +43,11 @@ export default class BulkBekrachtigingRoute extends Route {
             canShowCheckbox = false;
           } else if (uri === MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE) {
             canShowCheckbox = false;
+          } else if (
+            mandataris.bekleedt.get('isBurgemeester') &&
+            uri === MANDATARIS_EFFECTIEF_PUBLICATION_STATE
+          ) {
+            canShowCheckbox = false;
           }
           return {
             mandataris,

--- a/app/routes/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/routes/organen/orgaan/bulk-bekrachtiging.js
@@ -44,7 +44,7 @@ export default class BulkBekrachtigingRoute extends Route {
           } else if (uri === MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE) {
             canShowCheckbox = false;
           } else if (
-            mandataris.bekleedt.get('isBurgemeester') &&
+            mandataris.isStrictBurgemeester &&
             uri === MANDATARIS_EFFECTIEF_PUBLICATION_STATE
           ) {
             canShowCheckbox = false;

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -53,7 +53,7 @@
     <Mandatarissen::MandatarisCard
       @mandataris={{@model.mandataris}}
       @bestuursorgaanIT={{get @model.bestuursorganen 0}}
-      @disableEdits={{this.isDisabledBecauseLegislatuur}}
+      @legislatuurInBehandeling={{this.isDisabledBecauseLegislatuur}}
     />
   </div>
 

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -60,6 +60,13 @@
   @closeModal={{this.closeModal}}
 >
   <div class="au-o-box au-o-flow">
+    {{#if this.burgemeesterSelected}}
+      <AuAlert @icon="info-circle" @closable={{false}}>
+        De publicatiestatus van een burgemeester kan niet manueel op
+        <strong>bekrachtigd</strong>
+        geplaatst worden, dit gebeurt automatisch via een benoeming.
+      </AuAlert>
+    {{/if}}
     {{#if (eq this.status "Bekrachtigd")}}
       <AuAlert @icon="info-circle" @closable={{false}}>
         De publicatiestatus


### PR DESCRIPTION
## Description

Add warning when adding a burgemeester (Not really sure about the text and placement).
![Screenshot 2025-02-10 at 09 51 07](https://github.com/user-attachments/assets/5e2f7a21-b0f9-4d06-ab4c-48b68c27cad1)

Don't allow updating the publication status of burgemeester to bekrachtigd. This should be the case in the person page and in the bulk bekrachtiging. Also improved tooltips and the different cases in when the publication status can be edited.

## How to test

Try adding a burgemeester, this should still be possible, but should give you a warning.

You shouldnt' be able to set the publication status of a burgemeester to bekrachtigd (this should still be possible for aangewezen burgemeester). Test this in the bulk-bekrachtiging route and the persoon route and check if the messages are clear. Also test if other cases still work (RMW has no effectief state ...)