### PR TITLE
only don't show edit publication status if bekrachtigd

### DIFF
--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -37,7 +37,7 @@
                 @showInfoText={{true}}
                 @showBekijkBewijs={{true}}
               />
-              {{#if this.canEditPublicationStatus}}
+              {{#if this.showEditPublicationStatus}}
                 <AuButton
                   {{on "click" this.editStatus}}
                   @icon="pencil"


### PR DESCRIPTION
## Description

Revert edit icon removed for burgemeesters and if Vast Bureau or RMW. It makes more sense to still show the edit button, but disable it, because people expect it.

## How to test
Go to a mandataris of Vast Bureau, of RMW or a Burgemeester. Check if you can see the edit button for the publication status, but that it is disabled.