### PR TITLE
LMB-1402 fix broken csv download

### DIFF
--- a/app/templates/mandatarissen/search.hbs
+++ b/app/templates/mandatarissen/search.hbs
@@ -89,7 +89,7 @@
         </Group>
         <Group>
           <DownloadMandatarissenFromTable
-            @bestuursperiode={{@model.selectedPeriod.period}}
+            @bestuursperiode={{@model.selectedPeriod}}
             @activeOnly={{this.activeMandatarissen}}
             @personen={{@model.personen}}
             @fracties={{this.selectedFracties}}


### PR DESCRIPTION
## Description

Incident report from OCMW Roeselare that the download button seemed to download an empty csv.
It was actually broken everywhere.
This fixes it.

## How to test

Check out a random bestuurseenheid (and also OCMW Roeselare to be sure). Check if the download button works, see if the csv is not empty and that you can change the bestuursperiod to get different results.
