### PR TITLE
Lmb 1313 | allow removal of draft mandataris

### DIFF
--- a/app/components/mandatarissen/delete-modal.hbs
+++ b/app/components/mandatarissen/delete-modal.hbs
@@ -8,17 +8,36 @@
   <:body>
     <p>Deze mandataris zal definitief verwijderd worden en is dus niet
       recupereerbaar.</p>
+    {{#if @linkedMandatarisCanBeDeleted}}
+      <p>Deze mandataris is ook gelinkt aan een andere mandataris in het OCMW.
+        Je kan kiezen om de gelinkte mandataris ook te verwijderen.</p>
+    {{else if @linkedMandatarisExists}}
+      <p>Deze mandataris is gelinkt aan een andere mandataris in de gemeente.
+        Enkel deze mandataris zal verwijderd worden.</p>
+    {{/if}}
   </:body>
   <:footer>
     <AuToolbar as |Group|>
       <Group>
         <AuButtonGroup>
+          {{#if @linkedMandatarisCanBeDeleted}}
+            <AuButton
+              @alert={{true}}
+              @loading={{this.isDeleting}}
+              @loadingMessage="Mandataris wordt verwijderd"
+              {{on "click" this.deleteWithLinked}}
+            >Verwijder beide</AuButton>
+          {{/if}}
           <AuButton
             @alert={{true}}
             @loading={{this.isDeleting}}
             @loadingMessage="Mandataris wordt verwijderd"
+            @skin={{if @linkedMandatarisCanBeDeleted "secondary" "primary"}}
             {{on "click" this.delete}}
-          >Verwijder</AuButton>
+          >Verwijder
+            {{if @linkedMandatarisCanBeDeleted "enkel deze"}}
+          </AuButton>
+
           <AuButton
             @skin="secondary"
             {{on "click" @onClose}}

--- a/app/components/mandatarissen/delete-modal.hbs
+++ b/app/components/mandatarissen/delete-modal.hbs
@@ -12,15 +12,18 @@
   <:footer>
     <AuToolbar as |Group|>
       <Group>
-        <AuButton
-          @alert={{true}}
-          @loading={{this.isDeleting}}
-          @loadingMessage="Mandataris wordt verwijderd"
-          {{on "click" this.delete}}
-        >Verwijder</AuButton>
-      </Group>
-      <Group>
-        <AuButton @skin="secondary" {{on "click" @onClose}}>Annuleer</AuButton>
+        <AuButtonGroup>
+          <AuButton
+            @alert={{true}}
+            @loading={{this.isDeleting}}
+            @loadingMessage="Mandataris wordt verwijderd"
+            {{on "click" this.delete}}
+          >Verwijder</AuButton>
+          <AuButton
+            @skin="secondary"
+            {{on "click" @onClose}}
+          >Annuleer</AuButton>
+        </AuButtonGroup>
       </Group>
     </AuToolbar>
   </:footer>

--- a/app/components/mandatarissen/delete-modal.hbs
+++ b/app/components/mandatarissen/delete-modal.hbs
@@ -6,10 +6,11 @@
 >
   <:title>Verwijder mandataris</:title>
   <:body>
-    <p>Modal content</p>
+    <p>Deze mandataris zal definitief verwijderd worden en is dus niet
+      recupereerbaar.</p>
   </:body>
   <:footer>
-    <AuToolbar @size="medium" as |Group|>
+    <AuToolbar as |Group|>
       <Group>
         <AuButton
           @alert={{true}}

--- a/app/components/mandatarissen/delete-modal.hbs
+++ b/app/components/mandatarissen/delete-modal.hbs
@@ -9,11 +9,15 @@
     <p>Deze mandataris zal definitief verwijderd worden en is dus niet
       recupereerbaar.</p>
     {{#if @linkedMandatarisCanBeDeleted}}
-      <p>Deze mandataris is ook gelinkt aan een andere mandataris in het OCMW.
-        Je kan kiezen om de gelinkte mandataris ook te verwijderen.</p>
-    {{else if @linkedMandatarisExists}}
-      <p>Deze mandataris is gelinkt aan een andere mandataris in de gemeente.
-        Enkel deze mandataris zal verwijderd worden.</p>
+      <br />
+      <p>We hebben een gekoppelde mandataris
+        {{this.specificsLinkedMandataris}}
+        binnen het OCMW gevonden. Je kan kiezen om deze ook te verwijderen.</p>
+    {{else if @linkedMandataris.hasDouble}}
+      <br />
+      <p>We hebben een gekoppelde mandataris
+        {{this.specificsLinkedMandataris}}
+        binnen de gemeente gevonden. Let op, deze zal niet verwijderd worden.</p>
     {{/if}}
   </:body>
   <:footer>

--- a/app/components/mandatarissen/delete-modal.hbs
+++ b/app/components/mandatarissen/delete-modal.hbs
@@ -1,7 +1,7 @@
 <AuModal
   ...attributes
   @modalOpen={{@isOpen}}
-  @closable={{@onClose}}
+  @closable={{this.isClosable}}
   @closeModal={{@onClose}}
 >
   <:title>Verwijder mandataris</:title>

--- a/app/components/mandatarissen/delete-modal.hbs
+++ b/app/components/mandatarissen/delete-modal.hbs
@@ -1,0 +1,26 @@
+<AuModal
+  ...attributes
+  @modalOpen={{@isOpen}}
+  @closable={{@onClose}}
+  @closeModal={{@onClose}}
+>
+  <:title>Verwijder mandataris</:title>
+  <:body>
+    <p>Modal content</p>
+  </:body>
+  <:footer>
+    <AuToolbar @size="medium" as |Group|>
+      <Group>
+        <AuButton
+          @alert={{true}}
+          @loading={{this.isDeleting}}
+          @loadingMessage="Mandataris wordt verwijderd"
+          {{on "click" this.delete}}
+        >Verwijder</AuButton>
+      </Group>
+      <Group>
+        <AuButton @skin="secondary" {{on "click" @onClose}}>Annuleer</AuButton>
+      </Group>
+    </AuToolbar>
+  </:footer>
+</AuModal>

--- a/app/components/mandatarissen/delete-modal.js
+++ b/app/components/mandatarissen/delete-modal.js
@@ -4,10 +4,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-import { timeout } from 'ember-concurrency';
-
 import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
-import { RESOURCE_CACHE_TIMEOUT } from 'frontend-lmb/utils/constants';
 
 export default class MandatarissenDeleteModal extends Component {
   @service router;
@@ -21,7 +18,6 @@ export default class MandatarissenDeleteModal extends Component {
     try {
       this.args.mandataris.deleteRecord();
       await this.args.mandataris.save();
-      await timeout(RESOURCE_CACHE_TIMEOUT);
       showSuccessToast(
         this.toaster,
         'Mandataris succesvol verwijderd',

--- a/app/components/mandatarissen/delete-modal.js
+++ b/app/components/mandatarissen/delete-modal.js
@@ -4,7 +4,10 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
+import { timeout } from 'ember-concurrency';
+
 import { showSuccessToast } from 'frontend-lmb/utils/toasts';
+import { RESOURCE_CACHE_TIMEOUT } from 'frontend-lmb/utils/constants';
 
 export default class MandatarissenDeleteModal extends Component {
   @service router;
@@ -15,16 +18,16 @@ export default class MandatarissenDeleteModal extends Component {
   @action
   async delete() {
     this.isDeleting = true;
-    await this.args.mandataris.deleteRecord();
+    this.args.mandataris.deleteRecord();
+    await this.args.mandataris.save();
+    await timeout(RESOURCE_CACHE_TIMEOUT);
     this.isDeleting = false;
+    this.args.onClose();
     showSuccessToast(
       this.toaster,
       'Mandataris succesvol verwijderd',
       'Mandataris'
     );
-    if (this.args.afterDeleteRoute) {
-      await this.args.mandataris.save();
-      this.router.transitionTo(this.args.afterDeleteRoute);
-    }
+    this.router.transitionTo(this.args.afterDeleteRoute);
   }
 }

--- a/app/components/mandatarissen/delete-modal.js
+++ b/app/components/mandatarissen/delete-modal.js
@@ -1,0 +1,30 @@
+import Component from '@glimmer/component';
+
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+import { showSuccessToast } from 'frontend-lmb/utils/toasts';
+
+export default class MandatarissenDeleteModal extends Component {
+  @service router;
+  @service toaster;
+
+  @tracked isDeleting;
+
+  @action
+  async delete() {
+    this.isDeleting = true;
+    await this.args.mandataris.deleteRecord();
+    this.isDeleting = false;
+    showSuccessToast(
+      this.toaster,
+      'Mandataris succesvol verwijderd',
+      'Mandataris'
+    );
+    if (this.args.afterDeleteRoute) {
+      await this.args.mandataris.save();
+      this.router.transitionTo(this.args.afterDeleteRoute);
+    }
+  }
+}

--- a/app/components/mandatarissen/delete-modal.js
+++ b/app/components/mandatarissen/delete-modal.js
@@ -6,7 +6,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { timeout } from 'ember-concurrency';
 
-import { showSuccessToast } from 'frontend-lmb/utils/toasts';
+import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
 import { RESOURCE_CACHE_TIMEOUT } from 'frontend-lmb/utils/constants';
 
 export default class MandatarissenDeleteModal extends Component {
@@ -18,16 +18,24 @@ export default class MandatarissenDeleteModal extends Component {
   @action
   async delete() {
     this.isDeleting = true;
-    this.args.mandataris.deleteRecord();
-    await this.args.mandataris.save();
-    await timeout(RESOURCE_CACHE_TIMEOUT);
+    try {
+      this.args.mandataris.deleteRecord();
+      await this.args.mandataris.save();
+      await timeout(RESOURCE_CACHE_TIMEOUT);
+      showSuccessToast(
+        this.toaster,
+        'Mandataris succesvol verwijderd',
+        'Mandataris'
+      );
+      this.router.transitionTo(this.args.afterDeleteRoute);
+    } catch (error) {
+      showErrorToast(
+        this.toaster,
+        'Oeps er liep iets mis, kon mandataris niet verwijderen',
+        'Mandataris'
+      );
+    }
     this.isDeleting = false;
     this.args.onClose();
-    showSuccessToast(
-      this.toaster,
-      'Mandataris succesvol verwijderd',
-      'Mandataris'
-    );
-    this.router.transitionTo(this.args.afterDeleteRoute);
   }
 }

--- a/app/components/mandatarissen/delete-modal.js
+++ b/app/components/mandatarissen/delete-modal.js
@@ -12,27 +12,37 @@ export default class MandatarissenDeleteModal extends Component {
 
   @tracked isDeleting;
 
-  @action
-  async delete() {
+  async realDelete(withLinked) {
     this.isDeleting = true;
     try {
-      this.args.mandataris.deleteRecord();
-      await this.args.mandataris.save();
+      const mandaat = await this.args.mandataris.bekleedt;
+      const orgT = await mandaat.bevatIn;
+      const org = await orgT[0].isTijdsspecialisatieVan;
+      await this.args.mandataris.deleteMandataris(withLinked);
       showSuccessToast(
         this.toaster,
         'Mandataris succesvol verwijderd',
         'Mandataris'
       );
-      this.router.transitionTo(this.args.afterDeleteRoute);
+      this.router.transitionTo('organen.orgaan.mandatarissen', org.id);
     } catch (error) {
       showErrorToast(
         this.toaster,
         'De mandataris kon niet verwijderd worden, probeer later opnieuw.',
         'Mandataris'
       );
+      console.log(error);
     }
     this.isDeleting = false;
     this.args.onClose();
+  }
+  @action
+  delete() {
+    this.realDelete(false);
+  }
+  @action
+  deleteWithLinked() {
+    this.realDelete(true);
   }
 
   get isClosable() {

--- a/app/components/mandatarissen/delete-modal.js
+++ b/app/components/mandatarissen/delete-modal.js
@@ -31,7 +31,7 @@ export default class MandatarissenDeleteModal extends Component {
     } catch (error) {
       showErrorToast(
         this.toaster,
-        'Oeps er liep iets mis, kon mandataris niet verwijderen',
+        'De mandataris kon niet verwijderd worden, probeer later opnieuw.',
         'Mandataris'
       );
     }

--- a/app/components/mandatarissen/delete-modal.js
+++ b/app/components/mandatarissen/delete-modal.js
@@ -38,4 +38,8 @@ export default class MandatarissenDeleteModal extends Component {
     this.isDeleting = false;
     this.args.onClose();
   }
+
+  get isClosable() {
+    return !!this.args.onClose;
+  }
 }

--- a/app/components/mandatarissen/delete-modal.js
+++ b/app/components/mandatarissen/delete-modal.js
@@ -48,4 +48,12 @@ export default class MandatarissenDeleteModal extends Component {
   get isClosable() {
     return !!this.args.onClose;
   }
+
+  get specificsLinkedMandataris() {
+    const linked = this.args.linkedMandataris;
+    if (!linked) {
+      return '';
+    }
+    return `(${linked.duplicateMandate})`;
+  }
 }

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -4,7 +4,6 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import {
-  MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE,
   MANDATARIS_DRAFT_PUBLICATION_STATE,
   MANDATARIS_EFFECTIEF_PUBLICATION_STATE,
 } from 'frontend-lmb/utils/well-known-uris';
@@ -48,11 +47,7 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
     await this.checkPublicationStatus();
 
     const optionIds = [PUBLICATION_STATUS_EFFECTIEF_ID];
-    if (
-      !this.nonReturnDraftStatusUri.includes(
-        this.mandataris.publicationStatus?.get('uri')
-      )
-    ) {
+    if (this.canReturnToDraftStatus) {
       optionIds.push(PUBLICATION_STATUS_DRAFT_ID);
     }
 
@@ -139,10 +134,10 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
     return 'Voeg een geldige link toe om deze form te kunnen opslaan.';
   }
 
-  get nonReturnDraftStatusUri() {
-    return [
-      MANDATARIS_EFFECTIEF_PUBLICATION_STATE,
-      MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE,
-    ];
+  get canReturnToDraftStatus() {
+    return (
+      this.mandataris.publicationStatus?.get('uri') ===
+      MANDATARIS_DRAFT_PUBLICATION_STATE
+    );
   }
 }

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import {
+  MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE,
   MANDATARIS_DRAFT_PUBLICATION_STATE,
   MANDATARIS_EFFECTIEF_PUBLICATION_STATE,
 } from 'frontend-lmb/utils/well-known-uris';
@@ -46,10 +47,14 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
   async loadOptions() {
     await this.checkPublicationStatus();
 
-    const optionIds = [
-      PUBLICATION_STATUS_EFFECTIEF_ID,
-      PUBLICATION_STATUS_DRAFT_ID,
-    ];
+    const optionIds = [PUBLICATION_STATUS_EFFECTIEF_ID];
+    if (
+      !this.nonReturnDraftStatusUri.includes(
+        this.mandataris.publicationStatus?.get('uri')
+      )
+    ) {
+      optionIds.push(PUBLICATION_STATUS_DRAFT_ID);
+    }
 
     if (!(await this.effectiefIsLastStatus)) {
       optionIds.push(PUBLICATION_STATUS_BEKRACHTIGD_ID);
@@ -132,5 +137,12 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
 
   get toolTipText() {
     return 'Voeg een geldige link toe om deze form te kunnen opslaan.';
+  }
+
+  get nonReturnDraftStatusUri() {
+    return [
+      MANDATARIS_EFFECTIEF_PUBLICATION_STATE,
+      MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE,
+    ];
   }
 }

--- a/app/components/verkiezingen/draft-mandataris-list.js
+++ b/app/components/verkiezingen/draft-mandataris-list.js
@@ -43,7 +43,7 @@ export default class DraftMandatarisListComponent extends Component {
   async removeMandataris(mandataris) {
     this.args.updateMandatarissen({ removed: [mandataris] });
     mandataris
-      .destroyRecord()
+      .deleteMandataris(false)
       .then(() => {
         const succesMessage = 'Mandataris succesvol verwijderd.';
         this.toaster.success(succesMessage, 'Succes', { timeOut: 5000 });

--- a/app/controllers/mandatarissen/persoon/mandataris.js
+++ b/app/controllers/mandatarissen/persoon/mandataris.js
@@ -31,7 +31,6 @@ export default class MandatarissenPersoonMandatarisController extends Controller
 
   @tracked formInitialized;
 
-  @tracked isCorrigeerDropdownOpen;
   @tracked isDeleteModalOpen;
 
   get bestuursorganenTitle() {
@@ -153,11 +152,6 @@ export default class MandatarissenPersoonMandatarisController extends Controller
       Het doorstromen van gegevens van de gemeente naar OCMW zal
       hierdoor ook niet meer gebeuren. Om een wijziging aan beide mandaten te
       maken, gelieve dit te doen in de gemeente.`;
-  }
-
-  @action
-  toggleCorrigeerDropdown() {
-    this.isCorrigeerDropdownOpen = !this.isCorrigeerDropdownOpen;
   }
 
   get isDraftStatus() {

--- a/app/controllers/mandatarissen/persoon/mandataris.js
+++ b/app/controllers/mandatarissen/persoon/mandataris.js
@@ -8,8 +8,10 @@ import { ForkingStore } from '@lblod/ember-submission-form-fields';
 import { SOURCE_GRAPH } from 'frontend-lmb/utils/constants';
 import { getApplicationContextMetaTtl } from 'frontend-lmb/utils/form-context/application-context-meta-ttl';
 import { task } from 'ember-concurrency';
-import { INSTALLATIEVERGADERING_BEHANDELD_STATUS } from 'frontend-lmb/utils/well-known-uris';
-import { showSuccessToast } from 'frontend-lmb/utils/toasts';
+import {
+  INSTALLATIEVERGADERING_BEHANDELD_STATUS,
+  MANDATARIS_DRAFT_PUBLICATION_STATE,
+} from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarissenPersoonMandatarisController extends Controller {
   @service router;
@@ -156,5 +158,11 @@ export default class MandatarissenPersoonMandatarisController extends Controller
   @action
   toggleCorrigeerDropdown() {
     this.isCorrigeerDropdownOpen = !this.isCorrigeerDropdownOpen;
+  }
+
+  get isDraftStatus() {
+    return (
+      this.model.publicationStatus?.uri === MANDATARIS_DRAFT_PUBLICATION_STATE
+    );
   }
 }

--- a/app/controllers/mandatarissen/persoon/mandataris.js
+++ b/app/controllers/mandatarissen/persoon/mandataris.js
@@ -9,10 +9,12 @@ import { SOURCE_GRAPH } from 'frontend-lmb/utils/constants';
 import { getApplicationContextMetaTtl } from 'frontend-lmb/utils/form-context/application-context-meta-ttl';
 import { task } from 'ember-concurrency';
 import { INSTALLATIEVERGADERING_BEHANDELD_STATUS } from 'frontend-lmb/utils/well-known-uris';
+import { showSuccessToast } from 'frontend-lmb/utils/toasts';
 
 export default class MandatarissenPersoonMandatarisController extends Controller {
   @service router;
   @service store;
+  @service toaster;
   @service fractieApi;
   @service('mandataris') mandatarisService;
 
@@ -26,6 +28,8 @@ export default class MandatarissenPersoonMandatarisController extends Controller
   @tracked newMandataris;
 
   @tracked formInitialized;
+
+  @tracked isCorrigeerDropdownOpen;
 
   get bestuursorganenTitle() {
     const bestuursfunctie = this.model.mandataris.bekleedt
@@ -146,5 +150,22 @@ export default class MandatarissenPersoonMandatarisController extends Controller
       Het doorstromen van gegevens van de gemeente naar OCMW zal
       hierdoor ook niet meer gebeuren. Om een wijziging aan beide mandaten te
       maken, gelieve dit te doen in de gemeente.`;
+  }
+
+  @action
+  toggleCorrigeerDropdown() {
+    this.isCorrigeerDropdownOpen = !this.isCorrigeerDropdownOpen;
+  }
+
+  @action
+  async deleteMandataris() {
+    // TODO : do you have a confirmation modal?
+    // await this.model.mandataris.destroyRecord();
+    showSuccessToast(
+      this.toaster,
+      'Mandataris successvol verwijderd',
+      'Mandataris'
+    );
+    this.router.transitionTo('mandatarissen.persoon.mandaten');
   }
 }

--- a/app/controllers/mandatarissen/persoon/mandataris.js
+++ b/app/controllers/mandatarissen/persoon/mandataris.js
@@ -30,6 +30,7 @@ export default class MandatarissenPersoonMandatarisController extends Controller
   @tracked formInitialized;
 
   @tracked isCorrigeerDropdownOpen;
+  @tracked isDeleteModalOpen;
 
   get bestuursorganenTitle() {
     const bestuursfunctie = this.model.mandataris.bekleedt
@@ -155,17 +156,5 @@ export default class MandatarissenPersoonMandatarisController extends Controller
   @action
   toggleCorrigeerDropdown() {
     this.isCorrigeerDropdownOpen = !this.isCorrigeerDropdownOpen;
-  }
-
-  @action
-  async deleteMandataris() {
-    // TODO : do you have a confirmation modal?
-    // await this.model.mandataris.destroyRecord();
-    showSuccessToast(
-      this.toaster,
-      'Mandataris successvol verwijderd',
-      'Mandataris'
-    );
-    this.router.transitionTo('mandatarissen.persoon.mandaten');
   }
 }

--- a/app/controllers/mandatarissen/persoon/mandataris.js
+++ b/app/controllers/mandatarissen/persoon/mandataris.js
@@ -8,10 +8,7 @@ import { ForkingStore } from '@lblod/ember-submission-form-fields';
 import { SOURCE_GRAPH } from 'frontend-lmb/utils/constants';
 import { getApplicationContextMetaTtl } from 'frontend-lmb/utils/form-context/application-context-meta-ttl';
 import { task } from 'ember-concurrency';
-import {
-  INSTALLATIEVERGADERING_BEHANDELD_STATUS,
-  MANDATARIS_DRAFT_PUBLICATION_STATE,
-} from 'frontend-lmb/utils/well-known-uris';
+import { INSTALLATIEVERGADERING_BEHANDELD_STATUS } from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarissenPersoonMandatarisController extends Controller {
   @service router;
@@ -152,11 +149,5 @@ export default class MandatarissenPersoonMandatarisController extends Controller
       Het doorstromen van gegevens van de gemeente naar OCMW zal
       hierdoor ook niet meer gebeuren. Om een wijziging aan beide mandaten te
       maken, gelieve dit te doen in de gemeente.`;
-  }
-
-  get isDraftStatus() {
-    return (
-      this.model.publicationStatus?.uri === MANDATARIS_DRAFT_PUBLICATION_STATE
-    );
   }
 }

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -4,7 +4,10 @@ import moment from 'moment';
 import { MANDATARIS_EDIT_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import { JSON_API_TYPE } from 'frontend-lmb/utils/constants';
 import { displayEndOfDay } from 'frontend-lmb/utils/date-manipulation';
-import { MANDAAT_BURGEMEESTER_CODE } from 'frontend-lmb/utils/well-known-uris';
+import {
+  MANDAAT_BURGEMEESTER_CODE,
+  MANDATARIS_DRAFT_PUBLICATION_STATE,
+} from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarisModel extends Model {
   @attr rangorde;
@@ -92,6 +95,18 @@ export default class MandatarisModel extends Model {
       (uri) =>
         uri == 'http://mu.semte.ch/vocabularies/ext/mandatenExtractorService'
     );
+  }
+
+  get isInDraftStatus() {
+    // eslint-disable-next-line no-async-promise-executor
+    return new Promise(async (resolve) => {
+      const status = await this.publicationStatus;
+
+      if (status && status.uri === MANDATARIS_DRAFT_PUBLICATION_STATE) {
+        resolve(true);
+      }
+      resolve(false);
+    });
   }
 
   get displayEinde() {

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -218,4 +218,19 @@ export default class MandatarisModel extends Model {
     const bestuursfunctie = this.get('bekleedt.bestuursfunctie.label');
     return `${naam} [${bestuursfunctie}]`;
   }
+
+  // custom delete function so we can tell the mandataris service to also delete the
+  // linked mandataris if any and to remove extra links toward the mandataris that may
+  // otherwise disrupt operations
+  async deleteMandataris(withLinked) {
+    await fetch(`/mandatarissen/${this.id}?withLinked=${withLinked}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': JSON_API_TYPE,
+      },
+    });
+    this.deleteRecord();
+    // give resources cache some time
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
 }

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -98,15 +98,9 @@ export default class MandatarisModel extends Model {
   }
 
   get isInDraftStatus() {
-    // eslint-disable-next-line no-async-promise-executor
-    return new Promise(async (resolve) => {
-      const status = await this.publicationStatus;
-
-      if (status && status.uri === MANDATARIS_DRAFT_PUBLICATION_STATE) {
-        resolve(true);
-      }
-      resolve(false);
-    });
+    return (
+      this.publicationStatus?.get('uri') === MANDATARIS_DRAFT_PUBLICATION_STATE
+    );
   }
 
   get displayEinde() {

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -119,9 +119,4 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
     }
     return false;
   }
-
-  setupController(controller) {
-    super.setupController(...arguments);
-    controller.isCorrigeerDropdownOpen = false;
-  }
 }

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -119,4 +119,9 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
     }
     return false;
   }
+
+  setupController(controller) {
+    super.setupController(...arguments);
+    controller.isCorrigeerDropdownOpen = false;
+  }
 }

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -37,7 +37,6 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
       .heeftBestuursperiode;
     const isDistrict = this.currentSession.isDistrict;
     const linkedMandataris = await this.linkedMandataris(params.mandataris_id);
-    console.log(linkedMandataris);
     const showOCMWLinkedMandatarisWarning =
       this.showOCMWLinkedMandatarisWarning(
         bestuurseenheid,
@@ -110,10 +109,8 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
       throw jsonResponse.message;
     }
     const hasDouble = !!jsonResponse.hasDouble;
-    delete jsonResponse.hasDouble;
 
     return {
-      currentMandate: jsonResponse.currentMandate ?? null,
       duplicateMandate: jsonResponse.duplicateMandate ?? null,
       hasDouble,
     };

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -43,6 +43,7 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
       );
 
     return RSVP.hash({
+      publicationStatus: await mandataris.publicationStatus,
       bestuurseenheid,
       mandataris,
       mandatarissen,

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -43,7 +43,6 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
       );
 
     return RSVP.hash({
-      publicationStatus: await mandataris.publicationStatus,
       bestuurseenheid,
       mandataris,
       mandatarissen,

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -421,18 +421,18 @@ main .au-c-main-container__content .au-u-wide-on-print {
   overflow: hidden;
 }
 
-.split-button-main-btn {
+.split-button--main-btn {
   border-top-right-radius: 0px !important;
   border-bottom-right-radius: 0px !important;
   border-right: 0px !important;
 }
-.split-button-dropdown-btn {
+.split-button--dropdown-btn {
   border-top-left-radius: 0px !important;
   border-bottom-left-radius: 0px !important;
   border-left: 0px !important;
 }
-.split-button-dropdown-option--container {
+.split-button--option-btn {
   position: absolute;
-  transform: translateY(3.5rem);
-  width: 100%;
+  justify-content: right;
+  background-color: rgba(170, 39, 41, 0.18) !important;
 }

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -420,19 +420,3 @@ $au-region-breakpoint: medium !default;
 main .au-c-main-container__content .au-u-wide-on-print {
   overflow: hidden;
 }
-
-.split-button--main-btn {
-  border-top-right-radius: 0px !important;
-  border-bottom-right-radius: 0px !important;
-  border-right: 0px !important;
-}
-.split-button--dropdown-btn {
-  border-top-left-radius: 0px !important;
-  border-bottom-left-radius: 0px !important;
-  border-left: 0px !important;
-}
-.split-button--option-btn {
-  position: absolute;
-  justify-content: right;
-  background-color: rgba(170, 39, 41, 0.18) !important;
-}

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -420,3 +420,19 @@ $au-region-breakpoint: medium !default;
 main .au-c-main-container__content .au-u-wide-on-print {
   overflow: hidden;
 }
+
+.split-button-main-btn {
+  border-top-right-radius: 0px !important;
+  border-bottom-right-radius: 0px !important;
+  border-right: 0px !important;
+}
+.split-button-dropdown-btn {
+  border-top-left-radius: 0px !important;
+  border-bottom-left-radius: 0px !important;
+  border-left: 0px !important;
+}
+.split-button-dropdown-option--container {
+  position: absolute;
+  transform: translateY(3.5rem);
+  width: 100%;
+}

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -420,3 +420,7 @@ $au-region-breakpoint: medium !default;
 main .au-c-main-container__content .au-u-wide-on-print {
   overflow: hidden;
 }
+
+.dropdown-btn--primary {
+  color: var(--au-blue-700) !important;
+}

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -53,13 +53,13 @@
           >Corrigeer fouten</AuButton>
         </Shared::Tooltip>
         <Shared::Tooltip
-          @showTooltip={{not this.isDraftStatus}}
+          @showTooltip={{not (await this.model.mandataris.isInDraftStatus)}}
           @tooltipText="Enkel mandatarissen met publicatie status Draft kunnen verwijderd worden"
         >
           <AuButton
             @width="block"
             @skin="naked"
-            @disabled={{not this.isDraftStatus}}
+            @disabled={{not (await this.model.mandataris.isInDraftStatus)}}
             @alert={{true}}
             {{on "click" (fn (mut this.isDeleteModalOpen) true)}}
           >Verwijder</AuButton>

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -32,17 +32,40 @@
             {{on "click" (fn (mut this.isChanging) true)}}
           >Wijzig huidig mandaat</AuButton>
         </Shared::Tooltip>
-        <Shared::Tooltip
-          @showTooltip={{true}}
-          @tooltipText={{this.toolTipTextCorrecting}}
-        >
-          <AuButton
-            @alert={{true}}
-            @skin="secondary"
-            @disabled={{this.isDisabledBecauseLegislatuur}}
-            {{on "click" (fn (mut this.isCorrecting) true)}}
-          >Corrigeer fouten</AuButton>
-        </Shared::Tooltip>
+        <div class="au-u-flex au-u-flex--column">
+          <div class="au-u-flex au-u-flex--row">
+            <Shared::Tooltip
+              @showTooltip={{true}}
+              @tooltipText={{this.toolTipTextCorrecting}}
+            >
+              <AuButton
+                class="split-button-main-btn"
+                @alert={{true}}
+                @skin="secondary"
+                @disabled={{this.isDisabledBecauseLegislatuur}}
+                {{on "click" (fn (mut this.isCorrecting) true)}}
+              >Corrigeer fouten</AuButton>
+            </Shared::Tooltip>
+            <AuButton
+              class="split-button-dropdown-btn"
+              @hideText={{true}}
+              @icon="three-dots"
+              @alert={{true}}
+              @skin="secondary"
+              @disabled={{this.isDisabledBecauseLegislatuur}}
+              {{on "click" this.toggleCorrigeerDropdown}}
+            >Corrigeer fouten extra options</AuButton>
+          </div>
+          {{#if this.isCorrigeerDropdownOpen}}
+            <div class="split-button-dropdown-option--container">
+              <AuButton
+                @alert={{true}}
+                @disabled={{false}}
+                {{on "click" this.deleteMandataris}}
+              >Verwijder</AuButton>
+            </div>
+          {{/if}}
+        </div>
       </AuButtonGroup>
     </div>
   </div>

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -32,45 +32,49 @@
             {{on "click" (fn (mut this.isChanging) true)}}
           >Wijzig huidig mandaat</AuButton>
         </Shared::Tooltip>
-        <div class="au-u-flex au-u-flex--column">
-          <div class="au-u-flex au-u-flex--row">
+        <div class="au-u-flex au-u-flex--row">
+          <div class="au-u-flex au-u-flex--column">
             <Shared::Tooltip
               @showTooltip={{true}}
               @tooltipText={{this.toolTipTextCorrecting}}
             >
               <AuButton
-                class="split-button-main-btn"
+                class="split-button--main-btn"
                 @alert={{true}}
                 @skin="secondary"
                 @disabled={{this.isDisabledBecauseLegislatuur}}
                 {{on "click" (fn (mut this.isCorrecting) true)}}
+                {{on "click" (fn (mut this.isCorrigeerDropdownOpen) false)}}
               >Corrigeer fouten</AuButton>
             </Shared::Tooltip>
-            <AuButton
-              class="split-button-dropdown-btn"
-              @hideText={{true}}
-              @icon="three-dots"
-              @alert={{true}}
-              @skin="secondary"
-              @disabled={{this.isDisabledBecauseLegislatuur}}
-              {{on "click" this.toggleCorrigeerDropdown}}
-            >Corrigeer fouten extra options</AuButton>
+            {{#if this.isCorrigeerDropdownOpen}}
+              <div>
+                <Shared::Tooltip
+                  @showTooltip={{not this.isDraftStatus}}
+                  @tooltipText="Enkel mandatarissen met publicatie status Draft kunnen verwijderd worden"
+                >
+                  <AuButton
+                    @skin="naked"
+                    @width="block"
+                    class="split-button--option-btn"
+                    @disabled={{not this.isDraftStatus}}
+                    @alert={{true}}
+                    {{on "click" (fn (mut this.isDeleteModalOpen) true)}}
+                    {{on "click" (fn (mut this.isCorrigeerDropdownOpen) false)}}
+                  >Verwijder</AuButton>
+                </Shared::Tooltip>
+              </div>
+            {{/if}}
           </div>
-          {{#if this.isCorrigeerDropdownOpen}}
-            <div class="split-button-dropdown-option--container">
-              <Shared::Tooltip
-                @showTooltip={{not this.isDraftStatus}}
-                @tooltipText="Enkel mandatarissen met publicatie status Draft kunnen verwijderd worden"
-              >
-                <AuButton
-                  @disabled={{not this.isDraftStatus}}
-                  @alert={{true}}
-                  {{on "click" (fn (mut this.isDeleteModalOpen) true)}}
-                  {{on "click" (fn (mut this.isCorrigeerDropdownOpen) false)}}
-                >Verwijder</AuButton>
-              </Shared::Tooltip>
-            </div>
-          {{/if}}
+          <AuButton
+            class="split-button--dropdown-btn"
+            @hideText={{true}}
+            @icon="three-dots"
+            @alert={{true}}
+            @skin="secondary"
+            @disabled={{this.isDisabledBecauseLegislatuur}}
+            {{on "click" this.toggleCorrigeerDropdown}}
+          >Corrigeer fouten extra options</AuButton>
         </div>
       </AuButtonGroup>
     </div>

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -19,7 +19,6 @@
       class="au-u-flex au-u-flex--end au-u-margin-bottom"
       {{did-insert (perform this.checkLegislatuur)}}
     >
-      {{! template-lint-disable require-context-role }}
       <AuDropdown
         @title="Bewerk"
         @alignment="right"
@@ -65,7 +64,6 @@
           >Verwijder</AuButton>
         </Shared::Tooltip>
       </AuDropdown>
-      {{! template-lint-enable require-context-role }}
     </div>
   </div>
 </div>

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -21,11 +21,10 @@
     >
       {{! template-lint-disable require-context-role }}
       <AuDropdown
-        @title="Andere"
+        @title="Bewerk"
         @alignment="right"
         @skin="primary"
-        @hideText={{true}}
-        @icon="drag-handle"
+        @icon="chevron-down"
         @onClose={{this.onClose}}
       >
         <Shared::Tooltip
@@ -48,9 +47,7 @@
           @tooltipText={{this.toolTipTextCorrecting}}
         >
           <AuButton
-            @alert={{true}}
             @width="block"
-            @skin="naked"
             @disabled={{this.isDisabledBecauseLegislatuur}}
             {{on "click" (fn (mut this.isCorrecting) true)}}
           >Corrigeer fouten</AuButton>
@@ -61,7 +58,7 @@
         >
           <AuButton
             @width="block"
-            @skin="primary"
+            @skin="naked"
             @disabled={{not this.isDraftStatus}}
             @alert={{true}}
             {{on "click" (fn (mut this.isDeleteModalOpen) true)}}

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -19,31 +19,37 @@
       class="au-u-flex au-u-flex--end au-u-margin-bottom"
       {{did-insert (perform this.checkLegislatuur)}}
     >
-      <Shared::Tooltip @showTooltip={{true}} @tooltipText={{this.toolTipText}}>
-        <AuButton
-          class="au-u-margin-right-large"
-          @disabled={{or
-            (not this.model.mandataris.isActive)
-            this.isDisabledBecauseLegislatuur
-          }}
-          {{on "click" (fn (mut this.isChanging) true)}}
-        >Wijzig huidig mandaat</AuButton>
-      </Shared::Tooltip>
       {{! template-lint-disable require-context-role }}
       <AuDropdown
         @title="Andere"
         @alignment="right"
         @skin="primary"
         @hideText={{true}}
-        @icon="three-dots"
+        @icon="drag-handle"
         @onClose={{this.onClose}}
       >
+        <Shared::Tooltip
+          @showTooltip={{true}}
+          @tooltipText={{this.toolTipText}}
+        >
+          <AuButton
+            class="dropdown-btn--primary"
+            @skin="naked"
+            @width="block"
+            @disabled={{or
+              (not this.model.mandataris.isActive)
+              this.isDisabledBecauseLegislatuur
+            }}
+            {{on "click" (fn (mut this.isChanging) true)}}
+          >Wijzig huidig mandaat</AuButton>
+        </Shared::Tooltip>
         <Shared::Tooltip
           @showTooltip={{true}}
           @tooltipText={{this.toolTipTextCorrecting}}
         >
           <AuButton
             @alert={{true}}
+            @width="block"
             @skin="naked"
             @disabled={{this.isDisabledBecauseLegislatuur}}
             {{on "click" (fn (mut this.isCorrecting) true)}}
@@ -63,7 +69,6 @@
         </Shared::Tooltip>
       </AuDropdown>
       {{! template-lint-enable require-context-role }}
-
     </div>
   </div>
 </div>

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -197,5 +197,9 @@
   @isOpen={{this.isDeleteModalOpen}}
   @onClose={{fn (mut this.isDeleteModalOpen) false}}
   @mandataris={{this.model.mandataris}}
-  @afterDeleteRoute="mandatarissen.search"
+  @linkedMandatarisCanBeDeleted={{and
+    this.model.hasLinkedMandataris
+    this.model.bestuurseenheid.isGemeente
+  }}
+  @linkedMandatarisExists={{this.model.hasLinkedMandataris}}
 />

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -198,8 +198,8 @@
   @onClose={{fn (mut this.isDeleteModalOpen) false}}
   @mandataris={{this.model.mandataris}}
   @linkedMandatarisCanBeDeleted={{and
-    this.model.hasLinkedMandataris
+    this.model.linkedMandataris.hasDouble
     this.model.bestuurseenheid.isGemeente
   }}
-  @linkedMandatarisExists={{this.model.hasLinkedMandataris}}
+  @linkedMandataris={{this.model.linkedMandataris}}
 />

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -19,64 +19,51 @@
       class="au-u-flex au-u-flex--end au-u-margin-bottom"
       {{did-insert (perform this.checkLegislatuur)}}
     >
-      <AuButtonGroup class="au-u-flex--spaced-small">
+      <Shared::Tooltip @showTooltip={{true}} @tooltipText={{this.toolTipText}}>
+        <AuButton
+          class="au-u-margin-right-large"
+          @disabled={{or
+            (not this.model.mandataris.isActive)
+            this.isDisabledBecauseLegislatuur
+          }}
+          {{on "click" (fn (mut this.isChanging) true)}}
+        >Wijzig huidig mandaat</AuButton>
+      </Shared::Tooltip>
+      {{! template-lint-disable require-context-role }}
+      <AuDropdown
+        @title="Andere"
+        @alignment="right"
+        @skin="primary"
+        @hideText={{true}}
+        @icon="three-dots"
+        @onClose={{this.onClose}}
+      >
         <Shared::Tooltip
           @showTooltip={{true}}
-          @tooltipText={{this.toolTipText}}
+          @tooltipText={{this.toolTipTextCorrecting}}
         >
           <AuButton
-            @disabled={{or
-              (not this.model.mandataris.isActive)
-              this.isDisabledBecauseLegislatuur
-            }}
-            {{on "click" (fn (mut this.isChanging) true)}}
-          >Wijzig huidig mandaat</AuButton>
-        </Shared::Tooltip>
-        <div class="au-u-flex au-u-flex--row">
-          <div class="au-u-flex au-u-flex--column">
-            <Shared::Tooltip
-              @showTooltip={{true}}
-              @tooltipText={{this.toolTipTextCorrecting}}
-            >
-              <AuButton
-                class="split-button--main-btn"
-                @alert={{true}}
-                @skin="secondary"
-                @disabled={{this.isDisabledBecauseLegislatuur}}
-                {{on "click" (fn (mut this.isCorrecting) true)}}
-                {{on "click" (fn (mut this.isCorrigeerDropdownOpen) false)}}
-              >Corrigeer fouten</AuButton>
-            </Shared::Tooltip>
-            {{#if this.isCorrigeerDropdownOpen}}
-              <div>
-                <Shared::Tooltip
-                  @showTooltip={{not this.isDraftStatus}}
-                  @tooltipText="Enkel mandatarissen met publicatie status Draft kunnen verwijderd worden"
-                >
-                  <AuButton
-                    @skin="naked"
-                    @width="block"
-                    class="split-button--option-btn"
-                    @disabled={{not this.isDraftStatus}}
-                    @alert={{true}}
-                    {{on "click" (fn (mut this.isDeleteModalOpen) true)}}
-                    {{on "click" (fn (mut this.isCorrigeerDropdownOpen) false)}}
-                  >Verwijder</AuButton>
-                </Shared::Tooltip>
-              </div>
-            {{/if}}
-          </div>
-          <AuButton
-            class="split-button--dropdown-btn"
-            @hideText={{true}}
-            @icon="three-dots"
             @alert={{true}}
-            @skin="secondary"
+            @skin="naked"
             @disabled={{this.isDisabledBecauseLegislatuur}}
-            {{on "click" this.toggleCorrigeerDropdown}}
-          >Corrigeer fouten extra options</AuButton>
-        </div>
-      </AuButtonGroup>
+            {{on "click" (fn (mut this.isCorrecting) true)}}
+          >Corrigeer fouten</AuButton>
+        </Shared::Tooltip>
+        <Shared::Tooltip
+          @showTooltip={{not this.isDraftStatus}}
+          @tooltipText="Enkel mandatarissen met publicatie status Draft kunnen verwijderd worden"
+        >
+          <AuButton
+            @width="block"
+            @skin="primary"
+            @disabled={{not this.isDraftStatus}}
+            @alert={{true}}
+            {{on "click" (fn (mut this.isDeleteModalOpen) true)}}
+          >Verwijder</AuButton>
+        </Shared::Tooltip>
+      </AuDropdown>
+      {{! template-lint-enable require-context-role }}
+
     </div>
   </div>
 </div>

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -58,12 +58,17 @@
           </div>
           {{#if this.isCorrigeerDropdownOpen}}
             <div class="split-button-dropdown-option--container">
-              <AuButton
-                @alert={{true}}
-                @disabled={{false}}
-                {{on "click" (fn (mut this.isDeleteModalOpen) true)}}
-                {{on "click" (fn (mut this.isCorrigeerDropdownOpen) false)}}
-              >Verwijder</AuButton>
+              <Shared::Tooltip
+                @showTooltip={{not this.isDraftStatus}}
+                @tooltipText="Enkel mandatarissen met publicatie status Draft kunnen verwijderd worden"
+              >
+                <AuButton
+                  @disabled={{not this.isDraftStatus}}
+                  @alert={{true}}
+                  {{on "click" (fn (mut this.isDeleteModalOpen) true)}}
+                  {{on "click" (fn (mut this.isCorrigeerDropdownOpen) false)}}
+                >Verwijder</AuButton>
+              </Shared::Tooltip>
             </div>
           {{/if}}
         </div>

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -61,7 +61,8 @@
               <AuButton
                 @alert={{true}}
                 @disabled={{false}}
-                {{on "click" this.deleteMandataris}}
+                {{on "click" (fn (mut this.isDeleteModalOpen) true)}}
+                {{on "click" (fn (mut this.isCorrigeerDropdownOpen) false)}}
               >Verwijder</AuButton>
             </div>
           {{/if}}
@@ -194,4 +195,11 @@
   @newMandataris={{this.newMandataris.id}}
   @callback={{this.callbackAfterUpdate}}
   @updateState="true"
+/>
+
+<Mandatarissen::DeleteModal
+  @isOpen={{this.isDeleteModalOpen}}
+  @onClose={{fn (mut this.isDeleteModalOpen) false}}
+  @mandataris={{this.model.mandataris}}
+  @afterDeleteRoute="mandatarissen.search"
 />

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -52,13 +52,13 @@
           >Corrigeer fouten</AuButton>
         </Shared::Tooltip>
         <Shared::Tooltip
-          @showTooltip={{not (await this.model.mandataris.isInDraftStatus)}}
+          @showTooltip={{not this.model.mandataris.isInDraftStatus}}
           @tooltipText="Enkel mandatarissen met publicatie status Draft kunnen verwijderd worden"
         >
           <AuButton
             @width="block"
             @skin="naked"
-            @disabled={{not (await this.model.mandataris.isInDraftStatus)}}
+            @disabled={{not this.model.mandataris.isInDraftStatus}}
             @alert={{true}}
             {{on "click" (fn (mut this.isDeleteModalOpen) true)}}
           >Verwijder</AuButton>

--- a/tests/integration/components/mandatarissen/delete-modal-test.js
+++ b/tests/integration/components/mandatarissen/delete-modal-test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | mandatarissen/delete-modal',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.set('myAction', function(val) { ... });
+
+      await render(hbs`<Mandatarissen::DeleteModal />`);
+
+      assert.dom().hasText('');
+
+      // Template block usage:
+      await render(hbs`<Mandatarissen::DeleteModal>
+  template block text
+</Mandatarissen::DeleteModal>`);
+
+      assert.dom().hasText('template block text');
+    });
+  }
+);


### PR DESCRIPTION
## Description

We want to be able to remove draft mandatarissen + the statussen selector should be resttricted so a user cannot go back to draft publication status.

## How to test

1. Go to a mandataris that is bekrachtigd or effectief => button should be disabled
2. Go to a draft mandataris or create one and see that you can delete the mandataris
3. Once deleted you should land on the mandataris search page

## Links to other PR's
https://github.com/lblod/mandataris-service/pull/97
**Button**
![image](https://github.com/user-attachments/assets/a2b8b8b5-b663-4002-a447-fe94ec8d9965)


**Modal**
![image](https://github.com/user-attachments/assets/76ebd6d2-b038-47e1-95e9-b220cdeb4aee)

![image](https://github.com/user-attachments/assets/f6daf630-43e3-475e-9652-570339448cbb)
![image](https://github.com/user-attachments/assets/0a4f7b4f-b4ce-4f17-b54a-1cdda3cb07c8)
