### PR TITLE
basic timeline for history

### DIFF
--- a/app/components/mandatarissen/timeline-card.hbs
+++ b/app/components/mandatarissen/timeline-card.hbs
@@ -1,0 +1,55 @@
+<div class="event {{if @event.selected 'selected'}}">
+  <AuButton
+    class="event-date"
+    @skin="naked"
+    {{on "click" (fn this.selectEvent @event)}}
+  >
+    <div class="event-marker"></div>
+    <div class="event-date-value">{{moment-format
+        @event.date
+        "DD-MM-YYYY"
+      }}</div>
+  </AuButton>
+  <div class="event-connector"></div>
+  {{#if @event.selected}}
+    <AuPill @skin="link" class="selected-pill">Geselecteerde Situatie</AuPill>
+  {{/if}}
+  <AuPanel
+    class="event-panel {{if @event.selected 'selected'}}"
+    {{on "click" (fn this.selectEvent @event)}}
+  >
+
+    <div class="au-u-flex au-u-flex--spaced-tiny">
+      <AuPill>{{@event.type}}</AuPill>
+      {{#if @event.active}}
+        <AuPill @skin="success">Actief</AuPill>
+      {{/if}}
+    </div>
+
+    <div
+      class="provenance au-u-muted au-u-italic au-u-margin-top-tiny au-u-margin-bottom-tiny"
+    >
+      {{#if (eq @event.type "Einde")}}
+        <p>Dit mandaat is beëindigd</p>
+      {{else}}
+        <p>
+          Bewerkt op
+          {{#if this.editedAt}}
+            {{moment-format this.editedAt "DD-MM-YY HH:mm"}}
+          {{else}}
+            Onbekend
+          {{/if}}
+        </p>
+        <p>door
+          {{#if this.editor}}
+            {{this.editor.voornaam}}
+            {{this.editor.achternaam}}
+          {{else}}
+            Onbekend
+          {{/if}}
+        </p>
+      {{/if}}
+    </div>
+    {{yield}}
+  </AuPanel>
+</div>

--- a/app/components/mandatarissen/timeline-card.hbs
+++ b/app/components/mandatarissen/timeline-card.hbs
@@ -33,7 +33,7 @@
         <p>Dit mandaat is beëindigd</p>
       {{else}}
         <p>
-          Bewerkt op
+          {{if (eq @event.type "Start") "Aangemaakt op" "Bewerkt op"}}
           {{#if this.editedAt}}
             {{moment-format this.editedAt "DD-MM-YY HH:mm"}}
           {{else}}

--- a/app/components/mandatarissen/timeline-card.js
+++ b/app/components/mandatarissen/timeline-card.js
@@ -1,0 +1,24 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class MandatarissenTimelineCard extends Component {
+  @service
+  router;
+
+  get editor() {
+    return this.args.event.corrections?.[0]?.creator;
+  }
+
+  get editedAt() {
+    return this.args.event.corrections?.[0]?.issued;
+  }
+
+  @action
+  selectEvent(event) {
+    this.router.transitionTo(
+      'mandatarissen.persoon.mandataris',
+      event.mandataris.id
+    );
+  }
+}

--- a/app/components/mandatarissen/timeline.hbs
+++ b/app/components/mandatarissen/timeline.hbs
@@ -23,47 +23,7 @@
         <div class="arrow-start"></div>
         <div class="arrow">
           {{#each this.timelineEvents as |event index|}}
-            <div class="event {{if event.selected 'selected'}}">
-              <AuButton
-                class="event-date"
-                @skin="naked"
-                {{on "click" (fn this.selectEvent event)}}
-              >
-                <div class="event-marker"></div>
-                <div class="event-date-value">{{moment-format
-                    event.date
-                    "DD-MM-YYYY"
-                  }}</div>
-              </AuButton>
-              <div class="event-connector"></div>
-              {{#if event.selected}}
-                <AuPill @skin="link" class="selected-pill">Geselecteerde
-                  Situatie</AuPill>
-              {{/if}}
-              <AuPanel
-                class="event-panel {{if event.selected 'selected'}}"
-                {{on "click" (fn this.selectEvent event)}}
-              >
-
-                <div class="au-u-flex au-u-flex--spaced-tiny">
-                  <AuPill>{{event.type}}</AuPill>
-                  {{#if event.active}}
-                    <AuPill @skin="success">Actief</AuPill>
-                  {{/if}}
-                </div>
-
-                <div
-                  class="provenance au-u-muted au-u-italic au-u-margin-top-tiny au-u-margin-bottom-tiny"
-                >
-                  {{#if (eq event.type "Einde")}}
-                    <p>Dit mandaat is beëindigd</p>
-                  {{else}}
-                    <p>Bewerkt op dd-mm-yyyy hh:mm</p>
-                    <p>door Jos met de HeleLangenaam</p>
-                  {{/if}}
-                </div>
-              </AuPanel>
-            </div>
+            <Mandatarissen::TimelineCard @event={{event}} @index={{index}} />
             <div class="spacer {{if event.last 'last'}}"></div>
           {{/each}}
         </div>

--- a/app/components/mandatarissen/timeline.hbs
+++ b/app/components/mandatarissen/timeline.hbs
@@ -1,0 +1,82 @@
+{{#if this.isFeatureEnabled}}
+  <div class="au-o-box">
+    <AuHeading @level="3" @skin="4">
+      Historiek
+    </AuHeading>
+    <ul class="au-c-list-vertical">
+      <Mandatarissen::History
+        @mandataris={{@mandataris}}
+        @mandatarissen={{@mandatarissen}}
+        @form={{@form}}
+      />
+    </ul>
+    <div class="timeline">
+      <div class="time-notations au-u-flex au-u-flex--between">
+        <div class="au-u-bold">
+          Start Mandaat
+        </div>
+        <div class="au-u-bold">
+          Einde Mandaat
+        </div>
+      </div>
+      <div class="arrow">
+        <div class="arrow-start"></div>
+        {{#each this.timelineEvents as |event index|}}
+          <div class="event {{if event.selected 'selected'}}">
+            <AuButton
+              class="event-date"
+              @skin="naked"
+              {{on "click" (fn this.selectEvent event)}}
+            >
+              <div class="event-marker"></div>
+              <div class="event-date-value">{{moment-format
+                  event.date
+                  "DD-MM-YYYY"
+                }}</div>
+            </AuButton>
+            <div class="event-connector"></div>
+            {{#if event.selected}}
+              <AuPill @skin="link" class="selected-pill">Geselecteerde Situatie</AuPill>
+            {{/if}}
+            <AuPanel
+              class="event-panel {{if event.selected 'selected'}}"
+              {{on "click" (fn this.selectEvent event)}}
+            >
+
+              <div class="au-u-flex au-u-flex--spaced-tiny">
+                <AuPill>{{event.type}}</AuPill>
+                {{#if event.active}}
+                  <AuPill @skin="success">Actief</AuPill>
+                {{/if}}
+              </div>
+
+              <div
+                class="provenance au-u-muted au-u-italic au-u-margin-top-tiny au-u-margin-bottom-tiny"
+              >
+                <p>Bewerkt op dd-mm-yyyy hh:mm</p>
+                <p>door Jos met de HeleLangenaam</p>
+              </div>
+            </AuPanel>
+          </div>
+          <div class="spacer {{if event.last 'last'}}"></div>
+        {{/each}}
+        <div class="arrow-end"></div>
+      </div>
+    </div>
+  </div>
+{{else}}
+  <div class="au-o-box">
+    <AuHeading @level="3" @skin="4">
+      Historiek
+    </AuHeading>
+
+    <ul class="au-c-list-vertical">
+      <Mandatarissen::History
+        @mandataris={{@mandataris}}
+        @mandatarissen={{@mandatarissen}}
+        @form={{@form}}
+        @history={{@history}}
+      />
+    </ul>
+  </div>
+{{/if}}

--- a/app/components/mandatarissen/timeline.hbs
+++ b/app/components/mandatarissen/timeline.hbs
@@ -7,6 +7,7 @@
       <Mandatarissen::History
         @mandataris={{@mandataris}}
         @mandatarissen={{@mandatarissen}}
+        @history={{@history}}
         @form={{@form}}
       />
     </ul>

--- a/app/components/mandatarissen/timeline.hbs
+++ b/app/components/mandatarissen/timeline.hbs
@@ -19,47 +19,54 @@
           Einde Mandaat
         </div>
       </div>
-      <div class="arrow">
+      <div class="au-u-flex">
         <div class="arrow-start"></div>
-        {{#each this.timelineEvents as |event index|}}
-          <div class="event {{if event.selected 'selected'}}">
-            <AuButton
-              class="event-date"
-              @skin="naked"
-              {{on "click" (fn this.selectEvent event)}}
-            >
-              <div class="event-marker"></div>
-              <div class="event-date-value">{{moment-format
-                  event.date
-                  "DD-MM-YYYY"
-                }}</div>
-            </AuButton>
-            <div class="event-connector"></div>
-            {{#if event.selected}}
-              <AuPill @skin="link" class="selected-pill">Geselecteerde Situatie</AuPill>
-            {{/if}}
-            <AuPanel
-              class="event-panel {{if event.selected 'selected'}}"
-              {{on "click" (fn this.selectEvent event)}}
-            >
-
-              <div class="au-u-flex au-u-flex--spaced-tiny">
-                <AuPill>{{event.type}}</AuPill>
-                {{#if event.active}}
-                  <AuPill @skin="success">Actief</AuPill>
-                {{/if}}
-              </div>
-
-              <div
-                class="provenance au-u-muted au-u-italic au-u-margin-top-tiny au-u-margin-bottom-tiny"
+        <div class="arrow">
+          {{#each this.timelineEvents as |event index|}}
+            <div class="event {{if event.selected 'selected'}}">
+              <AuButton
+                class="event-date"
+                @skin="naked"
+                {{on "click" (fn this.selectEvent event)}}
               >
-                <p>Bewerkt op dd-mm-yyyy hh:mm</p>
-                <p>door Jos met de HeleLangenaam</p>
-              </div>
-            </AuPanel>
-          </div>
-          <div class="spacer {{if event.last 'last'}}"></div>
-        {{/each}}
+                <div class="event-marker"></div>
+                <div class="event-date-value">{{moment-format
+                    event.date
+                    "DD-MM-YYYY"
+                  }}</div>
+              </AuButton>
+              <div class="event-connector"></div>
+              {{#if event.selected}}
+                <AuPill @skin="link" class="selected-pill">Geselecteerde
+                  Situatie</AuPill>
+              {{/if}}
+              <AuPanel
+                class="event-panel {{if event.selected 'selected'}}"
+                {{on "click" (fn this.selectEvent event)}}
+              >
+
+                <div class="au-u-flex au-u-flex--spaced-tiny">
+                  <AuPill>{{event.type}}</AuPill>
+                  {{#if event.active}}
+                    <AuPill @skin="success">Actief</AuPill>
+                  {{/if}}
+                </div>
+
+                <div
+                  class="provenance au-u-muted au-u-italic au-u-margin-top-tiny au-u-margin-bottom-tiny"
+                >
+                  {{#if (eq event.type "Einde")}}
+                    <p>Dit mandaat is beëindigd</p>
+                  {{else}}
+                    <p>Bewerkt op dd-mm-yyyy hh:mm</p>
+                    <p>door Jos met de HeleLangenaam</p>
+                  {{/if}}
+                </div>
+              </AuPanel>
+            </div>
+            <div class="spacer {{if event.last 'last'}}"></div>
+          {{/each}}
+        </div>
         <div class="arrow-end"></div>
       </div>
     </div>

--- a/app/components/mandatarissen/timeline.hbs
+++ b/app/components/mandatarissen/timeline.hbs
@@ -24,7 +24,13 @@
         <div class="arrow">
           {{#each this.timelineEvents as |event index|}}
             <Mandatarissen::TimelineCard @event={{event}} @index={{index}} />
-            <div class="spacer {{if event.last 'last'}}"></div>
+            <div
+              class="spacer
+                {{if
+                  (and (gt this.timelineEvents.length 1) event.last)
+                  'last'
+                }}"
+            ></div>
           {{/each}}
         </div>
         <div class="arrow-end"></div>

--- a/app/components/mandatarissen/timeline.js
+++ b/app/components/mandatarissen/timeline.js
@@ -7,12 +7,11 @@ export default class MandatarissenTimeline extends Component {
   @service store;
 
   get isFeatureEnabled() {
-    return this.features.isEnabled('shacl-report');
+    return this.features.isEnabled('timeline');
   }
 
   get timelineEvents() {
-    const mandatarissen = this.args.mandatarissen;
-    const sortedMandatarissen = mandatarissen.sortBy('start');
+    const sortedMandatarissen = this.args.mandatarissen.sortBy('start');
     const events = sortedMandatarissen.map((mandataris, index) => {
       return {
         type: index > 0 ? 'Wijziging' : 'Start',

--- a/app/components/mandatarissen/timeline.js
+++ b/app/components/mandatarissen/timeline.js
@@ -85,7 +85,7 @@ export default class MandatarissenTimeline extends Component {
     const sortedMandatarissen = mandatarissen.sortBy('start');
     const events = sortedMandatarissen.map((mandataris, index) => {
       return {
-        type: index > 0 ? 'Wijziging' : 'Aanmaak',
+        type: index > 0 ? 'Wijziging' : 'Start',
         active: mandataris.isCurrentlyActive,
         date: mandataris.start,
         mandataris,

--- a/app/components/mandatarissen/timeline.js
+++ b/app/components/mandatarissen/timeline.js
@@ -1,0 +1,35 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import { action } from '@ember/object';
+
+export default class MandatarissenTimeline extends Component {
+  @service features;
+  @service router;
+
+  get isFeatureEnabled() {
+    return this.features.isEnabled('shacl-report');
+  }
+
+  get timelineEvents() {
+    const mandatarissen = this.args.mandatarissen;
+    const sortedMandatarissen = mandatarissen.sortBy('start');
+    return sortedMandatarissen.map((mandataris, index) => {
+      return {
+        type: index > 0 ? 'Wijziging' : 'Aanmaak',
+        active: mandataris.isActive,
+        date: mandataris.start,
+        mandataris,
+        last: index === mandatarissen.length - 1,
+        selected: mandataris.id === this.args.mandataris.id,
+      };
+    });
+  }
+
+  @action
+  selectEvent(event) {
+    this.router.transitionTo(
+      'mandatarissen.persoon.mandataris',
+      event.mandataris.id
+    );
+  }
+}

--- a/app/components/mandatarissen/timeline.js
+++ b/app/components/mandatarissen/timeline.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
+import moment from 'moment';
 
 export default class MandatarissenTimeline extends Component {
   @service features;
@@ -13,16 +14,27 @@ export default class MandatarissenTimeline extends Component {
   get timelineEvents() {
     const mandatarissen = this.args.mandatarissen;
     const sortedMandatarissen = mandatarissen.sortBy('start');
-    return sortedMandatarissen.map((mandataris, index) => {
+    const events = sortedMandatarissen.map((mandataris, index) => {
       return {
         type: index > 0 ? 'Wijziging' : 'Aanmaak',
-        active: mandataris.isActive,
+        active: mandataris.isCurrentlyActive,
         date: mandataris.start,
         mandataris,
-        last: index === mandatarissen.length - 1,
         selected: mandataris.id === this.args.mandataris.id,
       };
     });
+    const lastMandataris = sortedMandatarissen[sortedMandatarissen.length - 1];
+    if (lastMandataris.einde) {
+      events.push({
+        type: 'Einde',
+        active: moment().isAfter(lastMandataris.einde),
+        date: lastMandataris.einde,
+        mandataris: lastMandataris,
+        selected: false,
+      });
+    }
+    events[events.length - 1].last = true;
+    return events;
   }
 
   @action

--- a/app/components/mandatarissen/timeline.js
+++ b/app/components/mandatarissen/timeline.js
@@ -2,79 +2,9 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import moment from 'moment';
 
-import { trackedFunction } from 'reactiveweb/function';
-import { use } from 'ember-resources';
-
-async function getCorrections(mandataris) {
-  const result = await fetch(
-    `/form-content/mandataris-edit/instances/${mandataris.id}/history`
-  );
-
-  const json = await result.json();
-  return json.instances;
-}
-function getHistory() {
-  return trackedFunction(async () => {
-    const mandatarissen = this.args.mandatarissen;
-    const newHistory = await Promise.all(
-      mandatarissen.map(async (mandataris) => {
-        let corrections = await getCorrections(mandataris);
-        const historyEntry = {
-          mandataris,
-          corrections,
-        };
-        return historyEntry;
-      })
-    );
-
-    const userIdsInHistory = new Set();
-    newHistory.forEach((h) => {
-      h.corrections.forEach((c) => {
-        userIdsInHistory.add(c.creator);
-      });
-    });
-
-    let users = [];
-    if (userIdsInHistory.size !== 0) {
-      users = await this.store.query('gebruiker', {
-        filter: {
-          id: Array.from(userIdsInHistory).join(','),
-        },
-      });
-    }
-
-    const userIdToUser = {};
-    users.forEach((u) => {
-      userIdToUser[u.id] = u;
-    });
-
-    return newHistory
-      .map((h) => {
-        return {
-          ...h,
-          corrections: h.corrections.map((c) => ({
-            ...c,
-            creator: userIdToUser[c.creator],
-          })),
-        };
-      })
-      .sort((a, b) => {
-        if (!b?.mandataris?.start) {
-          return -1;
-        }
-        if (!a?.mandataris?.start) {
-          return 1;
-        }
-        return b.mandataris.start.getTime() - a.mandataris.start.getTime();
-      });
-  });
-}
-
 export default class MandatarissenTimeline extends Component {
   @service features;
   @service store;
-
-  @use(getHistory) history;
 
   get isFeatureEnabled() {
     return this.features.isEnabled('shacl-report');
@@ -102,9 +32,9 @@ export default class MandatarissenTimeline extends Component {
         selected: false,
       });
     }
-    if (this.history?.value) {
+    if (this.args.history) {
       events.forEach((event) => {
-        event.corrections = this.history.value.find(
+        event.corrections = this.args.history.find(
           (h) => h.mandataris.id === event.mandataris.id
         )?.corrections;
       });

--- a/app/components/mandatarissen/timeline.js
+++ b/app/components/mandatarissen/timeline.js
@@ -1,11 +1,80 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
-import { action } from '@ember/object';
 import moment from 'moment';
+
+import { trackedFunction } from 'reactiveweb/function';
+import { use } from 'ember-resources';
+
+async function getCorrections(mandataris) {
+  const result = await fetch(
+    `/form-content/mandataris-edit/instances/${mandataris.id}/history`
+  );
+
+  const json = await result.json();
+  return json.instances;
+}
+function getHistory() {
+  return trackedFunction(async () => {
+    const mandatarissen = this.args.mandatarissen;
+    const newHistory = await Promise.all(
+      mandatarissen.map(async (mandataris) => {
+        let corrections = await getCorrections(mandataris);
+        const historyEntry = {
+          mandataris,
+          corrections,
+        };
+        return historyEntry;
+      })
+    );
+
+    const userIdsInHistory = new Set();
+    newHistory.forEach((h) => {
+      h.corrections.forEach((c) => {
+        userIdsInHistory.add(c.creator);
+      });
+    });
+
+    let users = [];
+    if (userIdsInHistory.size !== 0) {
+      users = await this.store.query('gebruiker', {
+        filter: {
+          id: Array.from(userIdsInHistory).join(','),
+        },
+      });
+    }
+
+    const userIdToUser = {};
+    users.forEach((u) => {
+      userIdToUser[u.id] = u;
+    });
+
+    return newHistory
+      .map((h) => {
+        return {
+          ...h,
+          corrections: h.corrections.map((c) => ({
+            ...c,
+            creator: userIdToUser[c.creator],
+          })),
+        };
+      })
+      .sort((a, b) => {
+        if (!b?.mandataris?.start) {
+          return -1;
+        }
+        if (!a?.mandataris?.start) {
+          return 1;
+        }
+        return b.mandataris.start.getTime() - a.mandataris.start.getTime();
+      });
+  });
+}
 
 export default class MandatarissenTimeline extends Component {
   @service features;
-  @service router;
+  @service store;
+
+  @use(getHistory) history;
 
   get isFeatureEnabled() {
     return this.features.isEnabled('shacl-report');
@@ -33,15 +102,14 @@ export default class MandatarissenTimeline extends Component {
         selected: false,
       });
     }
+    if (this.history?.value) {
+      events.forEach((event) => {
+        event.corrections = this.history.value.find(
+          (h) => h.mandataris.id === event.mandataris.id
+        )?.corrections;
+      });
+    }
     events[events.length - 1].last = true;
     return events;
-  }
-
-  @action
-  selectEvent(event) {
-    this.router.transitionTo(
-      'mandatarissen.persoon.mandataris',
-      event.mandataris.id
-    );
   }
 }

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -121,6 +121,13 @@ export default class MandatarisModel extends Model {
     return false;
   }
 
+  get isCurrentlyActive() {
+    const now = moment();
+    const start = moment(this.start);
+    const end = this.einde ? moment(this.einde) : moment('3000-01-01');
+    return now.isBetween(start, end);
+  }
+
   isActiveAt(date) {
     if (!this.einde) {
       return moment(this.start).isSameOrBefore(date);

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -14,6 +14,7 @@ $mq-breakpoints: (
 @import "project/c-document-status-pills";
 @import "project/c-status-label";
 @import "project/c-skeleton";
+@import "project/c-timeline";
 
 // PLUGINS
 @import "project/p-ember-promise-modals";

--- a/app/styles/project/_c-timeline.scss
+++ b/app/styles/project/_c-timeline.scss
@@ -1,0 +1,96 @@
+.timeline .arrow {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  .event-date,
+  .spacer {
+    background-color: $au-gray-100;
+    height: 28px;
+    border-radius: 0;
+  }
+  .event-date {
+    width: 100%;
+    position: relative;
+    flex-grow: 0;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    font-weight: normal;
+    padding: 0;
+    gap: 0.5em;
+    color: $au-gray-700;
+    .event-marker {
+      content: "";
+      display: block;
+      padding: 0;
+      flex-grow: 0;
+      width: 8px;
+      height: 8px;
+      overflow: hidden;
+      position: relative;
+      flex-grow: 0;
+      background-color: $au-blue-700;
+      border-radius: 50%;
+      margin-left: 1em;
+    }
+  }
+  .spacer {
+    flex-grow: 1;
+  }
+  .spacer.last {
+    display: none;
+  }
+  .event-connector {
+    position: relative;
+    top: -10px;
+    width: 1px;
+    background-color: $au-gray-200;
+    height: 58px;
+    margin-bottom: -10px;
+    margin-left: calc(1.5em - 2px);
+  }
+  .event-panel {
+    width: 210px;
+    cursor: pointer;
+    box-sizing: border-box;
+    padding: 5px;
+    &.selected {
+      border: solid 2px $au-blue-700;
+      background-color: $au-blue-100;
+    }
+    &:hover {
+      border: solid 2px $au-blue-700;
+    }
+  }
+  .provenance {
+    font-size: $au-small;
+  }
+  .event {
+    position: relative;
+  }
+  .selected-pill {
+    position: absolute;
+    top: 46px;
+    right: 0;
+  }
+
+  .arrow-start {
+    width: 0;
+    height: 0;
+    border-top: 14px solid $au-gray-100;
+    border-bottom: 14px solid $au-gray-100;
+
+    border-left: 14px solid transparent;
+    margin-left: -14px;
+  }
+  .arrow-end {
+    width: 0;
+    height: 0;
+    border-top: 14px solid transparent;
+    border-bottom: 14px solid transparent;
+
+    border-left: 14px solid $au-gray-100;
+    margin-right: -14px;
+  }
+}

--- a/app/styles/project/_c-timeline.scss
+++ b/app/styles/project/_c-timeline.scss
@@ -2,6 +2,10 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  width: 100%;
+  overflow-x: auto;
+  overscroll-behavior: none;
+  padding-bottom: 1em;
   .event-date,
   .spacer {
     background-color: $au-gray-100;
@@ -37,6 +41,7 @@
   }
   .spacer {
     flex-grow: 1;
+    min-width: 5px;
   }
   .spacer.last {
     display: none;
@@ -74,23 +79,23 @@
     top: 46px;
     right: 0;
   }
+}
 
-  .arrow-start {
-    width: 0;
-    height: 0;
-    border-top: 14px solid $au-gray-100;
-    border-bottom: 14px solid $au-gray-100;
+.timeline .arrow-start {
+  width: 0;
+  height: 0;
+  border-top: 14px solid $au-gray-100;
+  border-bottom: 14px solid $au-gray-100;
 
-    border-left: 14px solid transparent;
-    margin-left: -14px;
-  }
-  .arrow-end {
-    width: 0;
-    height: 0;
-    border-top: 14px solid transparent;
-    border-bottom: 14px solid transparent;
+  border-left: 14px solid transparent;
+  margin-left: -14px;
+}
+.timeline .arrow-end {
+  width: 0;
+  height: 0;
+  border-top: 14px solid transparent;
+  border-bottom: 14px solid transparent;
 
-    border-left: 14px solid $au-gray-100;
-    margin-right: -14px;
-  }
+  border-left: 14px solid $au-gray-100;
+  margin-right: -14px;
 }

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -104,20 +104,12 @@
     />
   </div>
 
-  <div class="au-o-box">
-    <AuHeading @level="3" @skin="4">
-      Historiek
-    </AuHeading>
-
-    <ul class="au-c-list-vertical">
-      <Mandatarissen::History
-        @mandataris={{@model.mandataris}}
-        @mandatarissen={{@model.mandatarissen}}
-        @form={{@model.mandatarisEditForm}}
-        @history={{@model.history}}
-      />
-    </ul>
-  </div>
+  <Mandatarissen::Timeline
+    @mandataris={{@model.mandataris}}
+    @mandatarissen={{@model.mandatarissen}}
+    @history={{@model.history}}
+    @form={{@model.mandatarisEditForm}}
+  />
 
   <div class="au-o-box">
     <ValidatieTable @instance={{@model.mandataris}} />

--- a/config/environment.js
+++ b/config/environment.js
@@ -36,7 +36,9 @@ module.exports = function (environment) {
       'show-forms-module': false,
       'show-codelijsten-module': false,
       'enable-mandataris-count-warnings': true,
+      timeline: false,
       politieraad: false,
+      'editable-forms': false,
     },
     lpdcUrl: '{{LPDC_URL}}',
     worshipDecisionsDatabaseUrl: '{{WORSHIP_DECISIONS_DATABASE_URL}}',
@@ -59,7 +61,6 @@ module.exports = function (environment) {
     },
   };
 
-  ENV.features['editable-forms'] = false;
   if (environment === 'development') {
     ENV.APP.DISABLE_RELOAD_WARNINGS = true;
     ENV.APP.SHOW_FORM_CONTENT = true;
@@ -69,6 +70,7 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
     ENV.features['editable-forms'] = true;
+    ENV.features['timeline'] = true;
 
     ENV.features['shacl-report'] = true;
     ENV.features['politieraad'] = true;

--- a/tests/integration/components/mandatarissen/timeline-card-test.js
+++ b/tests/integration/components/mandatarissen/timeline-card-test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | mandatarissen/timeline-card',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.set('myAction', function(val) { ... });
+
+      await render(hbs`<Mandatarissen::TimelineCard />`);
+
+      assert.dom().hasText('');
+
+      // Template block usage:
+      await render(hbs`<Mandatarissen::TimelineCard>
+  template block text
+</Mandatarissen::TimelineCard>`);
+
+      assert.dom().hasText('template block text');
+    });
+  }
+);

--- a/tests/integration/components/mandatarissen/timeline-test.js
+++ b/tests/integration/components/mandatarissen/timeline-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | mandatarissen/timeline', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Mandatarissen::Timeline />`);
+
+    assert.dom().hasText('');
+
+    // Template block usage:
+    await render(hbs`<Mandatarissen::Timeline>
+  template block text
+</Mandatarissen::Timeline>`);
+
+    assert.dom().hasText('template block text');
+  });
+});


### PR DESCRIPTION
## Description

Show the basic timeline for the history of a mandataris, allow switching events by clicking the cards or the dates (allowing for keyboard only interaction too)

![image](https://github.com/user-attachments/assets/e774ac53-0d78-40d0-b3d6-5a3b6f3d7e24)

Scroll on smaller screens:
![image](https://github.com/user-attachments/assets/a4976e64-8a1a-4d19-a91b-cd90748d6f06)

only basics are shown for now and the feature is behind a feature flag. Advanced things like what changed and corrections are separate stories.

## How to test

Go to gent and open a mandataris with a high rank, play around with correcting and updating state.