### PR TITLE
Reroute when trying to access disabled legislature page

### DIFF
--- a/app/routes/verkiezingen.js
+++ b/app/routes/verkiezingen.js
@@ -7,11 +7,16 @@ import { BESTUURSEENHEID_CLASSIFICATIECODE_GEMEENTE } from 'frontend-lmb/utils/w
 export default class VerkiezingenRoute extends Route {
   @service currentSession;
   @service session;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
 
     if (!this.currentSession.canAccessMandaat) {
+      this.router.transitionTo('index');
+    }
+
+    if (!this.currentSession.showLegislatuurModule) {
       this.router.transitionTo('index');
     }
   }


### PR DESCRIPTION
## Description

Also disable the route when the legislatuur is hidden.

## How to test

Manually try to go to [prepare legislature page](http://localhost:4200/verkiezingen/installatievergadering) for a bestuurseenheid where it is disabled. See if you got rerouted to the index page.