### PR TITLE
Ben/lmb 1311 Add date input to end mandatarissen

### DIFF
--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -149,4 +149,8 @@ export default class MandatarissenPersoonMandatenController extends Controller {
   get toolTipText() {
     return 'Deze persoon is reeds onafhankelijk.';
   }
+
+  get endMandatarissenDisabled() {
+    return !this.date;
+  }
 }

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -135,7 +135,7 @@ export default class MandatarissenPersoonMandatenController extends Controller {
   });
 
   endActiveMandaten = task(async () => {
-    await this.persoonApi.endActiveMandates(this.model.persoon.id);
+    await this.persoonApi.endActiveMandates(this.model.persoon.id, this.date);
     showSuccessToast(
       this.toaster,
       `Active mandatatarissen beëindigd voor ${this.model.persoon.naam}`

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -29,7 +29,7 @@ export default class MandatarissenPersoonMandatenController extends Controller {
   @tracked isEndMandatesModalOpen = false;
   @tracked selectedBestuursorgaan = null;
   @tracked activeOnly = true;
-  @tracked date = new Date();
+  @tracked date = endOfDay(new Date());
   sort = 'is-bestuurlijke-alias-van.achternaam';
 
   @action

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -29,6 +29,7 @@ export default class MandatarissenPersoonMandatenController extends Controller {
   @tracked isEndMandatesModalOpen = false;
   @tracked selectedBestuursorgaan = null;
   @tracked activeOnly = true;
+  @tracked date = new Date();
   sort = 'is-bestuurlijke-alias-van.achternaam';
 
   @action

--- a/app/services/persoon-api.js
+++ b/app/services/persoon-api.js
@@ -6,6 +6,7 @@ import { timeout } from 'ember-concurrency';
 
 import {
   API,
+  JSON_API_TYPE,
   RESOURCE_CACHE_TIMEOUT,
   STATUS_CODE,
 } from 'frontend-lmb/utils/constants';
@@ -55,11 +56,17 @@ export default class PersoonApiService extends Service {
     return jsonResponse.isTrue;
   }
 
-  async endActiveMandates(persoonId) {
+  async endActiveMandates(persoonId, date) {
     const response = await fetch(
       `${API.MANDATARIS_SERVICE}/personen/${persoonId}/end-active-mandates`,
       {
         method: 'PUT',
+        headers: {
+          'Content-Type': JSON_API_TYPE,
+        },
+        body: JSON.stringify({
+          date: date,
+        }),
       }
     );
     const jsonReponse = await response.json();

--- a/app/services/persoon-api.js
+++ b/app/services/persoon-api.js
@@ -13,6 +13,7 @@ import {
 
 export default class PersoonApiService extends Service {
   @service store;
+  @service bestuursperioden;
 
   async getCurrentFractie(persoonId, bestuursperiodeId) {
     const response = await fetch(
@@ -40,8 +41,10 @@ export default class PersoonApiService extends Service {
   }
 
   async hasActiveMandatarissen(persoonId) {
+    const currentPeriod =
+      await this.bestuursperioden.getCurrentBestuursperiode();
     const response = await fetch(
-      `${API.MANDATARIS_SERVICE}/personen/${persoonId}/has-active-mandates`
+      `${API.MANDATARIS_SERVICE}/personen/${persoonId}/has-active-mandates/${currentPeriod.id}`
     );
     const jsonResponse = await response.json();
 
@@ -57,6 +60,8 @@ export default class PersoonApiService extends Service {
   }
 
   async endActiveMandates(persoonId, date) {
+    const currentPeriod =
+      await this.bestuursperioden.getCurrentBestuursperiode();
     const response = await fetch(
       `${API.MANDATARIS_SERVICE}/personen/${persoonId}/end-active-mandates`,
       {
@@ -65,6 +70,7 @@ export default class PersoonApiService extends Service {
           'Content-Type': JSON_API_TYPE,
         },
         body: JSON.stringify({
+          bestuursperiodeId: currentPeriod.id,
           date: date,
         }),
       }

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -225,6 +225,7 @@
         <AuButton
           @loading={{this.endActiveMandaten.isRunning}}
           @loadingMessage="Actieve mandaten worden beëindigd"
+          @disabled={{this.endMandatarissenDisabled}}
           {{on "click" (perform this.endActiveMandaten)}}
         >
           Beëindig mandatarissen

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -208,8 +208,11 @@
   <Modal.Body>
     <div class="au-o-box au-o-flow">
       <div>
-        Door verder te gaan, worden de einddatums van de actieve mandatarissen
-        van deze persoon aangepast, waardoor deze mandaten beëindigd worden.
+        Door verder te gaan, worden de einddatums van de actieve mandaten van
+        deze persoon, in de huidige bestuursperiode aangepast, waardoor deze
+        mandaten beëindigd worden. Opgelet dit geld ook voor verhinderde
+        mandatarissen, hun einddatum wordt dan ook aangepast naar de ingevoerde
+        datum.
       </div>
       <DateInput
         @label="Einddatum"

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -206,11 +206,18 @@
   as |Modal|
 >
   <Modal.Body>
-    <AuContent class="au-u-margin-bottom-small">
-      Door verder te gaan, worden de einddatums van de actieve mandatarissen van
-      deze persoon aangepast naar vandaag, waardoor deze mandaten beëindigd
-      worden.
-    </AuContent>
+    <div class="au-o-box au-o-flow">
+      <div>
+        Door verder te gaan, worden de einddatums van de actieve mandatarissen
+        van deze persoon aangepast, waardoor deze mandaten beëindigd worden.
+      </div>
+      <DateInput
+        @label="Einddatum"
+        @value={{this.date}}
+        @onChange={{fn (mut this.date)}}
+        @isRequired={{true}}
+      />
+    </div>
   </Modal.Body>
   <Modal.Footer>
     <AuToolbar as |Group|>

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -219,6 +219,7 @@
         @value={{this.date}}
         @onChange={{fn (mut this.date)}}
         @isRequired={{true}}
+        @endOfDay={{true}}
       />
     </div>
   </Modal.Body>

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -211,7 +211,7 @@
         Door verder te gaan, worden de einddatums van de actieve mandaten van
         deze persoon, in de huidige bestuursperiode aangepast, waardoor deze
         mandaten beëindigd worden. Opgelet dit geld ook voor verhinderde
-        mandatarissen, hun einddatum wordt dan ook aangepast naar de ingevoerde
+        mandaten, hun einddatum wordt dan ook aangepast naar de ingevoerde
         datum.
       </div>
       <DateInput


### PR DESCRIPTION
## Description

When ending multiple mandatarissen, show a date input in the confirm modal. This date is used as the end date of the mandatarissen.

![Screenshot 2025-02-25 at 10 12 39](https://github.com/user-attachments/assets/4a632e3f-e15c-4dae-99e0-15460b026a5c)

## How to test

Go to the mandaten page of a person and beeindig mandaten. The date you entered should be the end date of the mandataris.
Test this for a few different cases. Only one active mandate, multiple active mandates, mandates in an older bestuursperiode ...

## Links to other PR's

- https://github.com/lblod/mandataris-service/pull/99