### PR TITLE
Karel/lmb 1517 how to show form links

### DIFF
--- a/app/components/rdf-input-fields/crud-custom-field-modal.hbs
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.hbs
@@ -92,27 +92,29 @@
               />
             </Shared::Tooltip></AuToggleSwitch>
         </AuFormRow>
-        <AuFormRow>
-          <AuToggleSwitch
-            @disabled={{@show}}
-            @checked={{this.isShownInSummary}}
-            @onChange={{this.toggleShowInSummary}}
-          >Toon in samenvatting
-            <Shared::Tooltip
-              @showTooltip={{true}}
-              @alignment="top-left"
-              @tooltipText="Dit veld zal getoond worden in de samenvatting van een item, bijvoorbeeld bij het tonen van een lijst van items of bij een verwijzing naar een item."
-            >
-              <AuButton
-                @skin="naked"
-                @icon="circle-question"
-                @hideText={{true}}
-                @disabled={{true}}
-                class="au-u-padding-bottom-small au-u-padding-left-none"
-              />
-            </Shared::Tooltip>
-          </AuToggleSwitch>
-        </AuFormRow>
+        {{#if this.isCustomForm}}
+          <AuFormRow>
+            <AuToggleSwitch
+              @disabled={{@show}}
+              @checked={{this.isShownInSummary}}
+              @onChange={{this.toggleShowInSummary}}
+            >Toon in samenvatting
+              <Shared::Tooltip
+                @showTooltip={{true}}
+                @alignment="top-left"
+                @tooltipText="Dit veld zal getoond worden in de samenvatting van een item, bijvoorbeeld bij het tonen van een lijst van items of bij een verwijzing naar een item."
+              >
+                <AuButton
+                  @skin="naked"
+                  @icon="circle-question"
+                  @hideText={{true}}
+                  @disabled={{true}}
+                  class="au-u-padding-bottom-small au-u-padding-left-none"
+                />
+              </Shared::Tooltip>
+            </AuToggleSwitch>
+          </AuFormRow>
+        {{/if}}
       </form>
     {{/if}}
 

--- a/app/components/rdf-input-fields/crud-custom-field-modal.hbs
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.hbs
@@ -3,6 +3,7 @@
   @closeModal={{this.closeModal}}
   @closable={{true}}
   @title={{this.title}}
+  class="overflow-visible"
 >
   <:body>
     {{#if this.wantsToRemove}}
@@ -76,7 +77,41 @@
             @disabled={{@show}}
             @checked={{this.isFieldRequired}}
             @onChange={{this.toggleIsRequired}}
-          >Maak veld verplicht</AuToggleSwitch>
+          >Maak veld verplicht
+            <Shared::Tooltip
+              @showTooltip={{true}}
+              @alignment="top-left"
+              @tooltipText="Bij het aanmaken of aanpassen van items zal dit veld steeds ingevuld moeten worden."
+            >
+              <AuButton
+                @skin="naked"
+                @icon="circle-question"
+                @hideText={{true}}
+                @disabled={{true}}
+                class="au-u-padding-bottom-small au-u-padding-left-none"
+              />
+            </Shared::Tooltip></AuToggleSwitch>
+        </AuFormRow>
+        <AuFormRow>
+          <AuToggleSwitch
+            @disabled={{@show}}
+            @checked={{this.isShownInSummary}}
+            @onChange={{this.toggleShowInSummary}}
+          >Toon in samenvatting
+            <Shared::Tooltip
+              @showTooltip={{true}}
+              @alignment="top-left"
+              @tooltipText="Dit veld zal getoond worden in de samenvatting van een item, bijvoorbeeld bij het tonen van een lijst van items of bij een verwijzing naar een item."
+            >
+              <AuButton
+                @skin="naked"
+                @icon="circle-question"
+                @hideText={{true}}
+                @disabled={{true}}
+                class="au-u-padding-bottom-small au-u-padding-left-none"
+              />
+            </Shared::Tooltip>
+          </AuToggleSwitch>
         </AuFormRow>
       </form>
     {{/if}}

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -15,6 +15,7 @@ import {
   LIBRARY_ENTREES,
   TEXT_CUSTOM_DISPLAY_TYPE,
 } from 'frontend-lmb/utils/well-known-uris';
+import { Literal, NamedNode } from 'rdflib';
 
 export default class RdfInputFieldCrudCustomFieldModalComponent extends Component {
   @consume('form-context') formContext;
@@ -224,7 +225,17 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
 
   get isCustomForm() {
     const forkingStore = this.forkingStore;
-    return !forkingStore.any(null, EXT('extendsForm'), null, SOURCE_GRAPH);
+    return (
+      forkingStore.any(
+        null,
+        EXT('isCustomForm'),
+        new Literal(
+          'true',
+          null,
+          new NamedNode('http://www.w3.org/2001/XMLSchema#boolean')
+        )
+      ) && !forkingStore.any(null, EXT('extendsForm'), null, SOURCE_GRAPH)
+    );
   }
 
   get libraryFieldOptions() {

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -9,7 +9,7 @@ import { ForkingStore } from '@lblod/ember-submission-form-fields';
 import { consume } from 'ember-provide-consume-context';
 
 import { JSON_API_TYPE, SOURCE_GRAPH } from 'frontend-lmb/utils/constants';
-import { PROV, FORM } from 'frontend-lmb/rdf/namespaces';
+import { PROV, FORM, EXT } from 'frontend-lmb/rdf/namespaces';
 import { showErrorToast } from 'frontend-lmb/utils/toasts';
 import {
   LIBRARY_ENTREES,
@@ -220,6 +220,11 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
       'text/turtle'
     );
     return forkingStore;
+  }
+
+  get isCustomForm() {
+    const forkingStore = this.forkingStore;
+    return !forkingStore.any(null, EXT('extendsForm'), null, SOURCE_GRAPH);
   }
 
   get libraryFieldOptions() {

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -9,7 +9,7 @@ import { ForkingStore } from '@lblod/ember-submission-form-fields';
 import { consume } from 'ember-provide-consume-context';
 
 import { JSON_API_TYPE, SOURCE_GRAPH } from 'frontend-lmb/utils/constants';
-import { PROV } from 'frontend-lmb/rdf/namespaces';
+import { PROV, FORM } from 'frontend-lmb/rdf/namespaces';
 import { showErrorToast } from 'frontend-lmb/utils/toasts';
 import {
   LIBRARY_ENTREES,
@@ -25,6 +25,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
 
   @tracked isRemovingField;
   @tracked isFieldRequired;
+  @tracked isShownInSummary;
   @tracked wantsToRemove;
 
   customFieldEntry = this.store.createRecord('library-entry', {
@@ -46,6 +47,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
       withValue = displayType;
     }
     this.isFieldRequired = this.args.isRequiredField ?? false;
+    this.isShownInSummary = this.originalIsShownInSummary;
     this.displayTypes.then((displayTypes) => {
       this.displayType = displayTypes.findBy('uri', withValue);
     });
@@ -65,6 +67,11 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
     this.isFieldRequired = !this.isFieldRequired;
   }
 
+  @action
+  toggleShowInSummary() {
+    this.isShownInSummary = !this.isShownInSummary;
+  }
+
   updateField = task(async () => {
     try {
       await fetch(
@@ -79,6 +86,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
             displayType: this.displayType.uri,
             name: this.fieldName,
             isRequired: !!this.isFieldRequired,
+            showInSummary: !!this.isShownInSummary,
           }),
         }
       );
@@ -106,6 +114,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
             libraryEntryUri: this.libraryFieldType.uri,
             name: this.fieldName,
             isRequired: !!this.isFieldRequired,
+            showInSummary: !!this.isShownInSummary,
           }),
         }
       );
@@ -203,14 +212,18 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
     return libraryEntree?.value;
   }
 
-  get libraryFieldOptions() {
+  get forkingStore() {
     const forkingStore = new ForkingStore();
     forkingStore.parse(
       this.formContext.formDefinition.formTtl,
       SOURCE_GRAPH,
       'text/turtle'
     );
+    return forkingStore;
+  }
 
+  get libraryFieldOptions() {
+    const forkingStore = this.forkingStore;
     const alreadyUsedLibraryEntries = forkingStore
       .match(null, PROV('wasDerivedFrom'), null, SOURCE_GRAPH)
       .map((triple) => triple.object.value);
@@ -232,6 +245,19 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
       });
   }
 
+  get originalIsShownInSummary() {
+    const forkingStore = this.forkingStore;
+    if (!this.args.field?.uri) {
+      return false;
+    }
+    return !!forkingStore.any(
+      this.args.field.uri,
+      FORM('showInSummary'),
+      null,
+      SOURCE_GRAPH
+    );
+  }
+
   get canSaveChanges() {
     return (
       this.fieldHasChanged && this.hasValidFieldName && this.libraryFieldType
@@ -246,7 +272,8 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
     return (
       (this.hasValidFieldName && this.fieldName !== this.args.field.label) ||
       this.displayType.uri !== this.args.field.displayType ||
-      this.isFieldRequired != this.args.isRequiredField
+      this.isFieldRequired != this.args.isRequiredField ||
+      this.isShownInSummary != this.args.isShownInSummary
     );
   }
 

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -59,4 +59,5 @@
   @form={{@form}}
   @field={{@field}}
   @isRequiredField={{this.isRequired}}
+  @isShownInSummary={{this.isShownInSummary}}
 />

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -433,3 +433,9 @@ main .au-c-main-container__content .au-u-wide-on-print {
 .power-select--min-width {
   min-width: 20rem;
 }
+.au-c-modal.overflow-visible {
+  overflow: visible;
+  .au-c-modal__body {
+    overflow: visible;
+  }
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -71,6 +71,7 @@ module.exports = function (environment) {
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
     ENV.features['editable-forms'] = true;
     ENV.features['timeline'] = true;
+    ENV.features['show-eigen-gegevens-module'] = true;
 
     ENV.features['shacl-report'] = true;
     ENV.features['politieraad'] = true;


### PR DESCRIPTION
## Description

This allows users to specify which fields to show in summary views (instance tables, links)
Note: this only allows configuring these fields and using them in instance tables. It also does not take into account fancy types like addresses or nested values. That feels like its own separate thing

## How to test
use yalc to have the linked semantic-forms version
run the linked form-content service instead of the regular one in the app

Create a custom form
Add a field
Add another field, mark it as show in summary
Add another field
Make the first field also show in summary
Add some instances to the form
See that by default the fields are shown in the list 

Make the second field no longer show in the summary
See that by default the field is no longer shown in the list of instances

See that you can still configure the columns in the list of instances
See that you can't make a field show up in a summary for form extensions
## Links to other PR's

- https://github.com/lblod/ember-semantic-forms/pull/6
- https://github.com/lblod/form-content-service/pull/75
- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/412