### PR TITLE
fix | resolve deprecation browser warnings

### DIFF
--- a/app/services/store.js
+++ b/app/services/store.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data/store';

--- a/app/transforms/boolean.js
+++ b/app/transforms/boolean.js
@@ -1,0 +1,1 @@
+export { BooleanTransform as default } from '@ember-data/serializer/transform';

--- a/app/transforms/number.js
+++ b/app/transforms/number.js
@@ -1,0 +1,1 @@
+export { NumberTransform as default } from '@ember-data/serializer/transform';

--- a/app/transforms/string.js
+++ b/app/transforms/string.js
@@ -1,0 +1,1 @@
+export { StringTransform as default } from '@ember-data/serializer/transform';

--- a/tests/unit/services/store-test.js
+++ b/tests/unit/services/store-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-lmb/tests/helpers';
+
+module('Unit | Service | store', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:store');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
Will remove the NumberTransform, BooleanTransform, StringTransform and store warnings in console.
![image](https://github.com/user-attachments/assets/6fa25a54-e1c5-43f6-bfc2-19af41189fb9)
![image](https://github.com/user-attachments/assets/1ad16f2a-2d88-41c3-9417-66b9ce63dcff)
![image](https://github.com/user-attachments/assets/3ae2fde6-1064-4ea7-8d0e-606395b4aa61)
![image](https://github.com/user-attachments/assets/4bbabb9c-db70-4b9f-a390-4430adc9c771)


Fun fact: I think this last one makes it possible to extend the store service and add the `queryRecord` to the store so we can use it aswell to query a single record :D e.g. `this.store.queryRecord('form', {})` instead of `queryRecord(this.store, 'form', {})`


