### PR TITLE
LMB 1353 | Make rangorde a dropdown

### DIFF
--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -99,13 +99,14 @@
           <AuLabel>
             Rangorde
           </AuLabel>
-          <AuInput
-            value={{this.rangorde}}
-            @width="block"
+          <RangordeDropdown
             id="mandataris-rangorde"
-            placeholder={{this.rangordePlaceholder}}
-            {{on "input" this.updateRangorde}}
+            @selected={{this.rangorde}}
+            @placeholder={{this.placeholderText}}
+            @mandaatLabel={{this.mandaatLabel}}
+            @onNewRangorde={{this.updateRangorde}}
           />
+
         </div>
       {{/if}}
     {{/unless}}

--- a/app/components/mandatarissen/update-state.hbs
+++ b/app/components/mandatarissen/update-state.hbs
@@ -102,7 +102,7 @@
           <RangordeDropdown
             id="mandataris-rangorde"
             @selected={{this.rangorde}}
-            @placeholder={{this.placeholderText}}
+            @placeholder={{this.rangordePlaceholder}}
             @mandaatLabel={{this.mandaatLabel}}
             @onNewRangorde={{this.updateRangorde}}
           />

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -178,17 +178,16 @@ export default class MandatarissenUpdateState extends Component {
         start: dateOfAction,
         einde: endDate,
         status: await this.newStatus,
-        rangorde: this.rangorde,
         publicationStatus: await getNietBekrachtigdPublicationStatus(
           this.store
         ),
       }
     );
 
