### PR TITLE
fix: do not show automatisch or handmatig bekrachtigd when burgemeester

### DIFF
--- a/app/components/mandaat/publicatie-status-pill.hbs
+++ b/app/components/mandaat/publicatie-status-pill.hbs
@@ -33,9 +33,8 @@
       class="au-u-italic au-u-h-functional au-u-flex au-u-flex--vertical-center"
     >
       <span class="au-u-margin-top-small u-u-margin-right-tiny">
-        Deze mandataris werd
-        {{if (await @mandataris.besluitUri) "automatisch" "handmatig"}}
-        bekrachtigd. Om een bekrachtiging terug te trekken moet je de
+        {{await this.besluitIsAddedThrough}}
+        Om een bekrachtiging terug te trekken moet je de
         <AuLinkExternal
           href="mailto:lokaalmandatenbeheer@vlaanderen.be?subject=Bekrachtiging terugtrekken - Lokaal Mandatenbeheer"
         >technische dienst contacteren</AuLinkExternal>

--- a/app/components/mandaat/publicatie-status-pill.js
+++ b/app/components/mandaat/publicatie-status-pill.js
@@ -57,6 +57,15 @@ export default class MandaatPublicatieStatusPillComponent extends Component {
     );
   }
 
+  get besluitIsAddedThrough() {
+    if (this.args.mandataris?.bekleedt?.get('isStrictBurgemeester')) {
+      return '';
+    }
+
+    const how = this.args.mandataris?.besluitUri ? 'automatisch' : 'handmatig';
+    return `Deze mandataris werd ${how} bekrachtigd.`;
+  }
+
   @action
   updateLink() {
     this.args.mandataris.linkToBesluit = this.newLink;

--- a/app/components/mandaat/publicatie-status-pill.js
+++ b/app/components/mandaat/publicatie-status-pill.js
@@ -58,7 +58,7 @@ export default class MandaatPublicatieStatusPillComponent extends Component {
   }
 
   get besluitIsAddedThrough() {
-    return this.args.mandataris?.bekleedt.then(async (mandaat) => {
+    return this.args.mandataris.bekleedt.then(async (mandaat) => {
       if (mandaat.isStrictBurgemeester) {
         return '';
       }

--- a/app/components/mandaat/publicatie-status-pill.js
+++ b/app/components/mandaat/publicatie-status-pill.js
@@ -58,12 +58,16 @@ export default class MandaatPublicatieStatusPillComponent extends Component {
   }
 
   get besluitIsAddedThrough() {
-    if (this.args.mandataris?.bekleedt?.get('isStrictBurgemeester')) {
-      return '';
-    }
+    return this.args.mandataris?.bekleedt.then(async (mandaat) => {
+      if (mandaat.isStrictBurgemeester) {
+        return '';
+      }
 
-    const how = this.args.mandataris?.besluitUri ? 'automatisch' : 'handmatig';
-    return `Deze mandataris werd ${how} bekrachtigd.`;
+      const how = (await this.args.mandataris?.besluitUri)
+        ? 'automatisch'
+        : 'handmatig';
+      return `Deze mandataris werd ${how} bekrachtigd.`;
+    });
   }
 
   @action


### PR DESCRIPTION
## Description

Burgmeester mandatarissen hebben geen besluit link. Toon de text van manueel of automatisch bekrachtigd niet.

## How to test

Ga naar een berkachtigde burgemeester Of pas de mandaat uri aan in mandaat model voor strict burgemeester naar aangewezen en dan kan je dit testen in aalst

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/180
