### PR TITLE
lmb-1168 | hide the legislatuur module when bestuurseenheid has property hide-legislatuur

### DIFF
--- a/app/models/bestuurseenheid.js
+++ b/app/models/bestuurseenheid.js
@@ -11,6 +11,7 @@ export default class Bestuurseenheid extends Model {
   @attr mailAdres;
   @attr wilMailOntvangen;
   @attr isTrialUser;
+  @attr('boolean', { defaultValue: false }) hideLegislatuur;
   @attr viewOnlyModules;
 
   @belongsTo('werkingsgebied', {

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -114,7 +114,8 @@ export default class CurrentSessionService extends Service {
       this.features.isEnabled('show-iv-module') &&
       !this.isDistrict &&
       !this.isProvincie &&
-      !this.isPolitiezone
+      !this.isPolitiezone &&
+      !this.group.hideLegislatuur
     );
   }
 


### PR DESCRIPTION
## Description

In the domain a new property is been added to the bestuurseenheid "hide-legislatuur" this needs to be added in the frontend as well + we want to hide the legislatuur when it has this triple set to true.

## How to test

1. run togheter with the app
2. there should be 551 closed IV's (e.g. Aalst)
3. there should be 53 "open" IV's (e.g. Melle)

All open IV's, query to use when you want to test out more gemeente that have an open IV
```sparql
  PREFIX org: <http://www.w3.org/ns/org#>
  PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
  PREFIX lmb: <http://lblod.data.gift/vocabularies/lmb/>
  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
  PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
  
  SELECT DISTINCT ?bestuurseenheid ?name
  WHERE {
        GRAPH ?g {
          VALUES ?status {
                  <http://data.lblod.info/id/concept/InstallatievergaderingStatus/a40b8f8a-8de2-4710-8d9b-3fc43a4b740e>  # Klaar voor vergadering
                  <http://data.lblod.info/id/concept/InstallatievergaderingStatus/b54dbe98-d618-4af7-9f01-791aa90774e4>  # Te behandelen
          }
          ?iv lmb:hasStatus ?status .
        }
        ?g ext:ownedBy ?bestuurseenheid .
        ?bestuurseenheid skos:prefLabel ?name .
      }

```

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/376
