### PR TITLE
fix link to besluit not shown for manual

### DIFF
--- a/app/components/mandaat/publicatie-status-pill.hbs
+++ b/app/components/mandaat/publicatie-status-pill.hbs
@@ -8,22 +8,27 @@
   >
     {{or this.status.label "Niet beschikbaar"}}
   </AuPill>
-  {{#if
-    (and
-      @showBekijkBewijs (await this.linkToDecision) this.isMandatarisBekrachtigd
-    )
-  }}
-    <AuLinkExternal
-      href={{await this.linkToDecision}}
-      class="au-u-margin-left-tiny"
-    >Bekijk besluit</AuLinkExternal>
+  {{#if @showBekijkBewijs}}
+    {{#if (await @mandataris.besluitUri)}}
+      <AuLinkExternal
+        href={{await @mandataris.besluitUri}}
+        class="au-u-margin-left-tiny"
+      >Bekijk besluit</AuLinkExternal>
+    {{else if @mandataris.linkToBesluit}}
+      <AuLinkExternal
+        href={{@mandataris.linkToBesluit}}
+        class="au-u-margin-left-tiny"
+      >Bekijk besluit</AuLinkExternal>
+    {{/if}}
   {{/if}}
   {{#if (and @showInfoText this.isMandatarisBekrachtigd)}}
     <p
       class="au-u-italic au-u-h-functional au-u-flex au-u-flex--vertical-center"
     >
-      <span class="au-u-margin-top-small u-u-margin-right-tiny">Om een
-        bekrachtiging terug te trekken moet je de
+      <span class="au-u-margin-top-small u-u-margin-right-tiny">
+        Deze mandataris werd
+        {{if @mandataris.linkToBesluit "handmatig" "automatisch"}}
+        bekrachtigd. Om een bekrachtiging terug te trekken moet je de
         <AuLinkExternal
           href="mailto:lokaalmandatenbeheer@vlaanderen.be?subject=Bekrachtiging terugtrekken - Lokaal Mandatenbeheer"
         >technische dienst contacteren</AuLinkExternal>

--- a/app/components/mandaat/publicatie-status-pill.js
+++ b/app/components/mandaat/publicatie-status-pill.js
@@ -7,15 +7,6 @@ export default class MandaatPublicatieStatusPillComponent extends Component {
     return this.status ? this.status.get('isBekrachtigd') : true;
   }
 
-  get linkToDecision() {
-    return this.getLink();
-  }
-
-  async getLink() {
-    const link = this.args.mandataris.besluitUri;
-    return link ?? this.args.mandataris.linkToBesluit;
-  }
-
   get effectiefIsLastStatus() {
     return effectiefIsLastPublicationStatus(this.args.mandataris);
   }


### PR DESCRIPTION
## Description

fix link to besluit not shown for manual
![image](https://github.com/user-attachments/assets/4e3203a6-3d93-49e9-ba7f-f33bb5a41b2e)

![image](https://github.com/user-attachments/assets/49dee5a6-2586-496b-b90c-809a9effdf06)

## How to test

view a manually and not manually approved mandataris and open their links