### PR TITLE
Ben/lmb 1245 locally managed

### DIFF
--- a/app/models/bestuurseenheid.js
+++ b/app/models/bestuurseenheid.js
@@ -12,6 +12,7 @@ export default class Bestuurseenheid extends Model {
   @attr wilMailOntvangen;
   @attr isTrialUser;
   @attr('boolean', { defaultValue: false }) hideLegislatuur;
+  @attr('boolean', { defaultValue: false }) lokaalBeheerd;
   @attr viewOnlyModules;
 
   @belongsTo('werkingsgebied', {

--- a/app/models/bestuurseenheid.js
+++ b/app/models/bestuurseenheid.js
@@ -12,7 +12,7 @@ export default class Bestuurseenheid extends Model {
   @attr wilMailOntvangen;
   @attr isTrialUser;
   @attr('boolean', { defaultValue: false }) hideLegislatuur;
-  @attr('boolean', { defaultValue: false }) lokaalBeheerd;
+  @attr('boolean', { defaultValue: false }) isLokaalBeheerd;
   @attr viewOnlyModules;
 
   @belongsTo('werkingsgebied', {

--- a/app/router.js
+++ b/app/router.js
@@ -66,6 +66,7 @@ Router.map(function () {
   });
 
   this.route('under-construction');
+  this.route('lokaal-beheerd');
 
   this.route('admin-panel', function () {
     this.route('global-system-message');

--- a/app/routes/forms.js
+++ b/app/routes/forms.js
@@ -13,6 +13,10 @@ export default class FormsRoute extends Route {
     if (!this.currentSession.canAccessMandaat) {
       this.router.transitionTo('index');
     }
+
+    if (this.currentSession.isLokaalBeheerd) {
+      this.router.transitionTo('lokaal-beheerd');
+    }
   }
 
   async model() {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -5,8 +5,13 @@ import { service } from '@ember/service';
 export default class IndexRoute extends Route {
   @service currentSession;
   @service session;
+  @service router;
 
   async beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+
+    if (this.currentSession.isLokaalBeheerd) {
+      this.router.transitionTo('lokaal-beheerd');
+    }
   }
 }

--- a/app/routes/mandatarissen.js
+++ b/app/routes/mandatarissen.js
@@ -13,5 +13,9 @@ export default class MandatarissenRoute extends Route {
     if (!this.currentSession.canAccessMandaat) {
       this.router.transitionTo('index');
     }
+
+    if (this.currentSession.isLokaalBeheerd) {
+      this.router.transitionTo('lokaal-beheerd');
+    }
   }
 }

--- a/app/routes/organen.js
+++ b/app/routes/organen.js
@@ -17,6 +17,10 @@ export default class OrganenRoute extends Route {
     if (!this.currentSession.canAccessMandaat) {
       this.router.transitionTo('index');
     }
+
+    if (this.currentSession.isLokaalBeheerd) {
+      this.router.transitionTo('lokaal-beheerd');
+    }
   }
 
   async model() {

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -8,9 +8,14 @@ export default class SettingsRoute extends Route {
   @service currentSession;
   @service semanticFormRepository;
   @service store;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+
+    if (this.currentSession.isLokaalBeheerd) {
+      this.router.transitionTo('lokaal-beheerd');
+    }
   }
 
   async model() {

--- a/app/routes/system-notifications.js
+++ b/app/routes/system-notifications.js
@@ -6,6 +6,7 @@ export default class SystemNotificationsRoute extends Route {
   @service currentSession;
   @service session;
   @service store;
+  @service router;
 
   queryParams = {
     sort: { refreshModel: true },
@@ -14,6 +15,10 @@ export default class SystemNotificationsRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+
+    if (this.currentSession.isLokaalBeheerd) {
+      this.router.transitionTo('lokaal-beheerd');
+    }
   }
 
   model(params) {

--- a/app/routes/verkiezingen.js
+++ b/app/routes/verkiezingen.js
@@ -7,12 +7,17 @@ import { BESTUURSEENHEID_CLASSIFICATIECODE_GEMEENTE } from 'frontend-lmb/utils/w
 export default class VerkiezingenRoute extends Route {
   @service currentSession;
   @service session;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
 
     if (!this.currentSession.canAccessMandaat) {
       this.router.transitionTo('index');
+    }
+
+    if (this.currentSession.isLokaalBeheerd) {
+      this.router.transitionTo('lokaal-beheerd');
     }
   }
 

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -124,7 +124,6 @@ export default class CurrentSessionService extends Service {
   }
 
   get isLokaalBeheerd() {
-    console.log(this.group);
     return this.group.lokaalBeheerd;
   }
 

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -123,6 +123,11 @@ export default class CurrentSessionService extends Service {
     return this.canAccess(MODULE.MANDATENBEHEER);
   }
 
+  get isLokaalBeheerd() {
+    console.log(this.group);
+    return this.group.lokaalBeheerd;
+  }
+
   get isAdmin() {
     let roles = this.roles;
     if (this.impersonation.isImpersonating) {

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -124,7 +124,7 @@ export default class CurrentSessionService extends Service {
   }
 
   get isLokaalBeheerd() {
-    return this.group.lokaalBeheerd;
+    return this.group.isLokaalBeheerd;
   }
 
   get isAdmin() {

--- a/app/templates/lokaal-beheerd.hbs
+++ b/app/templates/lokaal-beheerd.hbs
@@ -1,0 +1,20 @@
+{{page-title "Lokaal beheerd"}}
+
+<AuToolbar @border="bottom" @size="large" as |Group|>
+  <Group>
+    <AuHeading @skin="2">Deze bestuurseenheid wordt lokaal beheerd
+    </AuHeading>
+  </Group>
+</AuToolbar>
+
+<div class="au-c-body-container au-c-body-container--scroll">
+  <div class="au-o-box">
+    <AuAlert @icon="info-circle" @size="small">
+      <p>Mandaten voor deze bestuurseenheid worden lokaal beheerd, dit betekent
+        dat deze niet editeerbaar zijn op de centrale applicatie voor lokaal
+        mandatenbeheer. Gelieve deze data dan lokaal te raadplegen en nodige
+        wijzigingen ook lokaal door te voeren.</p>
+    </AuAlert>
+  </div>
+  {{yield}}
+</div>


### PR DESCRIPTION
## Description

Disable application pages when a bestuurseenheid is locally managed.

## How to test

First checkout out the backend. And restart resources. Then you need to add a predicate to a bestuurseenheid to mark it as locally managed. The following query does this for Gemeente Brugge, but you can choose your own bestuurseenheid.

```
  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
    INSERT {
      GRAPH ?h {
        ?bestuurseenheid ext:lokaalBeheerd "true"^^xsd:boolean .
      }
    }
    WHERE {
      VALUES ?bestuurseenheid { <http://data.lblod.info/id/bestuurseenheden/28346950e285b8b816133fece5ac9408097c3f190c7f32573cf0c640d6c34b1a> }
      GRAPH ?g {
        ?bestuurseenheid a besluit:Bestuurseenheid .
      }
      BIND(?g AS ?h)
    }

```
After you ran this query you can go to the specific bestuurseenheid. And from the moment you login you should be redirected to an info page about the locally managed stuff. You shouldn't be able to see any other pages that are directly available (e.g. links you can click on or the major modules).

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/383
