### PR TITLE
Lmb 1396 | cannot set status further than effectief on any orgaan

### DIFF
--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -37,7 +37,7 @@
                 @showInfoText={{true}}
                 @showBekijkBewijs={{true}}
               />
-              {{#if this.showEditPublicationStatus}}
+              {{#if this.canEditPublicationStatus}}
                 <AuButton
                   {{on "click" this.editStatus}}
                   @icon="pencil"

--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -43,7 +43,7 @@
                   @icon="pencil"
                   @skin="link-secondary"
                   @size="small"
-                  class="au-u-maring-left-tiny"
+                  class="au-u-margin-left-tiny"
                   @hideText={{true}}
                   @disabled={{not this.canEditPublicationStatus}}
                 >

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -10,7 +10,6 @@ import {
 } from 'frontend-lmb/utils/well-known-uris';
 import { getDraftPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
 import { showErrorToast } from 'frontend-lmb/utils/toasts';
-import { effectiefIsLastPublicationStatus } from 'frontend-lmb/utils/effectief-is-last-publication-status';
 
 import { task } from 'ember-concurrency';
 
@@ -41,9 +40,7 @@ export default class MandatarisCardComponent extends Component {
   }
 
   get isEffectiefLastStatus() {
-    return (
-      this.isEffectief && effectiefIsLastPublicationStatus(this.args.mandataris)
-    );
+    return this.isEffectief && !!this.args.effectiefIsLastPublicationStatus;
   }
 
   get fractie() {
@@ -53,7 +50,7 @@ export default class MandatarisCardComponent extends Component {
   }
 
   get showEditPublicationStatus() {
-    return !this.isBekrachtigd;
+    return !this.isBekrachtig;
   }
 
   get canEditPublicationStatus() {

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -50,7 +50,7 @@ export default class MandatarisCardComponent extends Component {
   }
 
   get showEditPublicationStatus() {
-    return !this.isBekrachtig;
+    return !this.isBekrachtigd;
   }
 
   get canEditPublicationStatus() {

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -2,6 +2,8 @@ import Route from '@ember/routing/route';
 
 import { service } from '@ember/service';
 
+import { effectiefIsLastPublicationStatus } from 'frontend-lmb/utils/effectief-is-last-publication-status';
+
 import {
   MANDATARIS_EDIT_FORM_ID,
   MANDATARIS_EXTRA_INFO_FORM_ID,
@@ -49,6 +51,8 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
       bestuursorganen,
       selectedBestuursperiode,
       isDistrictEenheid: isDistrict,
+      effectiefIsLastPublicationStatus:
+        await effectiefIsLastPublicationStatus(mandataris),
       showOCMWLinkedMandatarisWarning,
     });
   }

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -54,6 +54,7 @@
       @mandataris={{@model.mandataris}}
       @bestuursorgaanIT={{get @model.bestuursorganen 0}}
       @legislatuurInBehandeling={{this.isDisabledBecauseLegislatuur}}
+      @effectiefIsLastPublicationStatus={{this.model.effectiefIsLastPublicationStatus}}
     />
   </div>
 


### PR DESCRIPTION
## Description

We blocked of setting the status to bekrachtigd for all organen, only Vast Bureau and RMW should have last status to be effectief

## How to test

Go to ocmw  Vast Bureau or  RMW create a mandataris and set it to end status
Go to gemeente GR  create a mandataris and set it to end status

