### PR TITLE
Lmb 1351 | Replacements rangorde

### DIFF
--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -94,13 +94,12 @@
           />
         {{/if}}
       </div>
-      {{#if @mandataris.bekleedt.isSchepen}}
+      {{#if (and @mandataris.bekleedt.isSchepen (not this.statusIsVerhinderd))}}
         <div>
           <AuLabel>
             Rangorde
           </AuLabel>
           <AuInput
-            @disabled={{this.statusIsVerhinderd}}
             value={{this.rangorde}}
             @width="block"
             id="mandataris-rangorde"

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -142,11 +142,12 @@
 >
   <:title>Rangorde vervanger</:title>
   <:body>
-    <p>Het aanpassen van de rangorde van huidige mandataris werd op vorig scherm
-      geblokkeerd.
-      <br />
-      Mocht je de rangorde willen aanpassen van de vervanger, dan kan je hier
-      verder klikken. Anders mag u het dit sluiten.
+    <p>
+      U heeft een mandataris verhinderd, die een rangorde heeft. Deze rangorde
+      kan niet automatisch overgenomen worden in de vervanger. Het toewijzen van
+      een rangorde kan namelijk gevolgen hebben op de rangorde van andere
+      mandatarissen. Wenst u dit nu aan te passen? Het is ook mogelijk dit op
+      een later tijdstip aan te passen in de wijzig rangorde pagina.
     </p>
   </:body>
   <:footer>
@@ -158,14 +159,12 @@
           @model={{this.currentBestuursorgaan?.isTijdsspecialisatieVan?.id}}
           @query={{hash bestuursperiode=this.bestuursperiode.id}}
         >
-          Pas rangorde aan
+          Ja
         </AuLink>
-      </Group>
-      <Group>
         <AuButton
           @skin="secondary"
           {{on "click" (fn (mut this.isRangordeModalOpen) false)}}
-        >Sluiten</AuButton>
+        >Nee</AuButton>
       </Group>
     </AuToolbar>
   </:footer>

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -156,7 +156,8 @@
         <AuLink
           @skin="button"
           @route="organen.orgaan.edit-rangorde"
-          @model={{@mandataris.bekleedt}}
+          @model={{this.currentBestuursorgaan?.isTijdsspecialisatieVan?.id}}
+          @query={{hash bestuursperiode=this.bestuursperiode.id}}
         >
           Pas rangorde aan
         </AuLink>

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -94,9 +94,7 @@
           />
         {{/if}}
       </div>
-      {{#if
-        (and @mandataris.bekleedt.hasRangorde (not this.statusIsVerhinderd))
-      }}
+      {{#if this.showRangordeField}}
         <div>
           <AuLabel>
             Rangorde

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -94,7 +94,9 @@
           />
         {{/if}}
       </div>
-      {{#if (and @mandataris.bekleedt.isSchepen (not this.statusIsVerhinderd))}}
+      {{#if
+        (and @mandataris.bekleedt.hasRangorde (not this.statusIsVerhinderd))
+      }}
         <div>
           <AuLabel>
             Rangorde

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -100,6 +100,7 @@
             Rangorde
           </AuLabel>
           <AuInput
+            @disabled={{this.statusIsVerhinderd}}
             value={{this.rangorde}}
             @width="block"
             id="mandataris-rangorde"
@@ -121,6 +122,7 @@
               {{on "click" (perform this.updateState)}}
               @disabled={{this.disabled}}
               @loading={{this.updateState.isRunning}}
+              @loadingMessage="Mandaat wordt gewijzigd"
             >
               {{if this.hasChanges "Pas aan" "Onveranderd"}}
             </AuButton>
@@ -132,4 +134,39 @@
       </Group>
     </AuToolbar>
   </div>
+</AuModal>
+
+<AuModal
+  @modalOpen={{this.isRangordeModalOpen}}
+  @closable={{true}}
+  @closeModal={{fn (mut this.isRangordeModalOpen) false}}
+>
+  <:title>Rangorde vervanger</:title>
+  <:body>
+    <p>Het aanpassen van de rangorde van huidige mandataris werd op vorig scherm
+      geblokkeerd.
+      <br />
+      Mocht je de rangorde willen aanpassen van de vervanger, dan kan je hier
+      verder klikken. Anders mag u het dit sluiten.
+    </p>
+  </:body>
+  <:footer>
+    <AuToolbar as |Group|>
+      <Group>
+        <AuLink
+          @skin="button"
+          @route="organen.orgaan.edit-rangorde"
+          @model={{@mandataris.bekleedt}}
+        >
+          Pas rangorde aan
+        </AuLink>
+      </Group>
+      <Group>
+        <AuButton
+          @skin="secondary"
+          {{on "click" (fn (mut this.isRangordeModalOpen) false)}}
+        >Annuleer</AuButton>
+      </Group>
+    </AuToolbar>
+  </:footer>
 </AuModal>

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -143,7 +143,7 @@
   <:title>Rangorde vervanger</:title>
   <:body>
     <p>
-      U heeft een mandataris verhinderd, die een rangorde heeft. Deze rangorde
+      U heeft een mandataris, die een rangorde heeft, verhinderd. Deze rangorde
       kan niet automatisch overgenomen worden in de vervanger. Het toewijzen van
       een rangorde kan namelijk gevolgen hebben op de rangorde van andere
       mandatarissen. Wenst u dit nu aan te passen? Het is ook mogelijk dit op

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -165,7 +165,7 @@
         <AuButton
           @skin="secondary"
           {{on "click" (fn (mut this.isRangordeModalOpen) false)}}
-        >Annuleer</AuButton>
+        >Sluiten</AuButton>
       </Group>
     </AuToolbar>
   </:footer>

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -261,6 +261,9 @@ export default class MandatarissenUpdateState extends Component {
   @action
   updateNewStatus(status) {
     this.newStatus = status;
+    if (status.get('isVerhinderd')) {
+      this.rangorde = this.args.mandataris.rangorde;
+    }
   }
 
   @action

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -52,7 +52,7 @@ export default class MandatarissenUpdateState extends Component {
   }
 
   load = task({ drop: true }, async () => {
-    this.newStatus = await this.args.mandataris.status;
+    this.newStatus = this.args.mandataris.status;
     this.date = new Date();
     this.rangorde = this.args.mandataris.rangorde;
     this.selectedFractie = await (
@@ -307,16 +307,16 @@ export default class MandatarissenUpdateState extends Component {
       return false;
     }
 
-    const hasRangorde = this.args.mandataris.bekleedt.get('hasRangorde');
     return (
-      hasRangorde && this.newStatus?.get('uri') === MANDATARIS_VERHINDERD_STATE
+      this.args.mandataris.bekleedt.get('hasRangorde') &&
+      this.newStatus?.get('uri') === MANDATARIS_VERHINDERD_STATE
     );
   }
 
   get showRangordeField() {
     return (
       this.args.mandataris.bekleedt.get('hasRangorde') &&
-      this.newStatus?.uri !== MANDATARIS_VERHINDERD_STATE
+      this.newStatus?.get('uri') !== MANDATARIS_VERHINDERD_STATE
     );
   }
 }

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -240,7 +240,7 @@ export default class MandatarissenUpdateState extends Component {
     }
 
     await promise
-      .then(async (newMandataris) => {
+      .then((newMandataris) => {
         showSuccessToast(
           this.toaster,
           'Status van mandaat werd succesvol aangepast.'

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -33,6 +33,7 @@ export default class MandatarissenUpdateState extends Component {
   @tracked replacementUpdated;
   @tracked statusOptions = [];
   @tracked isFractieSelectorRequired;
+  @tracked isRangordeModalOpen;
 
   @service mandatarisStatus;
   @service currentSession;
@@ -51,7 +52,7 @@ export default class MandatarissenUpdateState extends Component {
   }
 
   load = task({ drop: true }, async () => {
-    this.newStatus = this.args.mandataris.status;
+    this.newStatus = await this.args.mandataris.status;
     this.date = new Date();
     this.rangorde = this.args.mandataris.rangorde;
     this.selectedFractie = await (
@@ -239,12 +240,14 @@ export default class MandatarissenUpdateState extends Component {
     }
 
     await promise
-      .then((newMandataris) => {
+      .then(async (newMandataris) => {
         showSuccessToast(
           this.toaster,
           'Status van mandaat werd succesvol aangepast.'
         );
         this.onStateChanged(newMandataris);
+        console.log('should open?', await this.shouldOpenRangordeModal());
+        this.isRangordeModalOpen = await this.shouldOpenRangordeModal();
       })
       .catch((e) => {
         console.log(e);
@@ -298,5 +301,23 @@ export default class MandatarissenUpdateState extends Component {
     this.selectedReplacement = null;
     this.replacementUpdated = false;
     this.args.onCancel();
+  }
+
+  async shouldOpenRangordeModal() {
+    if (!this.selectedReplacement) {
+      return false;
+    }
+
+    return (
+      this.args.mandataris.isSchepen &&
+      this.newStatus?.uri === MANDATARIS_VERHINDERD_STATE
+    );
+  }
+
+  get statusIsVerhinderd() {
+    return (
+      this.args.mandataris.isVerhinderd &&
+      this.newStatus?.uri === MANDATARIS_VERHINDERD_STATE
+    );
   }
 }

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -170,7 +170,7 @@ export default class MandatarissenUpdateState extends Component {
     const newMandatarisProps = await this.mandatarisService.createNewProps(
       this.args.mandataris,
       {
-        rangorde: this.rangorde,
+        rangorde: '',
         start: dateOfAction,
         einde: endDate,
         status: await this.newStatus,

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -311,10 +311,10 @@ export default class MandatarissenUpdateState extends Component {
     return hasRangorde && this.newStatus?.uri === MANDATARIS_VERHINDERD_STATE;
   }
 
-  get statusIsVerhinderd() {
+  get showRangordeField() {
     return (
-      this.args.mandataris.isVerhinderd &&
-      this.newStatus?.uri === MANDATARIS_VERHINDERD_STATE
+      this.args.mandataris.bekleedt.get('hasRangorde') &&
+      this.newStatus?.uri !== MANDATARIS_VERHINDERD_STATE
     );
   }
 }

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -246,7 +246,7 @@ export default class MandatarissenUpdateState extends Component {
           'Status van mandaat werd succesvol aangepast.'
         );
         this.onStateChanged(newMandataris);
-        this.isRangordeModalOpen = await this.shouldOpenRangordeModal();
+        this.isRangordeModalOpen = this.shouldOpenRangordeModal();
       })
       .catch((e) => {
         console.log(e);
@@ -302,14 +302,13 @@ export default class MandatarissenUpdateState extends Component {
     this.args.onCancel();
   }
 
-  async shouldOpenRangordeModal() {
+  shouldOpenRangordeModal() {
     if (!this.selectedReplacement) {
       return false;
     }
 
-    const isSchepen = await (await this.args.mandataris.bekleedt)?.isSchepen;
-
-    return isSchepen && this.newStatus?.uri === MANDATARIS_VERHINDERD_STATE;
+    const hasRangorde = this.args.mandataris.bekleedt.get('hasRangorde');
+    return hasRangorde && this.newStatus?.uri === MANDATARIS_VERHINDERD_STATE;
   }
 
   get statusIsVerhinderd() {

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -308,7 +308,9 @@ export default class MandatarissenUpdateState extends Component {
     }
 
     const hasRangorde = this.args.mandataris.bekleedt.get('hasRangorde');
-    return hasRangorde && this.newStatus?.uri === MANDATARIS_VERHINDERD_STATE;
+    return (
+      hasRangorde && this.newStatus?.get('uri') === MANDATARIS_VERHINDERD_STATE
+    );
   }
 
   get showRangordeField() {

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -170,7 +170,6 @@ export default class MandatarissenUpdateState extends Component {
     const newMandatarisProps = await this.mandatarisService.createNewProps(
       this.args.mandataris,
       {
-        rangorde: '',
         start: dateOfAction,
         einde: endDate,
         status: await this.newStatus,
@@ -184,6 +183,7 @@ export default class MandatarissenUpdateState extends Component {
     );
 
     if (this.selectedReplacement) {
+      newMandatarisProps.rangorde = '';
       const replacementMandataris =
         await this.mandatarisService.getOrCreateReplacement(
           this.args.mandataris,
@@ -261,9 +261,6 @@ export default class MandatarissenUpdateState extends Component {
   @action
   updateNewStatus(status) {
     this.newStatus = status;
-    if (status.get('isVerhinderd')) {
-      this.rangorde = this.args.mandataris.rangorde;
-    }
   }
 
   @action

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -246,7 +246,6 @@ export default class MandatarissenUpdateState extends Component {
           'Status van mandaat werd succesvol aangepast.'
         );
         this.onStateChanged(newMandataris);
-        console.log('should open?', await this.shouldOpenRangordeModal());
         this.isRangordeModalOpen = await this.shouldOpenRangordeModal();
       })
       .catch((e) => {
@@ -308,10 +307,9 @@ export default class MandatarissenUpdateState extends Component {
       return false;
     }
 
-    return (
-      this.args.mandataris.isSchepen &&
-      this.newStatus?.uri === MANDATARIS_VERHINDERD_STATE
-    );
+    const isSchepen = await (await this.args.mandataris.bekleedt)?.isSchepen;
+
+    return isSchepen && this.newStatus?.uri === MANDATARIS_VERHINDERD_STATE;
   }
 
   get statusIsVerhinderd() {

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -4,10 +4,7 @@ import moment from 'moment';
 import { MANDATARIS_EDIT_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import { JSON_API_TYPE } from 'frontend-lmb/utils/constants';
 import { displayEndOfDay } from 'frontend-lmb/utils/date-manipulation';
-import {
-  MANDAAT_BURGEMEESTER_CODE,
-  MANDATARIS_VERHINDERD_STATE,
-} from 'frontend-lmb/utils/well-known-uris';
+import { MANDAAT_BURGEMEESTER_CODE } from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarisModel extends Model {
   @attr rangorde;
@@ -142,13 +139,6 @@ export default class MandatarisModel extends Model {
     return (
       this.bekleedt.get('bestuursfunctie').get('uri') ===
       MANDAAT_BURGEMEESTER_CODE
-    );
-  }
-
-  get isVerhinderd() {
-    // eslint-disable-next-line no-async-promise-executor
-    return new Promise(async (resolve) =>
-      resolve((await this.status)?.uri === MANDATARIS_VERHINDERD_STATE)
     );
   }
 

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -4,7 +4,10 @@ import moment from 'moment';
 import { MANDATARIS_EDIT_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 import { JSON_API_TYPE } from 'frontend-lmb/utils/constants';
 import { displayEndOfDay } from 'frontend-lmb/utils/date-manipulation';
-import { MANDAAT_BURGEMEESTER_CODE } from 'frontend-lmb/utils/well-known-uris';
+import {
+  MANDAAT_BURGEMEESTER_CODE,
+  MANDATARIS_VERHINDERD_STATE,
+} from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarisModel extends Model {
   @attr rangorde;
@@ -139,6 +142,19 @@ export default class MandatarisModel extends Model {
     return (
       this.bekleedt.get('bestuursfunctie').get('uri') ===
       MANDAAT_BURGEMEESTER_CODE
+    );
+  }
+
+  get isVerhinderd() {
+    // eslint-disable-next-line no-async-promise-executor
+    return new Promise(async (resolve) =>
+      resolve((await this.status)?.uri === MANDATARIS_VERHINDERD_STATE)
+    );
+  }
+  get isSchepen() {
+    // eslint-disable-next-line no-async-promise-executor
+    return new Promise(async (resolve) =>
+      resolve((await this.bekleedt).isSchepen)
     );
   }
 

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -151,12 +151,6 @@ export default class MandatarisModel extends Model {
       resolve((await this.status)?.uri === MANDATARIS_VERHINDERD_STATE)
     );
   }
-  get isSchepen() {
-    // eslint-disable-next-line no-async-promise-executor
-    return new Promise(async (resolve) =>
-      resolve((await this.bekleedt).isSchepen)
-    );
-  }
 
   get besluitUri() {
     // eslint-disable-next-line no-async-promise-executor


### PR DESCRIPTION
## Description

When a user wants to "wijzig mandataris" the rangorde field should be hidden when the current status is "Verhinderd" or the new selected status is "Verhinded". When a replacement person is selected  it shows a modal (after the ocmw modal) thats says that rangorde was blocked and if they want to update it that they can go top edit rangorde here

## How to test

1. Go to a schepen mandatari status effectief, update the "vanaf" date => all should work normaly
2. Edit the status of that mandataris to verhinderd and do NOT select a replacement => every should work normal
3. Edit another mandataris and set status to "verhinderd", now add a replacement person and save it => a modal should open for rangorde, you cancel or go to edit rangorde of that orgaan in the bestuursperiod

