### PR TITLE
make it clear when the mandataris shown is not the latest version

### DIFF
--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -70,6 +70,14 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
         },
       });
     }
+    const history = await this.fetchHistory(
+      mandataris,
+      mandatarissen,
+      mandatarisEditForm.id
+    );
+
+    const isMostRecentVersion =
+      mandatarissen.sortBy('start').reverse()[0].id === mandataris.id;
 
     return RSVP.hash({
       bestuurseenheid,
@@ -77,11 +85,8 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
       mandatarissen,
       mandatarisEditForm,
       mandatarisExtraInfoForm,
-      history: await this.fetchHistory(
-        mandataris,
-        mandatarissen,
-        mandatarisEditForm.id
-      ),
+      history,
+      isMostRecentVersion,
       bestuursorganen,
       periodeHasLegislatuur,
       behandeldeVergaderingen,

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -8,6 +8,19 @@
   <div class="au-o-grid__item au-u-1-2">
     <p class="au-u-h2 au-u-medium">
       {{this.bestuursorganenTitle}}
+      {{#unless this.model.isMostRecentVersion}}
+        {{! template-lint-disable no-inline-styles }}
+        <Shared::Tooltip
+          @tooltipText="Je bekijkt een toestand van de mandataris van vóór de laatste wijziging, zie historiek voor meer details."
+          @showTooltip={{true}}
+          @alignment="left"
+          class="au-u-h5 au-u-para au-u-flex--inline au-u-regular"
+          style="top: -5px;"
+        >
+          <AuPill @skin="warning">Versie niet actueel</AuPill>
+        </Shared::Tooltip>
+
+      {{/unless}}
     </p>
     <p class="au-u-h3">
       {{this.persoon.gebruikteVoornaam}}


### PR DESCRIPTION
## Description

make it clear when the mandataris shown is not the latest version
![image](https://github.com/user-attachments/assets/a44e85ac-eaf6-43f7-917b-19020c60cfb3)

## How to test

go to a mandataris that has changes, pick an old state, see the badge and the tooltip