### PR TITLE
Lmb 1407 | Soft removal draft publication status

### DIFF
--- a/app/components/mandaat/publicatie-status-pill.hbs
+++ b/app/components/mandaat/publicatie-status-pill.hbs
@@ -6,7 +6,7 @@
     @iconAlignment="left"
     @hideText={{false}}
   >
-    {{this.status.displayLabel}}
+    {{or this.status.label "Niet beschikbaar"}}
   </AuPill>
   {{#if @showBekijkBewijs}}
     {{#if (await @mandataris.besluitUri)}}

--- a/app/components/mandaat/publicatie-status-pill.hbs
+++ b/app/components/mandaat/publicatie-status-pill.hbs
@@ -28,7 +28,7 @@
       >Pas besluit aan</AuButton>
     {{/if}}
   {{/if}}
-  {{#if (and @showInfoText this.isMandatarisBekrachtigd)}}
+  {{#if (and @showInfoText this.status.isBekrachtigd)}}
     <p
       class="au-u-italic au-u-h-functional au-u-flex au-u-flex--vertical-center"
     >

--- a/app/components/mandaat/publicatie-status-pill.hbs
+++ b/app/components/mandaat/publicatie-status-pill.hbs
@@ -6,7 +6,7 @@
     @iconAlignment="left"
     @hideText={{false}}
   >
-    {{or this.status.label "Niet beschikbaar"}}
+    {{this.status.displayLabel}}
   </AuPill>
   {{#if @showBekijkBewijs}}
     {{#if (await @mandataris.besluitUri)}}

--- a/app/components/mandaat/publicatie-status-pill.js
+++ b/app/components/mandaat/publicatie-status-pill.js
@@ -26,7 +26,7 @@ export default class MandaatPublicatieStatusPillComponent extends Component {
     if (status.isBekrachtigd) {
       return 'success';
     }
-    if (status.isEffectief) {
+    if (status.isNietBekrachtigd) {
       if (await this.effectiefIsLastStatus) {
         return 'success';
       }

--- a/app/components/mandaat/publicatie-status-pill.js
+++ b/app/components/mandaat/publicatie-status-pill.js
@@ -13,10 +13,6 @@ export default class MandaatPublicatieStatusPillComponent extends Component {
   @tracked newLink;
   @tracked showEditLinkModal;
 
-  get isMandatarisBekrachtigd() {
-    return this.status ? this.status.get('isBekrachtigd') : true;
-  }
-
   get effectiefIsLastStatus() {
     return effectiefIsLastPublicationStatus(this.args.mandataris);
   }
@@ -27,16 +23,16 @@ export default class MandaatPublicatieStatusPillComponent extends Component {
 
   async getSkinForPill(statusPromise) {
     const status = await statusPromise;
-    if (status.label === 'Bekrachtigd') {
+    if (status.isBekrachtigd) {
       return 'success';
     }
-    if (status.label === 'Effectief') {
+    if (status.isEffectief) {
       if (await this.effectiefIsLastStatus) {
         return 'success';
       }
       return 'warning';
     }
-    if (status.label === 'Draft') {
+    if (status.isDraft) {
       return 'border';
     }
 

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -8,7 +8,7 @@ import {
   MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE,
   MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE,
 } from 'frontend-lmb/utils/well-known-uris';
-import { getDraftPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
+import { getNietBekrachtigdPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
 import { showErrorToast } from 'frontend-lmb/utils/toasts';
 
 import { task } from 'ember-concurrency';
@@ -114,7 +114,9 @@ export default class MandatarisCardComponent extends Component {
       this.args.mandataris,
       {
         start: new Date(),
-        publicationStatus: await getDraftPublicationStatus(this.store),
+        publicationStatus: await getNietBekrachtigdPublicationStatus(
+          this.store
+        ),
       }
     );
     const replacementMandataris =

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -6,7 +6,7 @@ import { service } from '@ember/service';
 
 import {
   MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE,
-  MANDATARIS_EFFECTIEF_PUBLICATION_STATE,
+  MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE,
 } from 'frontend-lmb/utils/well-known-uris';
 import { getDraftPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
 import { showErrorToast } from 'frontend-lmb/utils/toasts';
@@ -30,17 +30,19 @@ export default class MandatarisCardComponent extends Component {
     return !status || status === MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE;
   }
 
-  get isEffectief() {
+  get isNietBekrachtigd() {
     const status = this.args.mandataris.publicationStatus?.get('uri');
-    return !status || status === MANDATARIS_EFFECTIEF_PUBLICATION_STATE;
+    return !status || status === MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE;
   }
 
   get isEffectiefBurgemeester() {
-    return this.isEffectief && this.args.mandataris.isStrictBurgemeester;
+    return this.isNietBekrachtigd && this.args.mandataris.isStrictBurgemeester;
   }
 
   get isEffectiefLastStatus() {
-    return this.isEffectief && !!this.args.effectiefIsLastPublicationStatus;
+    return (
+      this.isNietBekrachtigd && !!this.args.effectiefIsLastPublicationStatus
+    );
   }
 
   get fractie() {

--- a/app/components/mandatarissen/mandataris-card.js
+++ b/app/components/mandatarissen/mandataris-card.js
@@ -4,10 +4,6 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 
-import {
-  MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE,
-  MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE,
-} from 'frontend-lmb/utils/well-known-uris';
 import { getNietBekrachtigdPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
 import { showErrorToast } from 'frontend-lmb/utils/toasts';
 
@@ -26,13 +22,13 @@ export default class MandatarisCardComponent extends Component {
   }
 
   get isBekrachtigd() {
-    const status = this.args.mandataris.publicationStatus?.get('uri');
-    return !status || status === MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE;
+    const status = this.args.mandataris.publicationStatus;
+    return !status || status.get('isBekrachtigd');
   }
 
   get isNietBekrachtigd() {
-    const status = this.args.mandataris.publicationStatus?.get('uri');
-    return !status || status === MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE;
+    const status = this.args.mandataris.publicationStatus;
+    return !status || status.get('isNietBekrachtigd');
   }
 
   get isEffectiefBurgemeester() {

--- a/app/components/mandatarissen/mandataris/publication-status-selector.hbs
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.hbs
@@ -38,8 +38,9 @@
         @size={{this.size}}
         @closable={{false}}
       >
-        <p>Na het toevoegen van een link naar een besluit kan deze niet meer
-          aangepast worden zonder de technische dienst te contacteren.
+        <p>Na het toevoegen van een link naar het besluit zal de publicatie
+          status naar bekrachtigd gaan. Hierna kan deze mandataris niet meer
+          verwijderd worden.
         </p>
       </AuAlert>
       <span class="au-u-padding">

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import {
   MANDATARIS_DRAFT_PUBLICATION_STATE,
-  MANDATARIS_EFFECTIEF_PUBLICATION_STATE,
+  MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE,
 } from 'frontend-lmb/utils/well-known-uris';
 
 import { restartableTask, task, timeout } from 'ember-concurrency';
@@ -95,7 +95,9 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
   @action
   async setStatus(publicationStatus) {
     this.mandataris.publicationStatus = publicationStatus;
-    if (publicationStatus?.uri === MANDATARIS_EFFECTIEF_PUBLICATION_STATE) {
+    if (
+      publicationStatus?.uri === MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE
+    ) {
       this.args.mandataris.effectiefAt = new Date();
     }
     if (publicationStatus?.uri === MANDATARIS_DRAFT_PUBLICATION_STATE) {

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -8,7 +8,7 @@ import { service } from '@ember/service';
 import moment from 'moment';
 
 import { showErrorToast, showSuccessToast } from 'frontend-lmb/utils/toasts';
-import { getDraftPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
+import { getNietBekrachtigdPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
 import {
   MANDATARIS_TITELVOEREND_STATE,
   MANDATARIS_VERHINDERD_STATE,
@@ -176,7 +176,9 @@ export default class MandatarissenUpdateState extends Component {
         start: dateOfAction,
         einde: endDate,
         status: await this.newStatus,
-        publicationStatus: await getDraftPublicationStatus(this.store),
+        publicationStatus: await getNietBekrachtigdPublicationStatus(
+          this.store
+        ),
       }
     );
 

--- a/app/components/verkiezingen/generate-rows.js
+++ b/app/components/verkiezingen/generate-rows.js
@@ -5,17 +5,9 @@ import { tracked } from '@glimmer/tracking';
 
 import { task } from 'ember-concurrency';
 
-import {
-  getDraftPublicationStatus,
-  getEffectiefStatus,
-} from 'frontend-lmb/utils/get-mandataris-status';
-
 export default class GenerateRowsFormComponent extends Component {
   @service store;
   @service('mandataris-api') mandatarisApi;
-
-  effectiefStatus;
-  draftPublicationStatus;
 
   @tracked startDate;
   @tracked endDate;
@@ -28,8 +20,6 @@ export default class GenerateRowsFormComponent extends Component {
   }
 
   initForm = task(async () => {
-    this.effectiefStatus = await getEffectiefStatus(this.store);
-    this.draftPublicationStatus = await getDraftPublicationStatus(this.store);
     this.startDate = new Date(this.args.bestuursorgaan.bindingStart);
     this.endDate = new Date(this.args.bestuursorgaan.bindingEinde);
     const mandaten = await this.args.bestuursorgaan.bevat;

--- a/app/components/verkiezingen/prepare-legislatuur-section.js
+++ b/app/components/verkiezingen/prepare-legislatuur-section.js
@@ -7,7 +7,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { restartableTask, task } from 'ember-concurrency';
 
-import { buildNewMandatarisSourceTtl } from 'frontend-lmb/utils/build-new-mandataris-source-ttl';
+import { buildNewIVMandatarisSourceTtl } from 'frontend-lmb/utils/build-new-mandataris-source-ttl';
 import { getApplicationContextMetaTtl } from 'frontend-lmb/utils/form-context/application-context-meta-ttl';
 import { showErrorToast, showWarningToast } from 'frontend-lmb/utils/toasts';
 import {
@@ -183,7 +183,7 @@ export default class PrepareLegislatuurSectionComponent extends Component {
 
   @action
   async buildSourceTtl(instanceUri) {
-    return await buildNewMandatarisSourceTtl(this.store, instanceUri);
+    return await buildNewIVMandatarisSourceTtl(this.store, instanceUri);
   }
 
   @action

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
 import { task } from 'ember-concurrency';
-import { getDraftPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
+import { getNietBekrachtigdPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
 import { showSuccessToast } from 'frontend-lmb/utils/toasts';
 
 import { endOfDay } from 'frontend-lmb/utils/date-manipulation';
@@ -109,7 +109,9 @@ export default class MandatarissenPersoonMandatenController extends Controller {
         mandataris,
         {
           start: dateNow,
-          publicationStatus: await getDraftPublicationStatus(this.store),
+          publicationStatus: await getNietBekrachtigdPublicationStatus(
+            this.store
+          ),
           fractie: onafhankelijkeFractie,
         }
       );

--- a/app/controllers/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/controllers/organen/orgaan/bulk-bekrachtiging.js
@@ -58,10 +58,6 @@ export default class BulkBekrachtigingController extends Controller {
     this.status = status;
   }
 
-  get showLinkField() {
-    return this.status == 'Bekrachtigd' ? true : false;
-  }
-
   @action
   updateLink(event) {
     if (event && typeof event.preventDefault === 'function') {
@@ -83,7 +79,7 @@ export default class BulkBekrachtigingController extends Controller {
       return true;
     }
     if (
-      this.status == 'Bekrachtigd' &&
+      this.status.isBekrachtigd &&
       (!this.linkToBesluit || this.invalidLink)
     ) {
       return true;
@@ -148,8 +144,12 @@ export default class BulkBekrachtigingController extends Controller {
 
   get statusOptions() {
     if (this.model.effectiefIsLastStatus || this.burgemeesterSelected) {
-      return ['Effectief'];
+      return this.model.publicationStatussen.filter(
+        (status) => status.isNietBekrachtigd
+      );
     }
-    return ['Effectief', 'Bekrachtigd'];
+    return this.model.publicationStatussen.filter(
+      (status) => status.isNietBekrachtigd || status.isBekrachtigd
+    );
   }
 }

--- a/app/models/mandataris-publication-status-code.js
+++ b/app/models/mandataris-publication-status-code.js
@@ -22,8 +22,4 @@ export default class MandatarisPublicationStatusCodeModel extends Model {
   get isDraft() {
     return this.uri === MANDATARIS_DRAFT_PUBLICATION_STATE;
   }
-
-  get displayLabel() {
-    return this.uri ? this.label : 'Niet beschikbaar';
-  }
 }

--- a/app/models/mandataris-publication-status-code.js
+++ b/app/models/mandataris-publication-status-code.js
@@ -24,12 +24,6 @@ export default class MandatarisPublicationStatusCodeModel extends Model {
   }
 
   get displayLabel() {
-    const statusMapping = {
-      [MANDATARIS_DRAFT_PUBLICATION_STATE]: 'Draft',
-      [MANDATARIS_EFFECTIEF_PUBLICATION_STATE]: 'Niet bekrachtigd',
-      [MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE]: 'Bekrachtigd',
-    };
-
-    return statusMapping[this.uri] ?? 'Niet beschikbaar';
+    return this.uri ? this.label : 'Niet beschikbaar';
   }
 }

--- a/app/models/mandataris-publication-status-code.js
+++ b/app/models/mandataris-publication-status-code.js
@@ -3,7 +3,7 @@ import Model, { attr } from '@ember-data/model';
 import {
   MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE,
   MANDATARIS_DRAFT_PUBLICATION_STATE,
-  MANDATARIS_EFFECTIEF_PUBLICATION_STATE,
+  MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE,
 } from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarisPublicationStatusCodeModel extends Model {
@@ -15,8 +15,8 @@ export default class MandatarisPublicationStatusCodeModel extends Model {
     return this.uri === MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE;
   }
 
-  get isEffectief() {
-    return this.uri === MANDATARIS_EFFECTIEF_PUBLICATION_STATE;
+  get isNietBekrachtigd() {
+    return this.uri === MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE;
   }
 
   get isDraft() {

--- a/app/models/mandataris-publication-status-code.js
+++ b/app/models/mandataris-publication-status-code.js
@@ -15,6 +15,14 @@ export default class MandatarisPublicationStatusCodeModel extends Model {
     return this.uri === MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE;
   }
 
+  get isEffectief() {
+    return this.uri === MANDATARIS_EFFECTIEF_PUBLICATION_STATE;
+  }
+
+  get isDraft() {
+    return this.uri === MANDATARIS_DRAFT_PUBLICATION_STATE;
+  }
+
   get displayLabel() {
     const statusMapping = {
       [MANDATARIS_DRAFT_PUBLICATION_STATE]: 'Draft',

--- a/app/models/mandataris-publication-status-code.js
+++ b/app/models/mandataris-publication-status-code.js
@@ -1,6 +1,10 @@
 import Model, { attr } from '@ember-data/model';
 
-import { MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE } from 'frontend-lmb/utils/well-known-uris';
+import {
+  MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE,
+  MANDATARIS_DRAFT_PUBLICATION_STATE,
+  MANDATARIS_EFFECTIEF_PUBLICATION_STATE,
+} from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarisPublicationStatusCodeModel extends Model {
   @attr uri;
@@ -9,5 +13,15 @@ export default class MandatarisPublicationStatusCodeModel extends Model {
 
   get isBekrachtigd() {
     return this.uri === MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE;
+  }
+
+  get displayLabel() {
+    const statusMapping = {
+      [MANDATARIS_DRAFT_PUBLICATION_STATE]: 'Draft',
+      [MANDATARIS_EFFECTIEF_PUBLICATION_STATE]: 'Niet bekrachtigd',
+      [MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE]: 'Bekrachtigd',
+    };
+
+    return statusMapping[this.uri] ?? 'Niet beschikbaar';
   }
 }

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -7,6 +7,7 @@ import { displayEndOfDay } from 'frontend-lmb/utils/date-manipulation';
 import {
   MANDAAT_BURGEMEESTER_CODE,
   MANDATARIS_DRAFT_PUBLICATION_STATE,
+  MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE,
 } from 'frontend-lmb/utils/well-known-uris';
 
 export default class MandatarisModel extends Model {
@@ -97,10 +98,13 @@ export default class MandatarisModel extends Model {
     );
   }
 
-  get isInDraftStatus() {
-    return (
-      this.publicationStatus?.get('uri') === MANDATARIS_DRAFT_PUBLICATION_STATE
-    );
+  get isApprovedForDeletion() {
+    const approvedStatussen = [
+      MANDATARIS_DRAFT_PUBLICATION_STATE,
+      MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE,
+    ];
+
+    return approvedStatussen.includes(this.publicationStatus?.get('uri'));
   }
 
   get displayEinde() {

--- a/app/routes/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/routes/organen/orgaan/bulk-bekrachtiging.js
@@ -4,7 +4,7 @@ import { service } from '@ember/service';
 
 import {
   MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE,
-  MANDATARIS_EFFECTIEF_PUBLICATION_STATE,
+  MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE,
 } from 'frontend-lmb/utils/well-known-uris';
 
 export default class BulkBekrachtigingRoute extends Route {
@@ -38,14 +38,14 @@ export default class BulkBekrachtigingRoute extends Route {
           let canShowCheckbox = true;
           if (
             effectiefIsLastStatus &&
-            uri === MANDATARIS_EFFECTIEF_PUBLICATION_STATE
+            uri === MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE
           ) {
             canShowCheckbox = false;
           } else if (uri === MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE) {
             canShowCheckbox = false;
           } else if (
             mandataris.isStrictBurgemeester &&
-            uri === MANDATARIS_EFFECTIEF_PUBLICATION_STATE
+            uri === MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE
           ) {
             canShowCheckbox = false;
           }

--- a/app/routes/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/routes/organen/orgaan/bulk-bekrachtiging.js
@@ -56,6 +56,10 @@ export default class BulkBekrachtigingRoute extends Route {
         })
       );
     }
+
+    const publicationStatussen = await this.store.findAll(
+      'mandataris-publication-status-code'
+    );
     return {
       mandatarissenMap,
       mandatarissen,
@@ -63,6 +67,7 @@ export default class BulkBekrachtigingRoute extends Route {
       bestuursorgaan: parentModel.bestuursorgaan,
       selectedBestuursperiode: parentModel.selectedBestuursperiode,
       currentBestuursorgaan: currentBestuursorgaan,
+      publicationStatussen,
     };
   }
 }

--- a/app/services/mandataris-api.js
+++ b/app/services/mandataris-api.js
@@ -43,7 +43,7 @@ export default class MandatarisApiService extends Service {
           'Content-Type': JSON_API_TYPE,
         },
         body: JSON.stringify({
-          status: status,
+          statusUri: status.uri,
           decision: decision,
           mandatarissen: mandatarissen,
         }),
@@ -60,7 +60,7 @@ export default class MandatarisApiService extends Service {
     }
     showSuccessToast(
       this.toaster,
-      `De publicatiestatussen werden succesvol geüpdatet naar ${status}`
+      `De publicatiestatussen werden succesvol geüpdatet naar "${status.label}"`
     );
   }
 

--- a/app/services/mandataris.js
+++ b/app/services/mandataris.js
@@ -3,7 +3,7 @@ import Service from '@ember/service';
 import { service } from '@ember/service';
 import { fold } from 'frontend-lmb/utils/fold-mandatarisses';
 
-import { getDraftPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
+import { getNietBekrachtigdPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
 import { MANDATARIS_WAARNEMEND_STATE_ID } from 'frontend-lmb/utils/well-known-ids';
 import { MANDATARIS_BEEINDIGD_STATE } from 'frontend-lmb/utils/well-known-uris';
 
@@ -71,7 +71,7 @@ export default class MandatarisService extends Service {
       isBestuurlijkeAliasVan: replacementPerson,
       beleidsdomein: await newMandatarisState.beleidsdomein,
       status: mandatarisStatus,
-      publicationStatus: await getDraftPublicationStatus(this.store),
+      publicationStatus: await getNietBekrachtigdPublicationStatus(this.store),
     });
     await newMandataris.save();
     return newMandataris;

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -66,19 +66,20 @@
             >Corrigeer fouten</AuButton>
           </Shared::Tooltip>
           <Shared::Tooltip
-            @showTooltip={{not this.model.mandataris.isInDraftStatus}}
-            @tooltipText="Enkel mandatarissen met publicatie status Draft kunnen verwijderd worden"
+            @showTooltip={{not this.model.mandataris.isApprovedForDeletion}}
+            @tooltipText="Mandatarissen die bekrachtigd zijn kunnen niet verwijderd worden."
           >
             <AuButton
               @width="block"
               @skin="naked"
-              @disabled={{not this.model.mandataris.isInDraftStatus}}
+              @disabled={{not this.model.mandataris.isApprovedForDeletion}}
               @alert={{true}}
               {{on "click" (fn (mut this.isDeleteModalOpen) true)}}
             >Verwijder</AuButton>
           </Shared::Tooltip>
         </AuDropdown>
       {{/if}}
+
     </div>
   </div>
 </div>

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -91,10 +91,10 @@
         @noMatchesMessage="Geen resultaten"
         as |status|
       >
-        {{status}}
+        {{status.label}}
       </PowerSelect>
     </div>
-    {{#if this.showLinkField}}
+    {{#if this.status.isBekrachtigd}}
       <div>
         <AuLabel @required={{true}} for="link-to-page">Link naar besluit</AuLabel>
         <AuInput

--- a/app/utils/build-new-mandataris-source-ttl.js
+++ b/app/utils/build-new-mandataris-source-ttl.js
@@ -1,6 +1,6 @@
 import {
   MANDATARIS_DRAFT_PUBLICATION_STATE,
-  MANDATARIS_EFFECTIEF_PUBLICATION_STATE,
+  MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE,
 } from './well-known-uris';
 
 export const buildNewMandatarisSourceTtl = async (
@@ -8,20 +8,20 @@ export const buildNewMandatarisSourceTtl = async (
   instanceUri,
   personId
 ) => {
-  const effectiefTriple = `
-    <${instanceUri}> <http://lblod.data.gift/vocabularies/lmb/hasPublicationStatus> <${MANDATARIS_EFFECTIEF_PUBLICATION_STATE}>.
+  const nietBekrachtigdTriple = `
+    <${instanceUri}> <http://lblod.data.gift/vocabularies/lmb/hasPublicationStatus> <${MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE}>.
     <${instanceUri}> <http://lblod.data.gift/vocabularies/lmb/effectiefAt> "${new Date().toJSON()}"^^<http://www.w3.org/2001/XMLSchema#DateTime>.
   `;
   if (!personId) {
-    return effectiefTriple;
+    return nietBekrachtigdTriple;
   }
   const person = await store.findRecord('persoon', personId);
   if (!person) {
-    return effectiefTriple;
+    return nietBekrachtigdTriple;
   }
 
   return `
-    ${effectiefTriple}
+    ${nietBekrachtigdTriple}
     <${instanceUri}> <http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan> <${person.uri}>.
     `;
 };

--- a/app/utils/build-new-mandataris-source-ttl.js
+++ b/app/utils/build-new-mandataris-source-ttl.js
@@ -1,4 +1,7 @@
-import { MANDATARIS_EFFECTIEF_PUBLICATION_STATE } from './well-known-uris';
+import {
+  MANDATARIS_DRAFT_PUBLICATION_STATE,
+  MANDATARIS_EFFECTIEF_PUBLICATION_STATE,
+} from './well-known-uris';
 
 export const buildNewMandatarisSourceTtl = async (
   store,
@@ -19,6 +22,26 @@ export const buildNewMandatarisSourceTtl = async (
 
   return `
     ${effectiefTriple}
+    <${instanceUri}> <http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan> <${person.uri}>.
+    `;
+};
+
+export const buildNewIVMandatarisSourceTtl = async (
+  store,
+  instanceUri,
+  personId
+) => {
+  const draftTriple = `<${instanceUri}> <http://lblod.data.gift/vocabularies/lmb/hasPublicationStatus> <${MANDATARIS_DRAFT_PUBLICATION_STATE}>.`;
+  if (!personId) {
+    return draftTriple;
+  }
+  const person = await store.findRecord('persoon', personId);
+  if (!person) {
+    return draftTriple;
+  }
+
+  return `
+    ${draftTriple}
     <${instanceUri}> <http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan> <${person.uri}>.
     `;
 };

--- a/app/utils/build-new-mandataris-source-ttl.js
+++ b/app/utils/build-new-mandataris-source-ttl.js
@@ -5,17 +5,20 @@ export const buildNewMandatarisSourceTtl = async (
   instanceUri,
   personId
 ) => {
-  const draftTriple = `<${instanceUri}> <http://lblod.data.gift/vocabularies/lmb/hasPublicationStatus> <${MANDATARIS_EFFECTIEF_PUBLICATION_STATE}>.`;
+  const effectiefTriple = `
+    <${instanceUri}> <http://lblod.data.gift/vocabularies/lmb/hasPublicationStatus> <${MANDATARIS_EFFECTIEF_PUBLICATION_STATE}>.
+    <${instanceUri}> <http://lblod.data.gift/vocabularies/lmb/effectiefAt> "${new Date().toJSON()}"^^<http://www.w3.org/2001/XMLSchema#DateTime>.
+  `;
   if (!personId) {
-    return draftTriple;
+    return effectiefTriple;
   }
   const person = await store.findRecord('persoon', personId);
   if (!person) {
-    return draftTriple;
+    return effectiefTriple;
   }
 
   return `
-    ${draftTriple}
+    ${effectiefTriple}
     <${instanceUri}> <http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan> <${person.uri}>.
     `;
 };

--- a/app/utils/build-new-mandataris-source-ttl.js
+++ b/app/utils/build-new-mandataris-source-ttl.js
@@ -10,7 +10,7 @@ export const buildNewMandatarisSourceTtl = async (
 ) => {
   const nietBekrachtigdTriple = `
     <${instanceUri}> <http://lblod.data.gift/vocabularies/lmb/hasPublicationStatus> <${MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE}>.
-    <${instanceUri}> <http://lblod.data.gift/vocabularies/lmb/effectiefAt> "${new Date().toJSON()}"^^<http://www.w3.org/2001/XMLSchema#DateTime>.
+    <${instanceUri}> <http://lblod.data.gift/vocabularies/lmb/effectiefAt> "${new Date().toJSON()}"^^<http://www.w3.org/2001/XMLSchema#dateTime>.
   `;
   if (!personId) {
     return nietBekrachtigdTriple;

--- a/app/utils/build-new-mandataris-source-ttl.js
+++ b/app/utils/build-new-mandataris-source-ttl.js
@@ -1,11 +1,11 @@
-import { MANDATARIS_DRAFT_PUBLICATION_STATE } from './well-known-uris';
+import { MANDATARIS_EFFECTIEF_PUBLICATION_STATE } from './well-known-uris';
 
 export const buildNewMandatarisSourceTtl = async (
   store,
   instanceUri,
   personId
 ) => {
-  const draftTriple = `<${instanceUri}> <http://lblod.data.gift/vocabularies/lmb/hasPublicationStatus> <${MANDATARIS_DRAFT_PUBLICATION_STATE}>.`;
+  const draftTriple = `<${instanceUri}> <http://lblod.data.gift/vocabularies/lmb/hasPublicationStatus> <${MANDATARIS_EFFECTIEF_PUBLICATION_STATE}>.`;
   if (!personId) {
     return draftTriple;
   }

--- a/app/utils/get-mandataris-status.js
+++ b/app/utils/get-mandataris-status.js
@@ -1,7 +1,7 @@
 import { queryRecord } from './query-record';
 import {
-  MANDATARIS_DRAFT_PUBLICATION_STATE,
   MANDATARIS_EFFECTIEF_STATE,
+  MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE,
 } from './well-known-uris';
 
 export const getEffectiefStatus = async (store) => {
@@ -10,8 +10,8 @@ export const getEffectiefStatus = async (store) => {
   });
 };
 
-export const getDraftPublicationStatus = async (store) => {
+export const getNietBekrachtigdPublicationStatus = async (store) => {
   return await queryRecord(store, 'mandataris-publication-status-code', {
-    'filter[:uri:]': MANDATARIS_DRAFT_PUBLICATION_STATE,
+    'filter[:uri:]': MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE,
   });
 };

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -25,7 +25,7 @@ export const MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE =
   'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/9d8fd14d-95d0-4f5e-b3a5-a56a126227b6';
 export const MANDATARIS_DRAFT_PUBLICATION_STATE =
   'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/588ce330-4abb-4448-9776-a17d9305df07';
-export const MANDATARIS_EFFECTIEF_PUBLICATION_STATE =
+export const MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE =
   'http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/d3b12468-3720-4cb0-95b4-6aa2996ab188';
 export const BELEIDSDOMEIN_CODES_CONCEPT_SCHEME =
   'http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode';


### PR DESCRIPTION
## Description

* When mandatarissen get created they need to start in publication status `EFFECTIEF`.  For installatievergadering mandatarissen this stays "DRAFT".
* The label for effectief status needs to be changed to `Niet bekrachtigd`

## How to test

1. Newly created mandataris has Niet bekrachtigd status
2. Mandataris updates are also added with this niet bekrachtigd status
3. Mandatarissen in IV starten in draft status (add + genereer)
4. Visueel is de effectief status nu Niet bekrachtigd 
5. Mandatarissen van draft en effectief kunnen verwijderd worden
6. Bij het manueel bekrachtiging is er een warning dat deze niet meer verwijderd kan worden
7. Na het uitvoeren van de migrations in de app zullen al de draft mandatarissen BUITEN diegene in een active legislatuur naar efffectief gezet zijn

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/386
