### PR TITLE
lmb-1428 | Notification for mandataris that is more than 10 days active

### DIFF
--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -3,10 +3,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
-import {
-  MANDATARIS_DRAFT_PUBLICATION_STATE,
-  MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE,
-} from 'frontend-lmb/utils/well-known-uris';
+import { MANDATARIS_DRAFT_PUBLICATION_STATE } from 'frontend-lmb/utils/well-known-uris';
 
 import { restartableTask, task, timeout } from 'ember-concurrency';
 

--- a/app/components/mandatarissen/mandataris/publication-status-selector.js
+++ b/app/components/mandatarissen/mandataris/publication-status-selector.js
@@ -95,14 +95,6 @@ export default class MandatarissenMandatarisPublicationStatusSelectorComponent e
   @action
   async setStatus(publicationStatus) {
     this.mandataris.publicationStatus = publicationStatus;
-    if (
-      publicationStatus?.uri === MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE
-    ) {
-      this.args.mandataris.effectiefAt = new Date();
-    }
-    if (publicationStatus?.uri === MANDATARIS_DRAFT_PUBLICATION_STATE) {
-      this.args.mandataris.effectiefAt = null;
-    }
 
     await this.mandataris.save();
     if (this.args.onUpdate) {

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -17,7 +17,6 @@ export default class MandatarisModel extends Model {
   @attr uri;
   @attr('string') linkToBesluit;
   @attr('datetime') modified;
-  @attr('datetime') effectiefAt;
 
   @belongsTo('mandaat', { async: true, inverse: 'bekleedDoor' })
   bekleedt;

--- a/app/utils/build-new-mandataris-source-ttl.js
+++ b/app/utils/build-new-mandataris-source-ttl.js
@@ -10,7 +10,6 @@ export const buildNewMandatarisSourceTtl = async (
 ) => {
   const nietBekrachtigdTriple = `
     <${instanceUri}> <http://lblod.data.gift/vocabularies/lmb/hasPublicationStatus> <${MANDATARIS_NIET_BEKRACHTIGD_PUBLICATION_STATE}>.
-    <${instanceUri}> <http://lblod.data.gift/vocabularies/lmb/effectiefAt> "${new Date().toJSON()}"^^<http://www.w3.org/2001/XMLSchema#dateTime>.
   `;
   if (!personId) {
     return nietBekrachtigdTriple;

--- a/tests/integration/components/validatie-table-test.js
+++ b/tests/integration/components/validatie-table-test.js
@@ -27,7 +27,6 @@ module('Integration | Component | validatie-table', function (hooks) {
       uri: 'http://example.com/mandataris/1',
       linkToBesluit: 'http://example.com/besluit/1',
       modified: new Date(),
-      effectiefAt: new Date(),
     });
     this.set('instance', mandataris);
 


### PR DESCRIPTION
## Description

We want to change the logic for notifications. Before 10 days after effectief (niet-bekrachtigd publication status) a notification was send (this was disabled). We do want these notifications but when a mandataris is active for more than 10 days. (start date + 10 days  > today)

## How to test

- see mandataris service

## Links to other PR's

- [mandataris](https://github.com/lblod/mandataris-service/pull/108)
- [app](https://github.com/lblod/app-lokaal-mandatenbeheer/pull/398)