-    const newMandataris = this.store.createRecord(
-      'mandataris',
-      newMandatarisProps
-    );
+    const newMandataris = this.store.createRecord('mandataris', {
+      ...newMandatarisProps,
+      rangorde: this.rangorde,
+    });
 
     if (this.selectedReplacement) {
       newMandatarisProps.rangorde = '';

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -28,6 +28,7 @@ export default class MandatarissenUpdateState extends Component {
   @tracked bestuurseenheid = null;
   @tracked bestuursorganenOfMandaat = [];
   @tracked bestuursperiode;
+  @tracked mandaat;
   @tracked bestuursorgaanStartDate;
   @tracked bestuursorgaanEndDate;
   @tracked rangorde = null;
@@ -76,8 +77,8 @@ export default class MandatarissenUpdateState extends Component {
   });
 
   async getBestuursorgaanPeriod() {
-    const mandaat = await this.args.mandataris.bekleedt;
-    const bestuursorganen = await mandaat.bevatIn;
+    this.mandaat = await this.args.mandataris.bekleedt;
+    const bestuursorganen = await this.mandaat.bevatIn;
     if (bestuursorganen.length >= 1) {
       this.currentBestuursorgaan = bestuursorganen.at(0);
       this.bestuursorgaanStartDate = this.currentBestuursorgaan.bindingStart;
@@ -159,11 +160,12 @@ export default class MandatarissenUpdateState extends Component {
     );
   }
 
+  get mandaatLabel() {
+    return this.mandaat.get('bestuursfunctie.label') || 'schepen';
+  }
+
   get rangordePlaceholder() {
-    const mandaatName = (
-      this.args.mandataris.get('bekleedt.bestuursfunctie.label') || 'schepen'
-    ).toLowerCase();
-    return `Eerste ${mandaatName}`;
+    return `Eerste ${this.mandaatLabel}`;
   }
 
   async changeMandatarisState() {
@@ -176,6 +178,7 @@ export default class MandatarissenUpdateState extends Component {
         start: dateOfAction,
         einde: endDate,
         status: await this.newStatus,
+        rangorde: this.rangorde,
         publicationStatus: await getNietBekrachtigdPublicationStatus(
           this.store
         ),
@@ -269,11 +272,8 @@ export default class MandatarissenUpdateState extends Component {
   }
 
   @action
-  updateRangorde(event) {
-    if (event && typeof event.preventDefault === 'function') {
-      event.preventDefault();
-    }
-    this.rangorde = event.target.value;
+  updateRangorde(rangordeAsString) {
+    this.rangorde = rangordeAsString;
   }
 
   @action updateFractie(newFractie) {

--- a/app/components/mandatarissen/update-state.js
+++ b/app/components/mandatarissen/update-state.js
@@ -161,7 +161,7 @@ export default class MandatarissenUpdateState extends Component {
   }
 
   get mandaatLabel() {
-    return this.mandaat.get('bestuursfunctie.label') || 'schepen';
+    return this.mandaat?.rangordeLabel;
   }
 
   get rangordePlaceholder() {

--- a/app/components/organen/rangorde-input.hbs
+++ b/app/components/organen/rangorde-input.hbs
@@ -12,7 +12,7 @@
       @selected={{this.rangorde}}
       @placeholder={{this.rangordePlaceholder}}
       @mandaatLabel={{this.mandaatLabel}}
-      @onNewRangorde={{this.onUpdateRangorde}}
+      @onNewRangorde={{this.setRangorde}}
     />
   {{/if}}
   <AuButton

--- a/app/components/organen/rangorde-input.hbs
+++ b/app/components/organen/rangorde-input.hbs
@@ -7,14 +7,12 @@
     @disabled={{this.isMinusDisabled}}
     {{on "click" this.rangordeDown}}
   />
-  {{#if this.mandaat}}
-    <RangordeDropdown
-      @selected={{this.rangorde}}
-      @placeholder={{this.rangordePlaceholder}}
-      @mandaatLabel={{this.mandaatLabel}}
-      @onNewRangorde={{this.setRangorde}}
-    />
-  {{/if}}
+  <RangordeDropdown
+    @selected={{this.rangorde}}
+    @placeholder={{this.rangordePlaceholder}}
+    @mandaatLabel={{this.mandaatLabel}}
+    @onNewRangorde={{this.setRangorde}}
+  />
   <AuButton
     hideText={{true}}
     @skin="secondary"

--- a/app/components/organen/rangorde-input.hbs
+++ b/app/components/organen/rangorde-input.hbs
@@ -1,20 +1,18 @@
-<div>
-  <div class="order-input-as-string">
-    {{#if this.mandaat}}
-      <RangordeDropdown
-        @selected={{this.rangorde}}
-        @placeholder={{this.rangordePlaceholder}}
-        @mandaatLabel={{this.mandaatLabel}}
-        @onNewRangorde={{this.onUpdateRangorde}}
-      />
+<div class="order-input-as-string">
+  {{#if this.mandaat}}
+    <RangordeDropdown
+      @selected={{this.rangorde}}
+      @placeholder={{this.rangordePlaceholder}}
+      @mandaatLabel={{this.mandaatLabel}}
+      @onNewRangorde={{this.onUpdateRangorde}}
+    />
+  {{/if}}
+  <div class="au-u-margin-left-tiny">
+    {{#if this.rangordeMovedUp}}
+      <AuBadge @icon="chevron-up" @skin="success" @size="small" />
     {{/if}}
-    <div class="au-u-margin-left-tiny">
-      {{#if this.rangordeMovedUp}}
-        <AuBadge @icon="chevron-up" @skin="success" @size="small" />
-      {{/if}}
-      {{#if this.rangordeMovedDown}}
-        <AuBadge @icon="chevron-down" @skin="error" @size="small" />
-      {{/if}}
-    </div>
+    {{#if this.rangordeMovedDown}}
+      <AuBadge @icon="chevron-down" @skin="error" @size="small" />
+    {{/if}}
   </div>
 </div>

--- a/app/components/organen/rangorde-input.hbs
+++ b/app/components/organen/rangorde-input.hbs
@@ -1,4 +1,12 @@
 <div class="order-input-as-string">
+  <AuButton
+    hideText={{true}}
+    @icon="chevron-up"
+    @skin="secondary"
+    class="order-input-as-string--minus"
+    @disabled={{this.isMinusDisabled}}
+    {{on "click" this.rangordeDown}}
+  />
   {{#if this.mandaat}}
     <RangordeDropdown
       @selected={{this.rangorde}}
@@ -7,6 +15,14 @@
       @onNewRangorde={{this.onUpdateRangorde}}
     />
   {{/if}}
+  <AuButton
+    hideText={{true}}
+    @skin="secondary"
+    @icon="chevron-down"
+    class="order-input-as-string--plus"
+    @disabled={{this.isPlusDisabled}}
+    {{on "click" this.rangordeUp}}
+  />
   <div class="au-u-margin-left-tiny">
     {{#if this.rangordeMovedUp}}
       <AuBadge @icon="chevron-up" @skin="success" @size="small" />

--- a/app/components/organen/rangorde-input.hbs
+++ b/app/components/organen/rangorde-input.hbs
@@ -1,28 +1,13 @@
 <div>
   <div class="order-input-as-string">
-    <AuButton
-      hideText={{true}}
-      @icon="chevron-up"
-      @skin="secondary"
-      class="order-input-as-string--minus"
-      @disabled={{this.isMinusDisabled}}
-      {{on "click" this.rangordeDown}}
-    />
-    <AuInput
-      value={{this.rangorde}}
-      placeholder={{this.rangordePlaceholder}}
-      @warning={{this.inputWarningMessage}}
-      {{on "blur" this.onUpdateRangorde}}
-      {{on "keyup" this.onEnterInRangorde}}
-    />
-    <AuButton
-      hideText={{true}}
-      @skin="secondary"
-      @icon="chevron-down"
-      class="order-input-as-string--plus"
-      @disabled={{this.isPlusDisabled}}
-      {{on "click" this.rangordeUp}}
-    />
+    {{#if this.mandaat}}
+      <RangordeDropdown
+        @selected={{this.rangorde}}
+        @placeholder={{this.rangordePlaceholder}}
+        @mandaatLabel={{this.mandaatLabel}}
+        @onNewRangorde={{this.onUpdateRangorde}}
+      />
+    {{/if}}
     <div class="au-u-margin-left-tiny">
       {{#if this.rangordeMovedUp}}
         <AuBadge @icon="chevron-up" @skin="success" @size="small" />
@@ -32,7 +17,4 @@
       {{/if}}
     </div>
   </div>
-  <AuHelpText @warning={{this.inputWarningMessage}}>
-    {{this.inputWarningMessage}}
-  </AuHelpText>
 </div>

--- a/app/components/organen/rangorde-input.js
+++ b/app/components/organen/rangorde-input.js
@@ -5,10 +5,9 @@ import { tracked } from '@glimmer/tracking';
 
 import { keepLatestTask } from 'ember-concurrency';
 import {
-  orderMandatarisStructByRangorde,
+  getNextAvailableRangorde,
   rangordeNumberMapping,
   rangordeStringMapping,
-  rangordeStringToNumber,
 } from 'frontend-lmb/utils/rangorde';
 
 export default class OrganenRangordeInputComponent extends Component {
@@ -112,19 +111,6 @@ export default class OrganenRangordeInputComponent extends Component {
     });
   }
 
-  getNextAvailableRangorde() {
-    const sortedMandatarissen = orderMandatarisStructByRangorde([
-      ...this.args.mandatarissen,
-    ]);
-    const lastNumber = rangordeStringToNumber(
-      sortedMandatarissen[sortedMandatarissen.length - 1].rangorde
-    );
-    if (lastNumber) {
-      return rangordeNumberMapping[lastNumber + 1];
-    }
-    return rangordeNumberMapping[1];
-  }
-
   @action
   onUpdateRangorde(rangordeAsString) {
     this.setRangorde(rangordeAsString);
@@ -137,7 +123,7 @@ export default class OrganenRangordeInputComponent extends Component {
 
     if (this.rangordeInteger == null) {
       this.setRangorde(
-        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`,
+        `${getNextAvailableRangorde(this.args.mandatarissen)} ${this.mandaatLabel}`,
         true
       );
     } else {
@@ -152,19 +138,12 @@ export default class OrganenRangordeInputComponent extends Component {
 
     if (this.rangordeInteger == null) {
       this.setRangorde(
-        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`,
+        `${getNextAvailableRangorde(this.args.mandatarissen)} ${this.mandaatLabel}`,
         true
       );
     } else {
       const currentOrder = rangordeNumberMapping[currentNumber];
       this.setRangorde(this.rangorde.replace(currentOrder, newOrder), true);
-    }
-  }
-
-  @action
-  onEnterInRangorde(event) {
-    if (event.key === 'Enter') {
-      this.setRangorde(event.currentTarget.value);
     }
   }
 }

--- a/app/components/organen/rangorde-input.js
+++ b/app/components/organen/rangorde-input.js
@@ -6,6 +6,7 @@ import { tracked } from '@glimmer/tracking';
 import { keepLatestTask } from 'ember-concurrency';
 import {
   findOrderInString,
+  getMandatarisForRangorde,
   getNextAvailableRangorde,
   rangordeNumberMapping,
   rangordeStringMapping,
@@ -53,7 +54,10 @@ export default class OrganenRangordeInputComponent extends Component {
     async (value, switchWithPrevious) => {
       const oldRangorde = this.args.mandatarisStruct.rangorde;
       const newRangorde = value;
-      const previousHolder = this.getMandatarisWithRangorde(newRangorde);
+      const previousHolder = getMandatarisForRangorde(
+        this.args.mandatarissen,
+        newRangorde
+      );
 
       this.args.mandatarisStruct.rangorde = newRangorde;
 
@@ -83,12 +87,6 @@ export default class OrganenRangordeInputComponent extends Component {
 
   get isPlusDisabled() {
     return this.rangordeInteger >= Object.keys(rangordeStringMapping).length;
-  }
-
-  getMandatarisWithRangorde(targetRangorde) {
-    return this.args.mandatarissen.find((mandatarisStruct) => {
-      return mandatarisStruct.rangorde === targetRangorde;
-    });
   }
 
   @action

--- a/app/components/organen/rangorde-input.js
+++ b/app/components/organen/rangorde-input.js
@@ -4,12 +4,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 import { keepLatestTask } from 'ember-concurrency';
-import {
-  orderMandatarisStructByRangorde,
-  rangordeNumberMapping,
-  rangordeStringMapping,
-  rangordeStringToNumber,
-} from 'frontend-lmb/utils/rangorde';
+import { rangordeStringMapping } from 'frontend-lmb/utils/rangorde';
 
 export default class OrganenRangordeInputComponent extends Component {
   @tracked rangordePlaceholder;
@@ -89,82 +84,14 @@ export default class OrganenRangordeInputComponent extends Component {
     return foundNumber;
   }
 
-  findFirstWordOfString(string) {
-    // eslint-disable-next-line no-useless-escape
-    const regex = new RegExp(/^([\w\-]+)/);
-    if (regex.test(string)) {
-      return `${string}`.match(regex);
-    }
-    return null;
-  }
-
-  get isMinusDisabled() {
-    return this.rangordeInteger <= 1;
-  }
-
-  get isPlusDisabled() {
-    return this.rangordeInteger >= Object.keys(rangordeStringMapping).length;
-  }
-
   getMandatarisWithRangorde(targetRangorde) {
     return this.args.mandatarissen.find((mandatarisStruct) => {
       return mandatarisStruct.rangorde === targetRangorde;
     });
   }
 
-  getNextAvailableRangorde() {
-    const sortedMandatarissen = orderMandatarisStructByRangorde([
-      ...this.args.mandatarissen,
-    ]);
-    const lastNumber = rangordeStringToNumber(
-      sortedMandatarissen[sortedMandatarissen.length - 1].rangorde
-    );
-    if (lastNumber) {
-      return rangordeNumberMapping[lastNumber + 1];
-    }
-    return rangordeNumberMapping[1];
-  }
-
   @action
   onUpdateRangorde(rangordeAsString) {
     this.setRangorde(rangordeAsString);
-  }
-
-  @action
-  async rangordeUp() {
-    const currentNumber = this.rangordeInteger || 0;
-    const newOrder = rangordeNumberMapping[currentNumber + 1];
-
-    if (this.rangordeInteger == null) {
-      this.setRangorde(
-        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`,
-        true
-      );
-    } else {
-      const currentOrder = rangordeNumberMapping[currentNumber];
-      this.setRangorde(this.rangorde.replace(currentOrder, newOrder), true);
-    }
-  }
-  @action
-  async rangordeDown() {
-    const currentNumber = this.rangordeInteger || 2;
-    const newOrder = rangordeNumberMapping[currentNumber - 1];
-
-    if (this.rangordeInteger == null) {
-      this.setRangorde(
-        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`,
-        true
-      );
-    } else {
-      const currentOrder = rangordeNumberMapping[currentNumber];
-      this.setRangorde(this.rangorde.replace(currentOrder, newOrder), true);
-    }
-  }
-
-  @action
-  onEnterInRangorde(event) {
-    if (event.key === 'Enter') {
-      this.setRangorde(event.currentTarget.value);
-    }
   }
 }

--- a/app/components/organen/rangorde-input.js
+++ b/app/components/organen/rangorde-input.js
@@ -13,19 +13,11 @@ import {
 
 export default class OrganenRangordeInputComponent extends Component {
   @tracked rangordePlaceholder;
+  @tracked mandaat;
 
   constructor() {
     super(...arguments);
     this.setPlaceholder();
-  }
-
-  get inputWarningMessage() {
-    const order = this.rangordeInteger;
-    if (order == null) {
-      return 'Opgelet! Dit is geen gekende rangorde!';
-    } else {
-      return null;
-    }
   }
 
   get rangordeInteger() {
@@ -53,8 +45,8 @@ export default class OrganenRangordeInputComponent extends Component {
   }
 
   async setPlaceholder() {
-    const mandaat = await this.args.mandatarisStruct.mandataris.get('bekleedt');
-    this.rangordePlaceholder = `Vul de rangorde in, bv. “Eerste ${mandaat.rangordeLabel}”`;
+    this.mandaat = await this.args.mandatarisStruct.mandataris.get('bekleedt');
+    this.rangordePlaceholder = `Vul de rangorde in, bv. “Eerste ${this.mandaat.rangordeLabel}”`;
   }
 
   updateMandatarisRangorde = keepLatestTask(
@@ -72,7 +64,6 @@ export default class OrganenRangordeInputComponent extends Component {
       ) {
         previousHolder.rangorde = oldRangorde;
       }
-
       this.args.updateMandatarisList();
     }
   );
@@ -81,9 +72,8 @@ export default class OrganenRangordeInputComponent extends Component {
     this.updateMandatarisRangorde.perform(value, switchWithPrevious);
   }
 
-  async getMandaatLabel() {
-    const mandaat = await this.args.mandatarisStruct.mandataris.get('bekleedt');
-    return mandaat?.rangordeLabel;
+  get mandaatLabel() {
+    return this.mandaat?.rangordeLabel;
   }
 
   findOrderInString(possibleString) {
@@ -136,8 +126,8 @@ export default class OrganenRangordeInputComponent extends Component {
   }
 
   @action
-  onUpdateRangorde(event) {
-    this.setRangorde(event.currentTarget.value);
+  onUpdateRangorde(rangordeAsString) {
+    this.setRangorde(rangordeAsString);
   }
 
   @action
@@ -147,7 +137,7 @@ export default class OrganenRangordeInputComponent extends Component {
 
     if (this.rangordeInteger == null) {
       this.setRangorde(
-        `${this.getNextAvailableRangorde()} ${await this.getMandaatLabel()}`,
+        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`,
         true
       );
     } else {
@@ -162,7 +152,7 @@ export default class OrganenRangordeInputComponent extends Component {
 
     if (this.rangordeInteger == null) {
       this.setRangorde(
-        `${this.getNextAvailableRangorde()} ${await this.getMandaatLabel()}`,
+        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`,
         true
       );
     } else {

--- a/app/components/organen/rangorde-input.js
+++ b/app/components/organen/rangorde-input.js
@@ -4,7 +4,12 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 import { keepLatestTask } from 'ember-concurrency';
-import { rangordeStringMapping } from 'frontend-lmb/utils/rangorde';
+import {
+  orderMandatarisStructByRangorde,
+  rangordeNumberMapping,
+  rangordeStringMapping,
+  rangordeStringToNumber,
+} from 'frontend-lmb/utils/rangorde';
 
 export default class OrganenRangordeInputComponent extends Component {
   @tracked rangordePlaceholder;
@@ -84,14 +89,82 @@ export default class OrganenRangordeInputComponent extends Component {
     return foundNumber;
   }
 
+  findFirstWordOfString(string) {
+    // eslint-disable-next-line no-useless-escape
+    const regex = new RegExp(/^([\w\-]+)/);
+    if (regex.test(string)) {
+      return `${string}`.match(regex);
+    }
+    return null;
+  }
+
+  get isMinusDisabled() {
+    return this.rangordeInteger <= 1;
+  }
+
+  get isPlusDisabled() {
+    return this.rangordeInteger >= Object.keys(rangordeStringMapping).length;
+  }
+
   getMandatarisWithRangorde(targetRangorde) {
     return this.args.mandatarissen.find((mandatarisStruct) => {
       return mandatarisStruct.rangorde === targetRangorde;
     });
   }
 
+  getNextAvailableRangorde() {
+    const sortedMandatarissen = orderMandatarisStructByRangorde([
+      ...this.args.mandatarissen,
+    ]);
+    const lastNumber = rangordeStringToNumber(
+      sortedMandatarissen[sortedMandatarissen.length - 1].rangorde
+    );
+    if (lastNumber) {
+      return rangordeNumberMapping[lastNumber + 1];
+    }
+    return rangordeNumberMapping[1];
+  }
+
   @action
   onUpdateRangorde(rangordeAsString) {
     this.setRangorde(rangordeAsString);
+  }
+
+  @action
+  async rangordeUp() {
+    const currentNumber = this.rangordeInteger || 0;
+    const newOrder = rangordeNumberMapping[currentNumber + 1];
+
+    if (this.rangordeInteger == null) {
+      this.setRangorde(
+        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`,
+        true
+      );
+    } else {
+      const currentOrder = rangordeNumberMapping[currentNumber];
+      this.setRangorde(this.rangorde.replace(currentOrder, newOrder), true);
+    }
+  }
+  @action
+  async rangordeDown() {
+    const currentNumber = this.rangordeInteger || 2;
+    const newOrder = rangordeNumberMapping[currentNumber - 1];
+
+    if (this.rangordeInteger == null) {
+      this.setRangorde(
+        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`,
+        true
+      );
+    } else {
+      const currentOrder = rangordeNumberMapping[currentNumber];
+      this.setRangorde(this.rangorde.replace(currentOrder, newOrder), true);
+    }
+  }
+
+  @action
+  onEnterInRangorde(event) {
+    if (event.key === 'Enter') {
+      this.setRangorde(event.currentTarget.value);
+    }
   }
 }

--- a/app/components/organen/rangorde-input.js
+++ b/app/components/organen/rangorde-input.js
@@ -67,6 +67,7 @@ export default class OrganenRangordeInputComponent extends Component {
     }
   );
 
+  @action
   setRangorde(value, switchWithPrevious = false) {
     this.updateMandatarisRangorde.perform(value, switchWithPrevious);
   }
@@ -109,11 +110,6 @@ export default class OrganenRangordeInputComponent extends Component {
     return this.args.mandatarissen.find((mandatarisStruct) => {
       return mandatarisStruct.rangorde === targetRangorde;
     });
-  }
-
-  @action
-  onUpdateRangorde(rangordeAsString) {
-    this.setRangorde(rangordeAsString);
   }
 
   @action

--- a/app/components/organen/rangorde-input.js
+++ b/app/components/organen/rangorde-input.js
@@ -46,7 +46,7 @@ export default class OrganenRangordeInputComponent extends Component {
 
   async setPlaceholder() {
     this.mandaat = await this.args.mandatarisStruct.mandataris.get('bekleedt');
-    this.rangordePlaceholder = `Vul de rangorde in, bv. “Eerste ${this.mandaat.rangordeLabel}”`;
+    this.rangordePlaceholder = `Selecteer een rangorde, bv. “Eerste ${this.mandaat.rangordeLabel}”`;
   }
 
   updateMandatarisRangorde = keepLatestTask(

--- a/app/components/organen/rangorde-input.js
+++ b/app/components/organen/rangorde-input.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { keepLatestTask } from 'ember-concurrency';
 import {
+  findOrderInString,
   getNextAvailableRangorde,
   rangordeNumberMapping,
   rangordeStringMapping,
@@ -20,12 +21,12 @@ export default class OrganenRangordeInputComponent extends Component {
   }
 
   get rangordeInteger() {
-    return this.findOrderInString(this.args.mandatarisStruct.rangorde);
+    return findOrderInString(this.args.mandatarisStruct.rangorde);
   }
 
   get rangordeMovedUp() {
     const currentNumber = this.rangordeInteger || 0;
-    const oldNumber = this.findOrderInString(
+    const oldNumber = findOrderInString(
       this.args.mandatarisStruct.mandataris.rangorde
     );
     return currentNumber < oldNumber;
@@ -33,7 +34,7 @@ export default class OrganenRangordeInputComponent extends Component {
 
   get rangordeMovedDown() {
     const currentNumber = this.rangordeInteger || 0;
-    const oldNumber = this.findOrderInString(
+    const oldNumber = findOrderInString(
       this.args.mandatarisStruct.mandataris.rangorde
     );
     return currentNumber > oldNumber;
@@ -74,28 +75,6 @@ export default class OrganenRangordeInputComponent extends Component {
 
   get mandaatLabel() {
     return this.mandaat?.rangordeLabel;
-  }
-
-  findOrderInString(possibleString) {
-    if (!possibleString || typeof possibleString != 'string') {
-      return null;
-    }
-    let foundNumber = null;
-    Object.keys(rangordeStringMapping).forEach((key) => {
-      if (possibleString.startsWith(key)) {
-        foundNumber = rangordeStringMapping[key];
-      }
-    });
-    return foundNumber;
-  }
-
-  findFirstWordOfString(string) {
-    // eslint-disable-next-line no-useless-escape
-    const regex = new RegExp(/^([\w\-]+)/);
-    if (regex.test(string)) {
-      return `${string}`.match(regex);
-    }
-    return null;
   }
 
   get isMinusDisabled() {

--- a/app/components/rangorde-dropdown.hbs
+++ b/app/components/rangorde-dropdown.hbs
@@ -1,12 +1,12 @@
 <div class="power-select--min-width">
   <PowerSelect
-    @allowClear={{@allowClear}}
+    @allowClear={{false}}
     @disabled={{@disabled}}
     @placeholder={{@placeholder}}
     @selected={{@selected}}
     @options={{this.labels}}
     @class="is-optional"
-    @onChange={{@onNewRangorde}}
+    @onChange={{this.onUpdateRangorde}}
     @searchEnabled={{true}}
     @loadingMessage="Aan het laden..."
     @noMatchesMessage="Geen resultaten"

--- a/app/components/rangorde-dropdown.hbs
+++ b/app/components/rangorde-dropdown.hbs
@@ -1,17 +1,19 @@
 <div class="power-select--min-width">
-  <PowerSelect
-    @allowClear={{false}}
-    @disabled={{@disabled}}
-    @placeholder={{@placeholder}}
-    @selected={{@selected}}
-    @options={{this.labels}}
-    @class="is-optional"
-    @onChange={{this.onUpdateRangorde}}
-    @searchEnabled={{true}}
-    @loadingMessage="Aan het laden..."
-    @noMatchesMessage="Geen resultaten"
-    as |rangordeLabel|
-  >
-    {{rangordeLabel}}
-  </PowerSelect>
+  {{#if @mandaatLabel}}
+    <PowerSelect
+      @allowClear={{false}}
+      @disabled={{@disabled}}
+      @placeholder={{@placeholder}}
+      @selected={{@selected}}
+      @options={{this.labels}}
+      @class="is-optional"
+      @onChange={{this.onUpdateRangorde}}
+      @searchEnabled={{true}}
+      @loadingMessage="Aan het laden..."
+      @noMatchesMessage="Geen resultaten"
+      as |rangordeLabel|
+    >
+      {{rangordeLabel}}
+    </PowerSelect>
+  {{/if}}
 </div>

--- a/app/components/rangorde-dropdown.hbs
+++ b/app/components/rangorde-dropdown.hbs
@@ -1,0 +1,17 @@
+<div class="power-select--min-width">
+  <PowerSelect
+    @allowClear={{@allowClear}}
+    @disabled={{@disabled}}
+    @placeholder={{@placeholder}}
+    @selected={{@selected}}
+    @options={{this.labels}}
+    @class="is-optional"
+    @onChange={{@onNewRangorde}}
+    @searchEnabled={{true}}
+    @loadingMessage="Aan het laden..."
+    @noMatchesMessage="Geen resultaten"
+    as |rangordeLabel|
+  >
+    {{rangordeLabel}}
+  </PowerSelect>
+</div>

--- a/app/components/rangorde-dropdown.js
+++ b/app/components/rangorde-dropdown.js
@@ -1,11 +1,26 @@
 import Component from '@glimmer/component';
 
+import { action } from '@ember/object';
+
 import { rangordeStringMapping } from 'frontend-lmb/utils/rangorde';
 
 export default class RangordeDropdown extends Component {
+  noRangordeLabel = 'Geen rangorde';
+
   get labels() {
-    return Object.keys(rangordeStringMapping).map(
+    const options = Object.keys(rangordeStringMapping).map(
       (key) => `${key} ${this.args.mandaatLabel}`
     );
+
+    return [this.noRangordeLabel, ...options];
+  }
+
+  @action
+  onUpdateRangorde(rangordeLabel) {
+    let rangorde = rangordeLabel;
+    if (rangorde === this.noRangordeLabel) {
+      rangorde = null;
+    }
+    this.args.onNewRangorde(rangorde);
   }
 }

--- a/app/components/rangorde-dropdown.js
+++ b/app/components/rangorde-dropdown.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+import { rangordeStringMapping } from 'frontend-lmb/utils/rangorde';
+
+export default class RangordeDropdown extends Component {
+  get labels() {
+    return Object.keys(rangordeStringMapping).map(
+      (key) => `${key} ${this.args.mandaatLabel}`
+    );
+  }
+}

--- a/app/components/rdf-input-fields/mandataris-rangorde.hbs
+++ b/app/components/rdf-input-fields/mandataris-rangorde.hbs
@@ -8,15 +8,13 @@
     {{@field.label}}
   </AuLabel>
 
-  {{#if this.mandaat}}
-    <RangordeDropdown
-      id={{this.inputId}}
-      @selected={{this.rangorde}}
-      @placeholder={{this.placeholderText}}
-      @mandaatLabel={{this.mandaatLabel}}
-      @onNewRangorde={{this.updateValue}}
-    />
-  {{/if}}
+  <RangordeDropdown
+    id={{this.inputId}}
+    @selected={{this.rangorde}}
+    @placeholder={{this.placeholderText}}
+    @mandaatLabel={{this.mandaatLabel}}
+    @onNewRangorde={{this.updateValue}}
+  />
 
   {{#each this.errors as |error|}}
     <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>

--- a/app/components/rdf-input-fields/mandataris-rangorde.hbs
+++ b/app/components/rdf-input-fields/mandataris-rangorde.hbs
@@ -7,15 +7,16 @@
   >
     {{@field.label}}
   </AuLabel>
-  <AuInput
-    @error={{this.hasErrors}}
-    @warning={{this.hasWarnings}}
-    @width="block"
-    id={{this.inputId}}
-    value={{this.rangorde}}
-    placeholder={{this.placeholderText}}
-    {{on "blur" this.updateValue}}
-  />
+
+  {{#if this.mandaat}}
+    <RangordeDropdown
+      id={{this.inputId}}
+      @selected={{this.rangorde}}
+      @placeholder={{this.placeholderText}}
+      @mandaatLabel={{this.mandaatLabel}}
+      @onNewRangorde={{this.updateValue}}
+    />
+  {{/if}}
 
   {{#each this.errors as |error|}}
     <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>

--- a/app/components/rdf-input-fields/mandataris-rangorde.js
+++ b/app/components/rdf-input-fields/mandataris-rangorde.js
@@ -23,7 +23,8 @@ export default class RdfMandatarisRangorde extends InputFieldComponent {
   @service store;
   @tracked rangorde;
   @tracked shouldRender;
-  @tracked placeholderText = 'Vul de rangorde in, bvb “Eerste schepen”';
+  @tracked placeholderText;
+  @tracked mandaat;
 
   constructor() {
     super(...arguments);
@@ -68,14 +69,14 @@ export default class RdfMandatarisRangorde extends InputFieldComponent {
       this.storeOptions.sourceGraph
     );
 
-    const mandaat = await getByUri(
+    this.mandaat = await getByUri(
       this.store,
       'mandaat',
       mandaatUri[0]?.object?.value,
       { include: 'bestuursfunctie' }
     );
-    this.shouldRender = mandaat?.hasRangorde;
-    this.placeholderText = `Vul de rangorde in, bvb “Eerste ${mandaat?.rangordeLabel}”`;
+    this.shouldRender = this.mandaat?.hasRangorde;
+    this.placeholderText = `Selecteer een rangorde, bvb “Eerste ${this.mandaat?.rangordeLabel}”`;
 
     if (!this.shouldRender && this.rangorde != null) {
       // without timeout, the form ttl doesn't update immediately
@@ -93,17 +94,17 @@ export default class RdfMandatarisRangorde extends InputFieldComponent {
   }
 
   @action
-  async updateValue(event) {
-    if (event && typeof event.preventDefault === 'function') {
-      event.preventDefault();
-    }
-    const rangorde = event.target.value.trim();
-    this.rangorde = rangorde;
+  async updateValue(rangordeAsString) {
+    this.rangorde = rangordeAsString;
 
-    replaceSingleFormValue(this.storeOptions, rangorde ? rangorde : null);
+    replaceSingleFormValue(this.storeOptions, rangordeAsString ?? null);
 
     this.updateValidations();
 
     this.hasBeenFocused = true;
+  }
+
+  get mandaatLabel() {
+    return this.mandaat?.rangordeLabel;
   }
 }

--- a/app/components/verkiezingen/rangorde-input.hbs
+++ b/app/components/verkiezingen/rangorde-input.hbs
@@ -1,30 +1,10 @@
-<div>
-  <div class="order-input-as-string">
-    <AuButton
-      hideText={{true}}
-      @icon="chevron-up"
-      @skin="secondary"
-      class="order-input-as-string--minus"
-      @disabled={{this.isMinusDisabled}}
-      {{on "click" this.rangordeDown}}
+<div class="order-input-as-string">
+  {{#if this.mandaat}}
+    <RangordeDropdown
+      @selected={{this.rangorde}}
+      @placeholder={{this.rangordePlaceholder}}
+      @mandaatLabel={{this.mandaatLabel}}
+      @onNewRangorde={{this.onUpdateRangorde}}
     />
-    <AuInput
-      value={{this.rangorde}}
-      placeholder={{this.rangordePlaceholder}}
-      @warning={{this.inputWarningMessage}}
-      {{on "blur" this.onUpdateRangorde}}
-      {{on "keyup" this.onEnterInRangorde}}
-    />
-    <AuButton
-      hideText={{true}}
-      @skin="secondary"
-      @icon="chevron-down"
-      class="order-input-as-string--plus"
-      @disabled={{this.isPlusDisabled}}
-      {{on "click" this.rangordeUp}}
-    />
-  </div>
-  <AuHelpText @warning={{this.inputWarningMessage}}>
-    {{this.inputWarningMessage}}
-  </AuHelpText>
+  {{/if}}
 </div>

--- a/app/components/verkiezingen/rangorde-input.hbs
+++ b/app/components/verkiezingen/rangorde-input.hbs
@@ -12,7 +12,7 @@
       @selected={{this.rangorde}}
       @placeholder={{this.rangordePlaceholder}}
       @mandaatLabel={{this.mandaatLabel}}
-      @onNewRangorde={{this.onUpdateRangorde}}
+      @onNewRangorde={{this.setRangorde}}
     />
   {{/if}}
   <AuButton

--- a/app/components/verkiezingen/rangorde-input.hbs
+++ b/app/components/verkiezingen/rangorde-input.hbs
@@ -7,14 +7,12 @@
     @disabled={{this.isMinusDisabled}}
     {{on "click" this.rangordeDown}}
   />
-  {{#if this.mandaat}}
-    <RangordeDropdown
-      @selected={{this.rangorde}}
-      @placeholder={{this.rangordePlaceholder}}
-      @mandaatLabel={{this.mandaatLabel}}
-      @onNewRangorde={{this.setRangorde}}
-    />
-  {{/if}}
+  <RangordeDropdown
+    @selected={{this.rangorde}}
+    @placeholder={{this.rangordePlaceholder}}
+    @mandaatLabel={{this.mandaatLabel}}
+    @onNewRangorde={{this.setRangorde}}
+  />
   <AuButton
     hideText={{true}}
     @skin="secondary"

--- a/app/components/verkiezingen/rangorde-input.hbs
+++ b/app/components/verkiezingen/rangorde-input.hbs
@@ -1,4 +1,12 @@
 <div class="order-input-as-string">
+  <AuButton
+    hideText={{true}}
+    @icon="chevron-up"
+    @skin="secondary"
+    class="order-input-as-string--minus"
+    @disabled={{this.isMinusDisabled}}
+    {{on "click" this.rangordeDown}}
+  />
   {{#if this.mandaat}}
     <RangordeDropdown
       @selected={{this.rangorde}}
@@ -7,4 +15,12 @@
       @onNewRangorde={{this.onUpdateRangorde}}
     />
   {{/if}}
+  <AuButton
+    hideText={{true}}
+    @skin="secondary"
+    @icon="chevron-down"
+    class="order-input-as-string--plus"
+    @disabled={{this.isPlusDisabled}}
+    {{on "click" this.rangordeUp}}
+  />
 </div>

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -6,10 +6,9 @@ import { tracked } from '@glimmer/tracking';
 import { keepLatestTask, timeout } from 'ember-concurrency';
 import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
 import {
-  orderMandatarissenByRangorde,
+  getNextAvailableRangorde,
   rangordeNumberMapping,
   rangordeStringMapping,
-  rangordeStringToNumber,
 } from 'frontend-lmb/utils/rangorde';
 
 export default class VerkiezingenRangordeInputComponent extends Component {
@@ -100,19 +99,6 @@ export default class VerkiezingenRangordeInputComponent extends Component {
     });
   }
 
-  getNextAvailableRangorde() {
-    const sortedMandatarissen = orderMandatarissenByRangorde([
-      ...this.args.mandatarissen,
-    ]);
-    const lastNumber = rangordeStringToNumber(
-      sortedMandatarissen[sortedMandatarissen.length - 1].rangorde
-    );
-    if (lastNumber) {
-      return rangordeNumberMapping[lastNumber + 1];
-    }
-    return rangordeNumberMapping[1];
-  }
-
   @action
   onUpdateRangorde(rangordeAsString) {
     this.setRangorde(rangordeAsString);
@@ -125,7 +111,7 @@ export default class VerkiezingenRangordeInputComponent extends Component {
 
     if (this.rangordeInteger == null) {
       this.setRangorde(
-        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`,
+        `${getNextAvailableRangorde(this.args.mandatarissen)} ${this.mandaatLabel}`,
         true
       );
     } else {
@@ -140,7 +126,7 @@ export default class VerkiezingenRangordeInputComponent extends Component {
 
     if (this.rangordeInteger == null) {
       this.setRangorde(
-        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`,
+        `${getNextAvailableRangorde(this.args.mandatarissen)} ${this.mandaatLabel}`,
         true
       );
     } else {

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -5,12 +5,6 @@ import { tracked } from '@glimmer/tracking';
 
 import { keepLatestTask, timeout } from 'ember-concurrency';
 import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
-import {
-  orderMandatarissenByRangorde,
-  rangordeNumberMapping,
-  rangordeStringMapping,
-  rangordeStringToNumber,
-} from 'frontend-lmb/utils/rangorde';
 
 export default class VerkiezingenRangordeInputComponent extends Component {
   @tracked rangordePlaceholder;
@@ -19,10 +13,6 @@ export default class VerkiezingenRangordeInputComponent extends Component {
   constructor() {
     super(...arguments);
     this.setPlaceholder();
-  }
-
-  get rangordeInteger() {
-    return this.findOrderInString(this.args.mandataris.rangorde);
   }
 
   get rangorde() {
@@ -58,93 +48,14 @@ export default class VerkiezingenRangordeInputComponent extends Component {
     return this.mandaat?.rangordeLabel;
   }
 
-  findOrderInString(possibleString) {
-    if (!possibleString || typeof possibleString != 'string') {
-      return null;
-    }
-    let foundNumber = null;
-    Object.keys(rangordeStringMapping).forEach((key) => {
-      if (possibleString.startsWith(key)) {
-        foundNumber = rangordeStringMapping[key];
-      }
-    });
-    return foundNumber;
-  }
-
-  findFirstWordOfString(string) {
-    // eslint-disable-next-line no-useless-escape
-    const regex = new RegExp(/^([\w\-]+)/);
-    if (regex.test(string)) {
-      return `${string}`.match(regex);
-    }
-    return null;
-  }
-
-  get isMinusDisabled() {
-    return this.rangordeInteger <= 1;
-  }
-
-  get isPlusDisabled() {
-    return this.rangordeInteger >= Object.keys(rangordeStringMapping).length;
-  }
-
   getMandatarisWithRangorde(targetRangorde) {
     return this.args.mandatarissen.find((mandataris) => {
       return mandataris.rangorde === targetRangorde;
     });
   }
 
-  getNextAvailableRangorde() {
-    const sortedMandatarissen = orderMandatarissenByRangorde([
-      ...this.args.mandatarissen,
-    ]);
-    const lastNumber = rangordeStringToNumber(
-      sortedMandatarissen[sortedMandatarissen.length - 1].rangorde
-    );
-    if (lastNumber) {
-      return rangordeNumberMapping[lastNumber + 1];
-    }
-    return rangordeNumberMapping[1];
-  }
-
   @action
   onUpdateRangorde(rangordeAsString) {
     this.setRangorde(rangordeAsString);
-  }
-
-  @action
-  async rangordeUp() {
-    const currentNumber = this.rangordeInteger || 0;
-    const newOrder = rangordeNumberMapping[currentNumber + 1];
-
-    if (this.rangordeInteger == null) {
-      this.setRangorde(
-        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`
-      );
-    } else {
-      const currentOrder = rangordeNumberMapping[currentNumber];
-      this.setRangorde(this.rangorde.replace(currentOrder, newOrder));
-    }
-  }
-  @action
-  async rangordeDown() {
-    const currentNumber = this.rangordeInteger || 2;
-    const newOrder = rangordeNumberMapping[currentNumber - 1];
-
-    if (this.rangordeInteger == null) {
-      this.setRangorde(
-        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`
-      );
-    } else {
-      const currentOrder = rangordeNumberMapping[currentNumber];
-      this.setRangorde(this.rangorde.replace(currentOrder, newOrder));
-    }
-  }
-
-  @action
-  onEnterInRangorde(event) {
-    if (event.key === 'Enter') {
-      this.setRangorde(event.currentTarget.value);
-    }
   }
 }

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -55,6 +55,7 @@ export default class VerkiezingenRangordeInputComponent extends Component {
     }
   );
 
+  @action
   setRangorde(value, switchWithPrevious = false) {
     this.updateMandatarisRangorde.perform(value, switchWithPrevious);
   }
@@ -97,11 +98,6 @@ export default class VerkiezingenRangordeInputComponent extends Component {
     return this.args.mandatarissen.find((mandataris) => {
       return mandataris.rangorde === targetRangorde;
     });
-  }
-
-  @action
-  onUpdateRangorde(rangordeAsString) {
-    this.setRangorde(rangordeAsString);
   }
 
   @action

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -34,24 +34,30 @@ export default class VerkiezingenRangordeInputComponent extends Component {
     this.rangordePlaceholder = `Selecteer een rangorde, bv. “Eerste ${this.mandaat.rangordeLabel}”`;
   }
 
-  updateMandatarisRangorde = keepLatestTask(async (value) => {
-    const oldRangorde = this.args.mandataris.rangorde;
-    const newRangorde = value;
-    const previousHolder = this.getMandatarisWithRangorde(newRangorde);
-    this.args.mandataris.rangorde = newRangorde;
+  updateMandatarisRangorde = keepLatestTask(
+    async (value, switchWithPrevious) => {
+      const oldRangorde = this.args.mandataris.rangorde;
+      const newRangorde = value;
+      const previousHolder = this.getMandatarisWithRangorde(newRangorde);
+      this.args.mandataris.rangorde = newRangorde;
 
-    const promises = [this.args.mandataris.save()];
+      const promises = [this.args.mandataris.save()];
 
-    if (previousHolder && previousHolder !== this.args.mandataris) {
-      previousHolder.rangorde = oldRangorde;
-      promises.push(previousHolder.save());
+      if (
+        switchWithPrevious &&
+        previousHolder &&
+        previousHolder !== this.args.mandataris
+      ) {
+        previousHolder.rangorde = oldRangorde;
+        promises.push(previousHolder.save());
+      }
+      await Promise.all(promises);
+      await timeout(SEARCH_TIMEOUT);
     }
-    await Promise.all(promises);
-    await timeout(SEARCH_TIMEOUT);
-  });
+  );
 
-  setRangorde(value) {
-    this.updateMandatarisRangorde.perform(value);
+  setRangorde(value, switchWithPrevious = false) {
+    this.updateMandatarisRangorde.perform(value, switchWithPrevious);
   }
 
   get mandaatLabel() {
@@ -119,11 +125,12 @@ export default class VerkiezingenRangordeInputComponent extends Component {
 
     if (this.rangordeInteger == null) {
       this.setRangorde(
-        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`
+        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`,
+        true
       );
     } else {
       const currentOrder = rangordeNumberMapping[currentNumber];
-      this.setRangorde(this.rangorde.replace(currentOrder, newOrder));
+      this.setRangorde(this.rangorde.replace(currentOrder, newOrder), true);
     }
   }
   @action
@@ -133,18 +140,12 @@ export default class VerkiezingenRangordeInputComponent extends Component {
 
     if (this.rangordeInteger == null) {
       this.setRangorde(
-        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`
+        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`,
+        true
       );
     } else {
       const currentOrder = rangordeNumberMapping[currentNumber];
-      this.setRangorde(this.rangorde.replace(currentOrder, newOrder));
-    }
-  }
-
-  @action
-  onEnterInRangorde(event) {
-    if (event.key === 'Enter') {
-      this.setRangorde(event.currentTarget.value);
+      this.setRangorde(this.rangorde.replace(currentOrder, newOrder), true);
     }
   }
 }

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -6,6 +6,7 @@ import { tracked } from '@glimmer/tracking';
 import { keepLatestTask, timeout } from 'ember-concurrency';
 import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
 import {
+  findOrderInString,
   getNextAvailableRangorde,
   rangordeNumberMapping,
   rangordeStringMapping,
@@ -21,7 +22,7 @@ export default class VerkiezingenRangordeInputComponent extends Component {
   }
 
   get rangordeInteger() {
-    return this.findOrderInString(this.args.mandataris.rangorde);
+    return findOrderInString(this.args.mandataris.rangorde);
   }
 
   get rangorde() {
@@ -62,28 +63,6 @@ export default class VerkiezingenRangordeInputComponent extends Component {
 
   get mandaatLabel() {
     return this.mandaat?.rangordeLabel;
-  }
-
-  findOrderInString(possibleString) {
-    if (!possibleString || typeof possibleString != 'string') {
-      return null;
-    }
-    let foundNumber = null;
-    Object.keys(rangordeStringMapping).forEach((key) => {
-      if (possibleString.startsWith(key)) {
-        foundNumber = rangordeStringMapping[key];
-      }
-    });
-    return foundNumber;
-  }
-
-  findFirstWordOfString(string) {
-    // eslint-disable-next-line no-useless-escape
-    const regex = new RegExp(/^([\w\-]+)/);
-    if (regex.test(string)) {
-      return `${string}`.match(regex);
-    }
-    return null;
   }
 
   get isMinusDisabled() {

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -7,6 +7,7 @@ import { keepLatestTask, timeout } from 'ember-concurrency';
 import { SEARCH_TIMEOUT } from 'frontend-lmb/utils/constants';
 import {
   findOrderInString,
+  getMandatarisForRangorde,
   getNextAvailableRangorde,
   rangordeNumberMapping,
   rangordeStringMapping,
@@ -38,7 +39,10 @@ export default class VerkiezingenRangordeInputComponent extends Component {
     async (value, switchWithPrevious) => {
       const oldRangorde = this.args.mandataris.rangorde;
       const newRangorde = value;
-      const previousHolder = this.getMandatarisWithRangorde(newRangorde);
+      const previousHolder = getMandatarisForRangorde(
+        this.args.mandatarissen,
+        newRangorde
+      );
       this.args.mandataris.rangorde = newRangorde;
 
       const promises = [this.args.mandataris.save()];
@@ -71,12 +75,6 @@ export default class VerkiezingenRangordeInputComponent extends Component {
 
   get isPlusDisabled() {
     return this.rangordeInteger >= Object.keys(rangordeStringMapping).length;
-  }
-
-  getMandatarisWithRangorde(targetRangorde) {
-    return this.args.mandatarissen.find((mandataris) => {
-      return mandataris.rangorde === targetRangorde;
-    });
   }
 
   @action

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -14,19 +14,11 @@ import {
 
 export default class VerkiezingenRangordeInputComponent extends Component {
   @tracked rangordePlaceholder;
+  @tracked mandaat;
 
   constructor() {
     super(...arguments);
     this.setPlaceholder();
-  }
-
-  get inputWarningMessage() {
-    const order = this.rangordeInteger;
-    if (order == null) {
-      return 'Opgelet! Dit is geen gekende rangorde!';
-    } else {
-      return null;
-    }
   }
 
   get rangordeInteger() {
@@ -38,8 +30,8 @@ export default class VerkiezingenRangordeInputComponent extends Component {
   }
 
   async setPlaceholder() {
-    const mandaat = await this.args.mandataris.bekleedt;
-    this.rangordePlaceholder = `Vul de rangorde in, bv. “Eerste ${mandaat.rangordeLabel}”`;
+    this.mandaat = await this.args.mandataris.bekleedt;
+    this.rangordePlaceholder = `Vul de rangorde in, bv. “Eerste ${this.mandaat.rangordeLabel}”`;
   }
 
   updateMandatarisRangorde = keepLatestTask(async (value) => {
@@ -62,9 +54,8 @@ export default class VerkiezingenRangordeInputComponent extends Component {
     this.updateMandatarisRangorde.perform(value);
   }
 
-  async getMandaatLabel() {
-    const mandaat = await this.args.mandataris.get('bekleedt');
-    return mandaat?.rangordeLabel;
+  get mandaatLabel() {
+    return this.mandaat?.rangordeLabel;
   }
 
   findOrderInString(possibleString) {
@@ -117,8 +108,8 @@ export default class VerkiezingenRangordeInputComponent extends Component {
   }
 
   @action
-  onUpdateRangorde(event) {
-    this.setRangorde(event.currentTarget.value);
+  onUpdateRangorde(rangordeAsString) {
+    this.setRangorde(rangordeAsString);
   }
 
   @action
@@ -128,7 +119,7 @@ export default class VerkiezingenRangordeInputComponent extends Component {
 
     if (this.rangordeInteger == null) {
       this.setRangorde(
-        `${this.getNextAvailableRangorde()} ${await this.getMandaatLabel()}`
+        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`
       );
     } else {
       const currentOrder = rangordeNumberMapping[currentNumber];
@@ -142,7 +133,7 @@ export default class VerkiezingenRangordeInputComponent extends Component {
 
     if (this.rangordeInteger == null) {
       this.setRangorde(
-        `${this.getNextAvailableRangorde()} ${await this.getMandaatLabel()}`
+        `${this.getNextAvailableRangorde()} ${this.mandaatLabel}`
       );
     } else {
       const currentOrder = rangordeNumberMapping[currentNumber];

--- a/app/components/verkiezingen/rangorde-input.js
+++ b/app/components/verkiezingen/rangorde-input.js
@@ -31,7 +31,7 @@ export default class VerkiezingenRangordeInputComponent extends Component {
 
   async setPlaceholder() {
     this.mandaat = await this.args.mandataris.bekleedt;
-    this.rangordePlaceholder = `Vul de rangorde in, bv. “Eerste ${this.mandaat.rangordeLabel}”`;
+    this.rangordePlaceholder = `Selecteer een rangorde, bv. “Eerste ${this.mandaat.rangordeLabel}”`;
   }
 
   updateMandatarisRangorde = keepLatestTask(async (value) => {

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -51,14 +51,7 @@ export default class EditRangordeController extends Controller {
   }
 
   get tooltipText() {
-    if (this.openModalDisabled) {
-      return 'Er werden nog geen wijzigingen gevonden.';
-    }
-
-    if (this.model.isEditingInPast) {
-      return 'Rangorde kan enkel gecorrigeerd worden voor mandatarissen in het verleden.';
-    }
-    return null;
+    return 'Er werden nog geen wijzigingen gevonden.';
   }
 
   get confirmDisabled() {

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -51,7 +51,14 @@ export default class EditRangordeController extends Controller {
   }
 
   get tooltipText() {
-    return 'Er werden nog geen wijzigingen gevonden.';
+    if (this.openModalDisabled) {
+      return 'Er werden nog geen wijzigingen gevonden.';
+    }
+
+    if (this.model.isEditingInPast) {
+      return 'Rangorde kan enkel gecorrigeerd worden voor mandatarissen in het verleden.';
+    }
+    return null;
   }
 
   get confirmDisabled() {

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -6,6 +6,7 @@ import { endOfDay } from 'frontend-lmb/utils/date-manipulation';
 
 export default class EditRangordeRoute extends Route {
   @service store;
+  @service bestuursperioden;
   @service('mandatarissen') mandatarissenService;
 
   queryParams = {
@@ -37,11 +38,17 @@ export default class EditRangordeRoute extends Route {
       return { mandataris: mandataris, rangorde: mandataris.rangorde };
     });
 
+    const currentBestuursperiode =
+      await this.bestuursperioden.getCurrentBestuursperiode();
+    const isEditingInPast =
+      parentModel.selectedBestuursperiode.id !== currentBestuursperiode.id;
+
     return {
       bestuursorgaan: parentModel.bestuursorgaan,
       bestuursorgaanInTijd,
       selectedBestuursperiode: parentModel.selectedBestuursperiode,
       mandatarisStruct,
+      isEditingInPast,
     };
   }
 

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -6,7 +6,6 @@ import { endOfDay } from 'frontend-lmb/utils/date-manipulation';
 
 export default class EditRangordeRoute extends Route {
   @service store;
-  @service bestuursperioden;
   @service('mandatarissen') mandatarissenService;
 
   queryParams = {
@@ -38,17 +37,11 @@ export default class EditRangordeRoute extends Route {
       return { mandataris: mandataris, rangorde: mandataris.rangorde };
     });
 
-    const currentBestuursperiode =
-      await this.bestuursperioden.getCurrentBestuursperiode();
-    const isEditingInPast =
-      parentModel.selectedBestuursperiode.id !== currentBestuursperiode.id;
-
     return {
       bestuursorgaan: parentModel.bestuursorgaan,
       bestuursorgaanInTijd,
       selectedBestuursperiode: parentModel.selectedBestuursperiode,
       mandatarisStruct,
-      isEditingInPast,
     };
   }
 

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -26,7 +26,6 @@ export default class EditRangordeRoute extends Route {
         await this.mandatarissenService.getActiveMandatarissenAtTime(
           params,
           bestuursorgaanInTijd,
-          parentModel.selectedBestuursperiode,
           endOfDay(params.date)
         );
     }

--- a/app/services/mandataris.js
+++ b/app/services/mandataris.js
@@ -15,7 +15,7 @@ export default class MandatarisService extends Service {
 
   async getOverlappingMandate(mandataris, person, endDate = null) {
     const mandate = await mandataris.bekleedt;
-    const mandatarisses = await this.store.query('mandataris', {
+    const mandatarissen = await this.store.query('mandataris', {
       filter: {
         bekleedt: {
           id: mandate.id,
@@ -26,7 +26,7 @@ export default class MandatarisService extends Service {
       },
     });
 
-    const toCheck = mandatarisses.slice();
+    const toCheck = mandatarissen.slice();
     let current;
     const start = moment(mandataris.start);
     const end = moment(endDate || mandataris.einde);
@@ -98,7 +98,6 @@ export default class MandatarisService extends Service {
 
   async createNewProps(mandataris, overwrites) {
     return {
-      rangorde: overwrites.rangorde ?? mandataris.rangorde,
       start: overwrites.start ?? mandataris.start,
       einde: overwrites.einde ?? mandataris.einde,
       bekleedt: overwrites.bekleedt ?? (await mandataris.bekleedt),

--- a/app/services/mandatarissen.js
+++ b/app/services/mandatarissen.js
@@ -8,24 +8,16 @@ export default class MandatarissenService extends Service {
   @service bestuursperioden;
   @service toaster;
 
-  async getActiveMandatarissenAtTime(
-    params,
-    bestuursorgaanInTijd,
-    bestuursperiode,
-    date
-  ) {
+  async getActiveMandatarissenAtTime(params, bestuursorgaanInTijd, date) {
     let mandatarissen = await this.getMandatarissen(
       params,
       bestuursorgaanInTijd
     );
-    const isCurrentBestuursperiode =
-      this.bestuursperioden.isCurrentPeriod(bestuursperiode);
-    if (isCurrentBestuursperiode) {
+    if (date) {
       return mandatarissen.filter((mandataris) => {
         return mandataris.isActiveAt(date);
       });
     }
-    return mandatarissen;
   }
 
   async getMandatarissen(params, bestuursorgaanInTijd) {

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -429,3 +429,7 @@ main .au-c-main-container__content .au-u-wide-on-print {
   display: grid;
   grid-template-columns: 1fr auto;
 }
+
+.power-select--min-width {
+  min-width: 20rem;
+}

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -14,7 +14,7 @@
   </Group>
   <Group>
     <Shared::Tooltip
-      @showTooltip={{this.tooltipText}}
+      @showTooltip={{this.openModalDisabled}}
       @tooltipText={{this.tooltipText}}
     >
       <AuButton
@@ -25,15 +25,9 @@
       >
         Corrigeer rangorde
       </AuButton>
-    </Shared::Tooltip>
-
-    <Shared::Tooltip
-      @showTooltip={{this.tooltipText}}
-      @tooltipText={{this.tooltipText}}
-    >
       <AuButton
         {{on "click" this.startChangeRangorde}}
-        @disabled={{or this.openModalDisabled this.model.isEditingInPast}}
+        @disabled={{this.openModalDisabled}}
       >
         Wijzig rangorde
       </AuButton>

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -14,7 +14,7 @@
   </Group>
   <Group>
     <Shared::Tooltip
-      @showTooltip={{this.openModalDisabled}}
+      @showTooltip={{this.tooltipText}}
       @tooltipText={{this.tooltipText}}
     >
       <AuButton
@@ -25,9 +25,15 @@
       >
         Corrigeer rangorde
       </AuButton>
+    </Shared::Tooltip>
+
+    <Shared::Tooltip
+      @showTooltip={{this.tooltipText}}
+      @tooltipText={{this.tooltipText}}
+    >
       <AuButton
         {{on "click" this.startChangeRangorde}}
-        @disabled={{this.openModalDisabled}}
+        @disabled={{or this.openModalDisabled this.model.isEditingInPast}}
       >
         Wijzig rangorde
       </AuButton>

--- a/app/utils/rangorde.js
+++ b/app/utils/rangorde.js
@@ -236,3 +236,9 @@ export const findOrderInString = (possibleString) => {
   });
   return foundNumber;
 };
+
+export const getMandatarisForRangorde = (mandatarissen, targetRangorde) => {
+  return mandatarissen.find((mandatarisStruct) => {
+    return mandatarisStruct.rangorde === targetRangorde;
+  });
+};

--- a/app/utils/rangorde.js
+++ b/app/utils/rangorde.js
@@ -212,3 +212,14 @@ const fallbackSortByOtherIVOrgans = (a, b, allMandatarissenInIv) => {
   }
   return rankA - rankB;
 };
+
+export const getNextAvailableRangorde = (mandatarissen) => {
+  const sortedMandatarissen = orderMandatarissenByRangorde([mandatarissen]);
+  const lastNumber = rangordeStringToNumber(
+    sortedMandatarissen[sortedMandatarissen.length - 1].rangorde
+  );
+  if (lastNumber) {
+    return rangordeNumberMapping[lastNumber + 1];
+  }
+  return rangordeNumberMapping[1];
+};

--- a/app/utils/rangorde.js
+++ b/app/utils/rangorde.js
@@ -223,3 +223,16 @@ export const getNextAvailableRangorde = (mandatarissen) => {
   }
   return rangordeNumberMapping[1];
 };
+
+export const findOrderInString = (possibleString) => {
+  if (!possibleString || typeof possibleString != 'string') {
+    return null;
+  }
+  let foundNumber = null;
+  Object.keys(rangordeStringMapping).forEach((key) => {
+    if (possibleString.startsWith(key)) {
+      foundNumber = rangordeStringMapping[key];
+    }
+  });
+  return foundNumber;
+};

--- a/tests/integration/components/rangorde-dropdown-test.js
+++ b/tests/integration/components/rangorde-dropdown-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | rangorde-dropdown', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<RangordeDropdown />`);
+
+    assert.dom().hasText('');
+
+    // Template block usage:
+    await render(hbs`<RangordeDropdown>
+  template block text
+</RangordeDropdown>`);
+
+    assert.dom().hasText('template block text');
+  });
+});


### PR DESCRIPTION
## Description

Instead of a text input field we want the rangorde to be shown as a dropdown with the options 1-...100 so the user can only select a valid rangorde. The up and down arrows stay visible next to the dropdown so they can go up and down with automatic reordering of the mandataris with rangorde.

## How to test

Do these test in edit-rangorde (organen) and in the IV page

1. clear a rangorde with the dropdown
2. assign a rangorde through the dropdown
3.  use the up/down arrows to change the rangorde value (see that the previous rangorde value is being replaced)
4. can set a duplicate rangorde by using the dropdown (not the up/down arrows)

## Attachements

**On IV page**
![image](https://github.com/user-attachments/assets/811274a4-0925-45e2-855b-ba5af12b3e98)

**In the mandataris form**
![image](https://github.com/user-attachments/assets/73488183-7b28-4576-a168-9b1541b21b7c)

**On the edit-rangorde page**
![image](https://github.com/user-attachments/assets/2e5487a8-1a7c-4173-a75b-4d75ce4546b7)
