### PR TITLE
LMB-1502 | Allow linking to other form instances

### DIFF
--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -67,8 +67,8 @@
       {{#if this.displayType.isLinkToForm}}
         <LinkToForm::SelectFormType
           @formDefintionId={{@formDefinitionId}}
-          @selectedFormTypeUri={{this.linkedFormTypeUri}}
-          @onSelectedType={{this.updateLinkedFormTypeUri}}
+          @selectedFormTypeId={{this.linkedFormTypeId}}
+          @onSelectedType={{this.updateLinkedFormTypeId}}
         />
       {{/if}}
       <AuFormRow>

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -67,8 +67,8 @@
       {{#if this.displayType.isLinkToForm}}
         <LinkToForm::SelectFormType
           @formDefintionId={{@formDefinitionId}}
-          @selectedFormTypeId={{this.linkedFormTypeId}}
-          @onSelectedType={{this.updateLinkedFormTypeId}}
+          @selectedFormTypeUri={{this.linkedFormTypeUri}}
+          @onSelectedType={{this.updateLinkedFormTypeUri}}
         />
       {{/if}}
       <AuFormRow>

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -64,6 +64,13 @@
           </PowerSelect>
         </AuFormRow>
       {{/if}}
+      {{#if this.displayType.isLinkToForm}}
+        <LinkToForm::SelectFormType
+          @formDefintionId={{@formDefinitionId}}
+          @selectedFormTypeUri={{this.linkedFormTypeUri}}
+          @onSelectedType={{this.updateLinkedFormTypeUri}}
+        />
+      {{/if}}
       <AuFormRow>
         <AuToggleSwitch
           @disabled={{not this.selectedField}}

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -87,9 +87,10 @@
               @icon="circle-question"
               @hideText={{true}}
               @disabled={{true}}
-              class="au-u-padding-bottom-small au-u-padding-left-none"
+              class="au-u-padding-bottom-small au-u-padding-left-none au-u-padding-right-none"
             />
-          </Shared::Tooltip></AuToggleSwitch>
+          </Shared::Tooltip>
+        </AuToggleSwitch>
       </AuFormRow>
       <AuFormRow>
         <AuToggleSwitch

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -18,7 +18,7 @@ export default class CustomFormEditCustomField extends Component {
   @tracked label;
   @tracked displayType;
   @tracked conceptScheme;
-  @tracked linkedFormTypeId;
+  @tracked linkedFormTypeUri;
   @tracked isRequired;
   @tracked isShownInSummary;
 
@@ -63,7 +63,7 @@ export default class CustomFormEditCustomField extends Component {
       this.selectedField.conceptScheme !== this.conceptScheme?.uri ||
       this.selectedField.isRequired !== this.isRequired ||
       this.selectedField.isShownInSummary !== this.isShownInSummary ||
-      this.selectedField.linkedFormTypeUri !== this.linkedFormTypeId
+      this.selectedField.linkedFormTypeUri !== this.linkedFormTypeUri
     );
   }
 
@@ -72,7 +72,7 @@ export default class CustomFormEditCustomField extends Component {
     this.label = field?.label;
     this.isRequired = !!field?.isRequired;
     this.isShownInSummary = !!field?.isShownInSummary;
-    this.linkedFormTypeId = field?.linkedFormTypeUri;
+    this.linkedFormTypeUri = field?.linkedFormTypeUri;
     this.displayType = this.displayTypes.filter(
       (t) => t.uri === field?.displayType
     )?.[0];
@@ -101,8 +101,8 @@ export default class CustomFormEditCustomField extends Component {
   }
 
   @action
-  updateLinkedFormTypeId(id) {
-    this.linkedFormTypeId = id;
+  updateLinkedFormTypeUri(uri) {
+    this.linkedFormTypeUri = uri;
   }
 
   @action
@@ -127,7 +127,7 @@ export default class CustomFormEditCustomField extends Component {
         conceptSchemeUri: this.conceptScheme?.uri,
         isRequired: this.isRequired,
         isShownInSummary: this.isShownInSummary,
-        linkedFormTypeUri: this.linkedFormTypeId,
+        linkedFormTypeUri: this.linkedFormTypeUri,
         formUri: this.args.selectedField.formUri,
       }
     );

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -18,7 +18,7 @@ export default class CustomFormEditCustomField extends Component {
   @tracked label;
   @tracked displayType;
   @tracked conceptScheme;
-  @tracked linkedFormTypeUri;
+  @tracked linkedFormTypeId;
   @tracked isRequired;
   @tracked isShownInSummary;
 
@@ -63,7 +63,7 @@ export default class CustomFormEditCustomField extends Component {
       this.selectedField.conceptScheme !== this.conceptScheme?.uri ||
       this.selectedField.isRequired !== this.isRequired ||
       this.selectedField.isShownInSummary !== this.isShownInSummary ||
-      this.selectedField.linkedFormTypeUri !== this.linkedFormTypeUri
+      this.selectedField.linkedFormTypeId !== this.linkedFormTypeId
     );
   }
 
@@ -72,7 +72,7 @@ export default class CustomFormEditCustomField extends Component {
     this.label = field?.label;
     this.isRequired = !!field?.isRequired;
     this.isShownInSummary = !!field?.isShownInSummary;
-    this.linkedFormTypeUri = field?.linkedFormTypeUri;
+    this.linkedFormTypeId = field?.linkedFormTypeUri;
     this.displayType = this.displayTypes.filter(
       (t) => t.uri === field?.displayType
     )?.[0];
@@ -101,8 +101,8 @@ export default class CustomFormEditCustomField extends Component {
   }
 
   @action
-  updateLinkedFormTypeUri(uri) {
-    this.linkedFormTypeUri = uri;
+  updateLinkedFormTypeId(id) {
+    this.linkedFormTypeId = id;
   }
 
   @action
@@ -127,7 +127,7 @@ export default class CustomFormEditCustomField extends Component {
         conceptSchemeUri: this.conceptScheme?.uri,
         isRequired: this.isRequired,
         isShownInSummary: this.isShownInSummary,
-        linkedFormTypeUri: this.linkedFormTypeUri,
+        linkedFormTypeUri: this.linkedFormTypeId,
         formUri: this.args.selectedField.formUri,
       }
     );

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -18,6 +18,7 @@ export default class CustomFormEditCustomField extends Component {
   @tracked label;
   @tracked displayType;
   @tracked conceptScheme;
+  @tracked linkedFormTypeUri;
   @tracked isRequired;
   @tracked isShownInSummary;
 
@@ -61,7 +62,8 @@ export default class CustomFormEditCustomField extends Component {
       this.selectedField.displayType !== this.displayType?.uri ||
       this.selectedField.conceptScheme !== this.conceptScheme?.uri ||
       this.selectedField.isRequired !== this.isRequired ||
-      this.selectedField.isShownInSummary !== this.isShownInSummary
+      this.selectedField.isShownInSummary !== this.isShownInSummary ||
+      this.selectedField.linkedFormTypeUri !== this.linkedFormTypeUri
     );
   }
 
@@ -70,6 +72,7 @@ export default class CustomFormEditCustomField extends Component {
     this.label = field?.label;
     this.isRequired = !!field?.isRequired;
     this.isShownInSummary = !!field?.isShownInSummary;
+    this.linkedFormTypeUri = field?.linkedFormTypeUri;
     this.displayType = this.displayTypes.filter(
       (t) => t.uri === field?.displayType
     )?.[0];
@@ -98,6 +101,11 @@ export default class CustomFormEditCustomField extends Component {
   }
 
   @action
+  updateLinkedFormTypeUri(uri) {
+    this.linkedFormTypeUri = uri;
+  }
+
+  @action
   toggleIsRequired() {
     this.isRequired = !this.isRequired;
   }
@@ -119,6 +127,7 @@ export default class CustomFormEditCustomField extends Component {
         conceptSchemeUri: this.conceptScheme?.uri,
         isRequired: this.isRequired,
         isShownInSummary: this.isShownInSummary,
+        linkedFormTypeUri: this.linkedFormTypeUri,
         formUri: this.args.selectedField.formUri,
       }
     );

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -63,7 +63,7 @@ export default class CustomFormEditCustomField extends Component {
       this.selectedField.conceptScheme !== this.conceptScheme?.uri ||
       this.selectedField.isRequired !== this.isRequired ||
       this.selectedField.isShownInSummary !== this.isShownInSummary ||
-      this.selectedField.linkedFormTypeId !== this.linkedFormTypeId
+      this.selectedField.linkedFormTypeUri !== this.linkedFormTypeId
     );
   }
 

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -38,7 +38,7 @@
         @options={{this.formOptions}}
         as |form|
       >
-        {{form}}
+        {{form.label}}
       </PowerSelect>
     </c.content>
   </AuCard>

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -36,16 +36,33 @@
         @selected={{this.form}}
         @onChange={{this.selectFormOfType}}
         @options={{this.formOptions}}
+        @onClose={{this.preventCloseOnLoadMoreOptions}}
         as |form|
       >
-        <AuList @direction="vertical" @divider={{true}} as |Item|>
-          {{#each form.values as |keyValue|}}
-            <Item>
-              <AuHelpText>{{keyValue.key}}: </AuHelpText>
-              {{keyValue.value}}
-            </Item>
-          {{/each}}
-        </AuList>
+        {{#if (eq form.id "load-more-options")}}
+          <span
+            class="au-u-flex au-u-flex--center au-u-padding-top-small au-u-padding-bottom-small"
+          >
+            {{#if this.canShowLoadMoreOptions}}
+              {{#if this.isLoadingMoreOptions}}
+                <AuLoader />
+              {{else}}
+                <AuHelpText>Laad meer opties</AuHelpText>
+              {{/if}}
+            {{else}}
+              <AuHelpText>Alle opties ingeladen</AuHelpText>
+            {{/if}}
+          </span>
+        {{else}}
+          <AuList @direction="vertical" @divider={{true}} as |Item|>
+            {{#each form.values as |keyValue|}}
+              <Item>
+                <AuHelpText>{{keyValue.key}}: </AuHelpText>
+                {{keyValue.value}}
+              </Item>
+            {{/each}}
+          </AuList>
+        {{/if}}
       </PowerSelect>
     </c.content>
   </AuCard>

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -54,14 +54,14 @@
             {{/if}}
           </span>
         {{else}}
-          <AuList @direction="vertical" @divider={{true}} as |Item|>
+          <div class="au-u-flex au-u-flex--row au-u-flex-wrap">
             {{#each form.values as |keyValue|}}
-              <Item>
+              <span>
                 <AuHelpText>{{keyValue.key}}: </AuHelpText>
                 {{keyValue.value}}
-              </Item>
+              </span>
             {{/each}}
-          </AuList>
+          </div>
         {{/if}}
       </PowerSelectMultiple>
     </c.content>

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -35,10 +35,10 @@
         @searchField="id"
         @selected={{this.form}}
         @onChange={{this.selectFormOfType}}
-        @options={{this.forms}}
+        @options={{this.formOptions}}
         as |form|
       >
-        {{form.id}}
+        {{form.label}}
       </PowerSelect>
       <PowerSelectMultiple
         @disabled={{not this.form}}

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -14,13 +14,13 @@
     @search={{perform this.searchForm}}
     @allowClear={{false}}
     @placeholder="Selecteer instantie"
-    @selected={{this.forms}}
-    @onChange={{this.selectFormsOfType}}
-    @options={{this.formOptions}}
+    @selected={{this.selectedInstances}}
+    @onChange={{this.selectInstance}}
+    @options={{this.instancesAsOptions}}
     @onClose={{this.preventCloseOnLoadMoreOptions}}
-    as |form|
+    as |instance|
   >
-    {{#if (eq form.id "load-more-options")}}
+    {{#if (eq instance.id "load-more-options")}}
       <span
         class="au-u-flex au-u-flex--center au-u-padding-top-small au-u-padding-bottom-small"
       >
@@ -34,7 +34,7 @@
       </span>
     {{else}}
       <div class="au-u-flex au-u-flex--row au-u-flex-wrap">
-        {{#each form.values as |keyValue|}}
+        {{#each instance.option as |keyValue|}}
           <span class="au-u-padding-right-small">
             <AuHelpText>{{keyValue.key}}: </AuHelpText>
             {{keyValue.value}}

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -7,22 +7,6 @@
 >
   <AuCard @standOut={{true}} as |c|>
     <c.content>
-      <PowerSelect
-        @labelText="Formulier type"
-        @loadingMessage="Aan het laden..."
-        @noMatchesMessage="Geen resultaten"
-        @searchMessage="Typ om te zoeken"
-        @searchEnabled={{true}}
-        @allowClear={{false}}
-        @placeholder="Type van het formulier"
-        @searchField="label"
-        @selected={{this.formType}}
-        @onChange={{this.selectFormType}}
-        @options={{this.formTypes}}
-        as |form|
-      >
-        {{form.label}}
-      </PowerSelect>
       <PowerSelectMultiple
         @disabled={{not this.formType}}
         @labelText="Formulier"

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -30,9 +30,9 @@
         @noMatchesMessage="Geen resultaten"
         @searchMessage="Typ om te zoeken"
         @searchEnabled={{true}}
+        @search={{perform this.searchForm}}
         @allowClear={{false}}
         @placeholder="Formulier voor het geselecteerde type"
-        @searchField="id"
         @selected={{this.form}}
         @onChange={{this.selectFormOfType}}
         @options={{this.formOptions}}

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -23,7 +23,7 @@
       >
         {{form.label}}
       </PowerSelect>
-      <PowerSelect
+      <PowerSelectMultiple
         @disabled={{not this.formType}}
         @labelText="Formulier"
         @loadingMessage="Aan het laden..."
@@ -33,8 +33,8 @@
         @search={{perform this.searchForm}}
         @allowClear={{false}}
         @placeholder="Formulier voor het geselecteerde type"
-        @selected={{this.form}}
-        @onChange={{this.selectFormOfType}}
+        @selected={{this.forms}}
+        @onChange={{this.selectFormsOfType}}
         @options={{this.formOptions}}
         @onClose={{this.preventCloseOnLoadMoreOptions}}
         as |form|
@@ -45,7 +45,7 @@
           >
             {{#if this.canShowLoadMoreOptions}}
               {{#if this.isLoadingMoreOptions}}
-                <AuLoader />
+                <AuLoader @hideMessage={{true}} />
               {{else}}
                 <AuHelpText>Laad meer opties</AuHelpText>
               {{/if}}
@@ -63,7 +63,7 @@
             {{/each}}
           </AuList>
         {{/if}}
-      </PowerSelect>
+      </PowerSelectMultiple>
     </c.content>
   </AuCard>
 </RdfInputFields::CustomFieldWrapper>

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -49,14 +49,12 @@
               {{else}}
                 <AuHelpText>Laad meer opties</AuHelpText>
               {{/if}}
-            {{else}}
-              <AuHelpText>Alle opties ingeladen</AuHelpText>
             {{/if}}
           </span>
         {{else}}
           <div class="au-u-flex au-u-flex--row au-u-flex-wrap">
             {{#each form.values as |keyValue|}}
-              <span>
+              <span class="au-u-padding-right-small">
                 <AuHelpText>{{keyValue.key}}: </AuHelpText>
                 {{keyValue.value}}
               </span>

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -1,0 +1,61 @@
+<RdfInputFields::CustomFieldWrapper
+  @inline={{true}}
+  @field={{@field}}
+  @form={{@form}}
+  @graphs={{@graphs}}
+  @formStore={{@formStore}}
+>
+  <AuCard @standOut={{true}} as |c|>
+    <c.content>
+      <PowerSelect
+        @labelText="Formulier type"
+        @loadingMessage="Aan het laden..."
+        @noMatchesMessage="Geen resultaten"
+        @searchMessage="Typ om te zoeken"
+        @searchEnabled={{true}}
+        @allowClear={{false}}
+        @placeholder="Type van het formulier"
+        @searchField="id"
+        @selected={{this.formType}}
+        @onChange={{this.selectFormType}}
+        @options={{this.formTypes}}
+        as |form|
+      >
+        {{form.id}}
+      </PowerSelect>
+      <PowerSelect
+        @disabled={{not this.formType}}
+        @labelText="Formulier"
+        @loadingMessage="Aan het laden..."
+        @noMatchesMessage="Geen resultaten"
+        @searchMessage="Typ om te zoeken"
+        @searchEnabled={{true}}
+        @allowClear={{false}}
+        @placeholder="Formulier voor het geselecteerde type"
+        @searchField="id"
+        @selected={{this.form}}
+        @onChange={{this.selectFormOfType}}
+        @options={{this.forms}}
+        as |form|
+      >
+        {{form.id}}
+      </PowerSelect>
+      <PowerSelectMultiple
+        @disabled={{not this.form}}
+        @labelText="Velden"
+        @searchField="label"
+        @searchPlaceholder="Zoek een veld in het formulier"
+        @searchEnabled={{true}}
+        @selected={{this.fields}}
+        @options={{this.fieldOptions}}
+        @onChange={{this.updateSelectedFields}}
+        @allowClear={{false}}
+        @loadingMessage="Aan het laden..."
+        @noMatchesMessage="Geen resultaten gevonden"
+        as |field|
+      >
+        {{field.label}}
+      </PowerSelectMultiple>
+    </c.content>
+  </AuCard>
+</RdfInputFields::CustomFieldWrapper>

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -38,7 +38,22 @@
         @options={{this.formOptions}}
         as |form|
       >
-        {{form.label}}
+        <AuTable @size={{this.size}}>
+          <:header>
+            <tr>
+              {{#each form.values as |keyValue|}}
+                <th>{{keyValue.key}}</th>
+              {{/each}}
+            </tr>
+          </:header>
+          <:body>
+            <tr>
+              {{#each form.values as |keyValue|}}
+                <td>{{keyValue.value}}</td>
+              {{/each}}
+            </tr>
+          </:body>
+        </AuTable>
       </PowerSelect>
     </c.content>
   </AuCard>

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -5,47 +5,42 @@
   @graphs={{@graphs}}
   @formStore={{@formStore}}
 >
-  <AuCard @standOut={{true}} as |c|>
-    <c.content>
-      <PowerSelectMultiple
-        @disabled={{not this.formType}}
-        @labelText="Formulier"
-        @loadingMessage="Aan het laden..."
-        @noMatchesMessage="Geen resultaten"
-        @searchMessage="Typ om te zoeken"
-        @searchEnabled={{true}}
-        @search={{perform this.searchForm}}
-        @allowClear={{false}}
-        @placeholder="Formulier voor het geselecteerde type"
-        @selected={{this.forms}}
-        @onChange={{this.selectFormsOfType}}
-        @options={{this.formOptions}}
-        @onClose={{this.preventCloseOnLoadMoreOptions}}
-        as |form|
+  <PowerSelectMultiple
+    @labelText="Formulier"
+    @loadingMessage="Aan het laden..."
+    @noMatchesMessage="Geen resultaten"
+    @searchMessage="Typ om te zoeken"
+    @searchEnabled={{true}}
+    @search={{perform this.searchForm}}
+    @allowClear={{false}}
+    @placeholder="Selecteer instantie"
+    @selected={{this.forms}}
+    @onChange={{this.selectFormsOfType}}
+    @options={{this.formOptions}}
+    @onClose={{this.preventCloseOnLoadMoreOptions}}
+    as |form|
+  >
+    {{#if (eq form.id "load-more-options")}}
+      <span
+        class="au-u-flex au-u-flex--center au-u-padding-top-small au-u-padding-bottom-small"
       >
-        {{#if (eq form.id "load-more-options")}}
-          <span
-            class="au-u-flex au-u-flex--center au-u-padding-top-small au-u-padding-bottom-small"
-          >
-            {{#if this.canShowLoadMoreOptions}}
-              {{#if this.isLoadingMoreOptions}}
-                <AuLoader @hideMessage={{true}} />
-              {{else}}
-                <AuHelpText>Laad meer opties</AuHelpText>
-              {{/if}}
-            {{/if}}
-          </span>
-        {{else}}
-          <div class="au-u-flex au-u-flex--row au-u-flex-wrap">
-            {{#each form.values as |keyValue|}}
-              <span class="au-u-padding-right-small">
-                <AuHelpText>{{keyValue.key}}: </AuHelpText>
-                {{keyValue.value}}
-              </span>
-            {{/each}}
-          </div>
+        {{#if this.canShowLoadMoreOptions}}
+          {{#if this.isLoadingMoreOptions}}
+            <AuLoader @hideMessage={{true}} />
+          {{else}}
+            <AuHelpText>Laad meer opties</AuHelpText>
+          {{/if}}
         {{/if}}
-      </PowerSelectMultiple>
-    </c.content>
-  </AuCard>
+      </span>
+    {{else}}
+      <div class="au-u-flex au-u-flex--row au-u-flex-wrap">
+        {{#each form.values as |keyValue|}}
+          <span class="au-u-padding-right-small">
+            <AuHelpText>{{keyValue.key}}: </AuHelpText>
+            {{keyValue.value}}
+          </span>
+        {{/each}}
+      </div>
+    {{/if}}
+  </PowerSelectMultiple>
 </RdfInputFields::CustomFieldWrapper>

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -38,22 +38,14 @@
         @options={{this.formOptions}}
         as |form|
       >
-        <AuTable @size={{this.size}}>
-          <:header>
-            <tr>
-              {{#each form.values as |keyValue|}}
-                <th>{{keyValue.key}}</th>
-              {{/each}}
-            </tr>
-          </:header>
-          <:body>
-            <tr>
-              {{#each form.values as |keyValue|}}
-                <td>{{keyValue.value}}</td>
-              {{/each}}
-            </tr>
-          </:body>
-        </AuTable>
+        <AuList @direction="vertical" @divider={{true}} as |Item|>
+          {{#each form.values as |keyValue|}}
+            <Item>
+              <AuHelpText>{{keyValue.key}}: </AuHelpText>
+              {{keyValue.value}}
+            </Item>
+          {{/each}}
+        </AuList>
       </PowerSelect>
     </c.content>
   </AuCard>

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -11,7 +11,7 @@
     @noMatchesMessage="Geen resultaten"
     @searchMessage="Typ om te zoeken"
     @searchEnabled={{true}}
-    @search={{perform this.searchForm}}
+    @searchField="searchString"
     @allowClear={{false}}
     @placeholder="Selecteer instantie"
     @selected={{this.selectedInstances}}

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -17,6 +17,7 @@
     @selected={{this.selectedInstances}}
     @onChange={{this.selectInstance}}
     @options={{this.instancesAsOptions}}
+    @onOpen={{this.onOpenSelector}}
     as |instance|
   >
     {{#if (eq instance.id this.LOAD_MORE_ID)}}

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -15,13 +15,13 @@
         @searchEnabled={{true}}
         @allowClear={{false}}
         @placeholder="Type van het formulier"
-        @searchField="id"
+        @searchField="label"
         @selected={{this.formType}}
         @onChange={{this.selectFormType}}
         @options={{this.formTypes}}
         as |form|
       >
-        {{form.id}}
+        {{form.label}}
       </PowerSelect>
       <PowerSelect
         @disabled={{not this.formType}}

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -17,7 +17,6 @@
     @selected={{this.selectedInstances}}
     @onChange={{this.selectInstance}}
     @options={{this.instancesAsOptions}}
-    @onClose={{this.preventCloseOnLoadMoreOptions}}
     as |instance|
   >
     {{#if (eq instance.id this.LOAD_MORE_ID)}}

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -21,14 +21,8 @@
     as |instance|
   >
     {{#if (eq instance.id this.LOAD_MORE_ID)}}
-      <span
-        class="au-u-flex au-u-flex--center au-u-padding-top-small au-u-padding-bottom-small"
-      >
-        {{#if this.isFetchingInstances}}
-          <AuLoader @hideMessage={{true}} />
-        {{else}}
-          <AuHelpText>Laad meer opties</AuHelpText>
-        {{/if}}
+      <span class="au-u-flex au-u-flex--center">
+        <AuLoader @hideMessage={{true}} />
       </span>
     {{else}}
       <div class="au-u-flex au-u-flex--row au-u-flex-wrap">

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -5,6 +5,8 @@
   @graphs={{@graphs}}
   @formStore={{@formStore}}
 >
+  <h1>can load more? {{this.areAllInstancesFetched}}</h1>
+  <h1>is load more? {{this.isLoadingMoreOptions}}</h1>
   <PowerSelectMultiple
     @labelText="Formulier"
     @loadingMessage="Aan het laden..."
@@ -20,16 +22,14 @@
     @onClose={{this.preventCloseOnLoadMoreOptions}}
     as |instance|
   >
-    {{#if (eq instance.id "load-more-options")}}
+    {{#if (eq instance.id this.LOAD_MORE_ID)}}
       <span
         class="au-u-flex au-u-flex--center au-u-padding-top-small au-u-padding-bottom-small"
       >
-        {{#if this.canShowLoadMoreOptions}}
-          {{#if this.isLoadingMoreOptions}}
-            <AuLoader @hideMessage={{true}} />
-          {{else}}
-            <AuHelpText>Laad meer opties</AuHelpText>
-          {{/if}}
+        {{#if this.isLoadingMoreOptions}}
+          <AuLoader @hideMessage={{true}} />
+        {{else}}
+          <AuHelpText>Laad meer opties</AuHelpText>
         {{/if}}
       </span>
     {{else}}

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -5,8 +5,6 @@
   @graphs={{@graphs}}
   @formStore={{@formStore}}
 >
-  <h1>can load more? {{this.areAllInstancesFetched}}</h1>
-  <h1>is load more? {{this.isLoadingMoreOptions}}</h1>
   <PowerSelectMultiple
     @labelText="Formulier"
     @loadingMessage="Aan het laden..."
@@ -26,7 +24,7 @@
       <span
         class="au-u-flex au-u-flex--center au-u-padding-top-small au-u-padding-bottom-small"
       >
-        {{#if this.isLoadingMoreOptions}}
+        {{#if this.isFetchingInstances}}
           <AuLoader @hideMessage={{true}} />
         {{else}}
           <AuHelpText>Laad meer opties</AuHelpText>

--- a/app/components/custom-form/link-to-form-instance.hbs
+++ b/app/components/custom-form/link-to-form-instance.hbs
@@ -38,24 +38,8 @@
         @options={{this.formOptions}}
         as |form|
       >
-        {{form.label}}
+        {{form}}
       </PowerSelect>
-      <PowerSelectMultiple
-        @disabled={{not this.form}}
-        @labelText="Velden"
-        @searchField="label"
-        @searchPlaceholder="Zoek een veld in het formulier"
-        @searchEnabled={{true}}
-        @selected={{this.fields}}
-        @options={{this.fieldOptions}}
-        @onChange={{this.updateSelectedFields}}
-        @allowClear={{false}}
-        @loadingMessage="Aan het laden..."
-        @noMatchesMessage="Geen resultaten gevonden"
-        as |field|
-      >
-        {{field.label}}
-      </PowerSelectMultiple>
     </c.content>
   </AuCard>
 </RdfInputFields::CustomFieldWrapper>

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -92,6 +92,11 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
         searchString: Object.values(instance).join(';'),
       });
     }
+
+    if (this.isFetchingInstances) {
+      instances.push({ id: this.LOAD_MORE_ID, disabled: true });
+    }
+
     return instances;
   }
 
@@ -178,7 +183,6 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
     );
     this.instanceDisplayLabels = formInfo.labels;
     this.instances.pushObjects(formInfo.instances);
-
     this.getInstances.perform(
       page,
       formInfo.instances.meta.pagination.last?.number

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -48,7 +48,7 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
   get formTypeId() {
     return this.storeOptions.store.any(
       this.args.field.uri,
-      EXT('targetTypeId'),
+      EXT('linkedFormType'),
       undefined,
       this.storeOptions.formGraph
     )?.value;

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -23,8 +23,19 @@ export default class CustomFormLinkToFormInstance extends InputFieldComponent {
   async selectFormType(type) {
     this.formType = type;
     replaceSingleFormValue(this.storeOptions, null);
+    const formInstances = await this.fetchFormsForType();
     this.formOptions.clear();
-    this.formOptions.pushObjects(await this.fetchFormsForType());
+    this.formOptions.pushObjects(
+      formInstances.map((instance) => {
+        delete instance.uri;
+        delete instance.id;
+        return {
+          values: Object.keys(instance).map((key) => {
+            return { key, value: instance[key] };
+          }),
+        };
+      })
+    );
   }
 
   @action
@@ -58,20 +69,13 @@ export default class CustomFormLinkToFormInstance extends InputFieldComponent {
       this.formType.id
     );
     const summaryLabels = allLabels.filter((label) => label.isShownInSummary);
-    const form = await this.semanticFormRepository.fetchInstances(
+    const formInfo = await this.semanticFormRepository.fetchInstances(
       { id: this.formType.id },
       {
         labels: summaryLabels,
       }
     );
-    let label = summaryLabels[0]?.name || 'uri';
-
-    return form.instances.map((instance) => {
-      return {
-        label: instance[label] || instance.uri,
-        uri: instance.uri,
-      };
-    });
+    return formInfo.instances;
   }
 }
 

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -186,10 +186,13 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
       return [];
     }
     const formTypes = await response.json();
+    const currentFormTypeId = this.formContext?.formDefinition?.id;
     this.formTypes = [
       {
         groupName: 'Eigen types',
-        options: formTypes.customTypes,
+        options: formTypes.customTypes.filter(
+          (t) => t.id !== currentFormTypeId
+        ),
       },
       {
         groupName: 'Standaard types',

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -11,6 +11,7 @@ import {
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
 import { NamedNode } from 'rdflib';
+import { consume } from 'ember-provide-consume-context';
 
 import {
   API,
@@ -18,7 +19,6 @@ import {
   JSON_API_TYPE,
 } from 'frontend-lmb/utils/constants';
 import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
-import { consume } from 'ember-provide-consume-context';
 
 export default class CustomFormLinkToFormInstance extends SelectorComponent {
   @service store;
@@ -97,10 +97,11 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
       };
     });
     this.formOptions.pushObjects(uniqueFormOptionsToAdd);
-    this.formOptions.pushObject({
-      id: 'load-more-options',
-      disabled: !this.canShowLoadMoreOptions,
-    });
+    if (this.canShowLoadMoreOptions) {
+      this.formOptions.pushObject({
+        id: 'load-more-options',
+      });
+    }
   }
 
   @action

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -107,9 +107,17 @@ export default class CustomFormLinkToFormInstance extends InputFieldComponent {
       this.formType = [
         ...formTypes.customTypes,
         ...formTypes.defaultTypes,
-      ].find((type) => type.usageUris.includes(selectedFormUri));
-      await this.setFormOptions();
-      this.form = this.formOptions.find((form) => form.uri === selectedFormUri);
+      ].find(
+        (type) =>
+          type.usageUris?.includes(selectedFormUri) ||
+          selectedFormUri.startsWith(type.prefix)
+      );
+      if (this.formType) {
+        await this.setFormOptions();
+        this.form = this.formOptions.find(
+          (form) => form.uri === selectedFormUri
+        );
+      }
     }
   });
 }

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -82,6 +82,9 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
         }),
         instance,
         searchString: [...Object.values(instance), instance.id].join(';'),
+        disabled: this.selectedInstances.find(
+          (o) => o.instance.id === instance.id
+        ),
       });
     }
 

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -10,6 +10,7 @@ import { triplesForPath } from '@lblod/submission-form-helpers';
 
 import { API } from 'frontend-lmb/utils/constants';
 import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
+
 export default class CustomFormLinkToFormInstance extends InputFieldComponent {
   @service store;
   @service semanticFormRepository;
@@ -63,7 +64,15 @@ export default class CustomFormLinkToFormInstance extends InputFieldComponent {
         labels: summaryLabels,
       }
     );
-    return formInfo.instances;
+    return formInfo.instances.map((instance) => {
+      let cleanedUpInstance = {
+        id: instance.id,
+      };
+      for (const label of formInfo.labels) {
+        cleanedUpInstance[label.name] = instance[label.name];
+      }
+      return cleanedUpInstance;
+    });
   }
 
   setInitalValues = task(async () => {

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -5,32 +5,33 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-import { task, timeout } from 'ember-concurrency';
 import {
   triplesForPath,
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
-import { NamedNode } from 'rdflib';
+import { Literal } from 'rdflib';
 import { consume } from 'ember-provide-consume-context';
 
-import {
-  API,
-  INPUT_DEBOUNCE,
-  JSON_API_TYPE,
-} from 'frontend-lmb/utils/constants';
+import { API, JSON_API_TYPE } from 'frontend-lmb/utils/constants';
 import { EXT } from 'frontend-lmb/rdf/namespaces';
+import { trackedFunction } from 'reactiveweb/function';
+import { use } from 'ember-resources';
 export default class CustomFormLinkToFormInstance extends SelectorComponent {
   @service store;
   @service semanticFormRepository;
 
+  @use(getAllFormLabels) getAllFormLabels;
+  @use(getInstances) getInstances;
+
   @consume('form-context') formContext;
 
-  @tracked forms = A([]);
-  @tracked formOptions = A([]);
-  @tracked summaryLabels = [];
+  // @tracked formOptions = A([]);
+  // @tracked summaryLabels = [];
+  @tracked selectedInstances = A([]);
+  @tracked instanceDisplayLabels = [];
   @tracked pageToLoad = 0;
   @tracked searchFilter;
-  @tracked isLoadingMoreOptions;
+  // @tracked isLoadingMoreOptions;
   @tracked canShowLoadMoreOptions = true;
 
   get formTypeId() {
@@ -42,148 +43,192 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
     )?.value;
   }
 
+  get labelsForFormType() {
+    return this.getAllFormLabels?.value || [];
+  }
+
+  get instances() {
+    return this.getInstances?.value || [];
+  }
+
+  get instancesAsOptions() {
+    const keysOfLabels = this.instanceDisplayLabels.map((label) => label.name);
+    return this.instances.map((instance) => {
+      return {
+        option: keysOfLabels.map((key) => {
+          return {
+            key: key,
+            value: instance[key],
+          };
+        }),
+        id: instance.id,
+      };
+    });
+  }
+
+  async loadOptions() {}
+
   @action
-  async selectFormsOfType(forms) {
-    if (forms.filter((f) => f.id === 'load-more-options')?.length === 1) {
-      this.isLoadingMoreOptions = true;
-      await this.setFormOptions();
-      this.isLoadingMoreOptions = false;
-      return;
-    }
-    this.forms.clear();
-    this.forms.pushObjects(forms);
+  selectInstance(selectedInstances) {
+    this.selectedInstances.clear();
+    this.selectedInstances.pushObjects(selectedInstances);
     const matches = triplesForPath(this.storeOptions, true).values;
+    console.log({ matches });
     matches
-      .filter((m) => !forms.find((form) => m.value === form.uri))
+      .filter(
+        (m) => !selectedInstances.find((instance) => m.value === instance.id)
+      )
       .forEach((m) => updateSimpleFormValue(this.storeOptions, undefined, m));
-    forms
-      .filter((form) => !matches.find((m) => form.uri === m.value))
+    selectedInstances
+      .filter((instance) => !matches.find((m) => instance.id === m.value))
       .forEach((option) =>
-        updateSimpleFormValue(this.storeOptions, new NamedNode(option.uri))
+        updateSimpleFormValue(this.storeOptions, new Literal(option.id))
       );
     super.updateSelectedItems();
   }
 
-  async setFormOptions(instanceUris = null) {
-    const formInstances = await this.fetchFormsForType(instanceUris);
-    if (!this.isLoadingMoreOptions) {
-      this.forms.clear();
-    }
-    if (formInstances.length === 0) {
-      return;
-    }
-    if (this.formOptions.length > 0) {
-      this.formOptions.popObject();
-    }
-    const addedOptionUris = this.formOptions.map((o) => o.instance?.uri);
-    const uniqueFormOptionsToAdd = formInstances.map((instance) => {
-      if (addedOptionUris.includes(instance.instance.uri)) {
-        return;
-      } else {
-        addedOptionUris.push(instance.instance.uri);
-      }
-      return {
-        id: instance.instance.id,
-        uri: instance.instance.uri,
-        values: Object.keys(instance.displayInstance).map((key) => {
-          return { key, value: instance.displayInstance[key] };
-        }),
-      };
-    });
-    this.formOptions.pushObjects(uniqueFormOptionsToAdd);
-    if (this.canShowLoadMoreOptions) {
-      this.formOptions.pushObject({
-        id: 'load-more-options',
-      });
-    }
-  }
+  // @action
+  // async selectFormsOfType(forms) {
+  //   if (forms.filter((f) => f.id === 'load-more-options')?.length === 1) {
+  //     this.isLoadingMoreOptions = true;
+  //     await this.setFormOptions();
+  //     this.isLoadingMoreOptions = false;
+  //     return;
+  //   }
+  //   this.forms.clear();
+  //   this.forms.pushObjects(forms);
+  //   const matches = triplesForPath(this.storeOptions, true).values;
+  //   matches
+  //     .filter((m) => !forms.find((form) => m.value === form.uri))
+  //     .forEach((m) => updateSimpleFormValue(this.storeOptions, undefined, m));
+  //   forms
+  //     .filter((form) => !matches.find((m) => form.uri === m.value))
+  //     .forEach((option) =>
+  //       updateSimpleFormValue(this.storeOptions, new NamedNode(option.uri))
+  //     );
+  //   super.updateSelectedItems();
+  // }
 
-  @action
-  preventCloseOnLoadMoreOptions() {
-    if (this.isLoadingMoreOptions) {
-      return false;
-    }
-  }
+  // async setFormOptions(instanceUris = null) {
+  //   const formInstances = await this.fetchFormsForType(instanceUris);
+  //   if (!this.isLoadingMoreOptions) {
+  //     this.forms.clear();
+  //   }
+  //   if (formInstances.length === 0) {
+  //     return;
+  //   }
+  //   if (this.formOptions.length > 0) {
+  //     this.formOptions.popObject();
+  //   }
+  //   const addedOptionUris = this.formOptions.map((o) => o.instance?.uri);
+  //   const uniqueFormOptionsToAdd = formInstances.map((instance) => {
+  //     if (addedOptionUris.includes(instance.instance.uri)) {
+  //       return;
+  //     } else {
+  //       addedOptionUris.push(instance.instance.uri);
+  //     }
+  //     return {
+  //       id: instance.instance.id,
+  //       uri: instance.instance.uri,
+  //       values: Object.keys(instance.displayInstance).map((key) => {
+  //         return { key, value: instance.displayInstance[key] };
+  //       }),
+  //     };
+  //   });
+  //   this.formOptions.pushObjects(uniqueFormOptionsToAdd);
+  //   if (this.canShowLoadMoreOptions) {
+  //     this.formOptions.pushObject({
+  //       id: 'load-more-options',
+  //     });
+  //   }
+  // }
 
-  searchForm = task({ restartable: true }, async (input) => {
-    await timeout(INPUT_DEBOUNCE);
-    if (this.searchFilter !== input?.trim()) {
-      this.pageToLoad = 0;
-      this.formOptions.clear();
-    }
-    this.searchFilter = input?.trim();
-    await this.setFormOptions();
-  });
+  // @action
+  // preventCloseOnLoadMoreOptions() {
+  //   if (this.isLoadingMoreOptions) {
+  //     return false;
+  //   }
+  // }
 
-  @action
-  async fetchFormsForType(instanceUris = null) {
-    const allLabels = await this.semanticFormRepository.getHeaderLabels(
-      this.formTypeId
-    );
-    const summaryLabels = allLabels.filter((label) => label.isShownInSummary);
-    const filterParams = {
-      labels: summaryLabels,
-      page: this.pageToLoad,
-      size: 20,
-      filter: this.searchFilter,
-    };
-    if (!this.searchFilter) {
-      delete filterParams.filter;
-    }
+  // searchForm = task({ restartable: true }, async (input) => {
+  //   await timeout(INPUT_DEBOUNCE);
+  //   if (this.searchFilter !== input?.trim()) {
+  //     this.pageToLoad = 0;
+  //     this.formOptions.clear();
+  //   }
+  //   this.searchFilter = input?.trim();
+  //   await this.setFormOptions();
+  // });
 
-    const instances = [];
-    const formInfo = await this.semanticFormRepository.fetchInstances(
-      { id: this.formTypeId },
-      filterParams
-    );
-    instances.push(...formInfo.instances);
+  // @action
+  // async fetchFormsForType(instanceUris = null) {
+  //   const allLabels = await this.semanticFormRepository.getHeaderLabels(
+  //     this.formTypeId
+  //   );
+  //   const summaryLabels = allLabels.filter((label) => label.isShownInSummary);
+  //   const filterParams = {
+  //     labels: summaryLabels,
+  //     page: this.pageToLoad,
+  //     size: 20,
+  //     filter: this.searchFilter,
+  //   };
+  //   if (!this.searchFilter) {
+  //     delete filterParams.filter;
+  //   }
 
-    this.summaryLabels = formInfo.labels;
-    const currentPage = formInfo.instances.meta.pagination.self.number;
-    const lastPage = formInfo.instances.meta.pagination.last.number;
-    this.pageToLoad =
-      formInfo.instances.meta.pagination.next?.number ?? currentPage;
-    this.canShowLoadMoreOptions = lastPage !== currentPage;
-    if (instanceUris) {
-      const formInfoForUris = await this.fetchInstancesForUris(instanceUris);
-      instances.push(...formInfoForUris.instances);
-    }
+  //   const instances = [];
+  //   const formInfo = await this.semanticFormRepository.fetchInstances(
+  //     { id: this.formTypeId },
+  //     filterParams
+  //   );
+  //   instances.push(...formInfo.instances);
 
-    const addedInstanceUris = [];
-    return instances
-      .map((instance) => {
-        if (addedInstanceUris.includes(instance.uri)) {
-          return;
-        } else {
-          addedInstanceUris.push(instance.uri);
-        }
+  //   this.summaryLabels = formInfo.labels;
+  //   const currentPage = formInfo.instances.meta.pagination.self.number;
+  //   const lastPage = formInfo.instances.meta.pagination.last.number;
+  //   this.pageToLoad =
+  //     formInfo.instances.meta.pagination.next?.number ?? currentPage;
+  //   this.canShowLoadMoreOptions = lastPage !== currentPage;
+  //   if (instanceUris) {
+  //     const formInfoForUris = await this.fetchInstancesForUris(instanceUris);
+  //     instances.push(...formInfoForUris.instances);
+  //   }
 
-        let cleanedUpInstance = {};
-        for (const label of formInfo.labels) {
-          cleanedUpInstance[label.name] = instance[label.name];
-        }
-        return {
-          displayInstance: cleanedUpInstance,
-          instance,
-        };
-      })
-      .filter((isInstance) => isInstance);
-  }
+  //   const addedInstanceUris = [];
+  //   return instances
+  //     .map((instance) => {
+  //       if (addedInstanceUris.includes(instance.uri)) {
+  //         return;
+  //       } else {
+  //         addedInstanceUris.push(instance.uri);
+  //       }
 
-  async loadOptions() {
-    const matches = triplesForPath(this.storeOptions);
-    console.log('matches', matches);
-    if (matches.values.length > 0) {
-      const selectedFormUris = matches.values.map((v) => v.value);
-      console.log('formTypeId', this.formTypeId);
-      if (this.formTypeId) {
-        await this.setFormOptions(selectedFormUris);
-        this.forms.pushObjects(
-          this.formOptions.filter((form) => selectedFormUris.includes(form.uri))
-        );
-      }
-    }
-  }
+  //       let cleanedUpInstance = {};
+  //       for (const label of formInfo.labels) {
+  //         cleanedUpInstance[label.name] = instance[label.name];
+  //       }
+  //       return {
+  //         displayInstance: cleanedUpInstance,
+  //         instance,
+  //       };
+  //     })
+  //     .filter((isInstance) => isInstance);
+  // }
+
+  // async loadOptions() {
+  //   const matches = triplesForPath(this.storeOptions);
+  //   console.log('matches', matches);
+  //   if (matches.values.length > 0) {
+  //     const selectedFormUris = matches.values.map((v) => v.value);
+  //     console.log('formTypeId', this.formTypeId);
+  //     if (this.formTypeId) {
+  //       await this.setFormOptions(selectedFormUris);
+  //       this.forms.pushObjects(
+  //         this.formOptions.filter((form) => selectedFormUris.includes(form.uri))
+  //       );
+  //     }
+  //   }
+  // }
 
   async fetchInstancesForUris(uris) {
     const response = await fetch(
@@ -208,4 +253,51 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
 
     return await response.json();
   }
+}
+
+function getInstances() {
+  return trackedFunction(async () => {
+    const filterParams = {
+      labels: this.labelsForFormType,
+      page: this.pageToLoad,
+      size: 20,
+      filter: this.searchFilter,
+    };
+    if (!this.searchFilter) {
+      delete filterParams.filter;
+    }
+    const formInfo = await this.semanticFormRepository.fetchInstances(
+      { id: this.formTypeId },
+      filterParams
+    );
+    const pagination = formInfo.instances.meta.pagination;
+    console.log({ pagination });
+    if (this.pageToLoad === pagination.last.number) {
+      console.log(`all instances fetched`);
+      this.canShowLoadMoreOptions = false;
+    }
+    this.pageToLoad = pagination.next?.number || this.pageToLoad;
+    this.instanceDisplayLabels = formInfo.labels;
+
+    const availableInstanceIds = this.instances.map((i) => i.id);
+    if (availableInstanceIds.length === 0) {
+      return formInfo.instances;
+    }
+    const newInstances = formInfo.instances.filter(
+      (i) => !availableInstanceIds.includes(i.id)
+    );
+    const instances = [...this.instances, ...newInstances];
+    instances.meta.pagination = pagination;
+
+    return instances;
+  });
+}
+
+function getAllFormLabels() {
+  return trackedFunction(async () => {
+    const allLabels = await this.semanticFormRepository.getHeaderLabels(
+      this.formTypeId
+    );
+    return allLabels.filter((label) => label.isShownInSummary);
+  });
 }

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -81,18 +81,22 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
     if (this.formOptions.length > 0) {
       this.formOptions.popObject();
     }
-
-    this.formOptions.pushObjects(
-      formInstances.map((instance) => {
-        return {
-          id: instance.instance.id,
-          uri: instance.instance.uri,
-          values: Object.keys(instance.displayInstance).map((key) => {
-            return { key, value: instance.displayInstance[key] };
-          }),
-        };
-      })
-    );
+    const addedOptionUris = this.formOptions.map((o) => o.instance?.uri);
+    const uniqueFormOptionsToAdd = formInstances.map((instance) => {
+      if (addedOptionUris.includes(instance.instance.uri)) {
+        return;
+      } else {
+        addedOptionUris.push(instance.instance.uri);
+      }
+      return {
+        id: instance.instance.id,
+        uri: instance.instance.uri,
+        values: Object.keys(instance.displayInstance).map((key) => {
+          return { key, value: instance.displayInstance[key] };
+        }),
+      };
+    });
+    this.formOptions.pushObjects(uniqueFormOptionsToAdd);
     this.formOptions.pushObject({
       id: 'load-more-options',
       disabled: !this.canShowLoadMoreOptions,
@@ -146,18 +150,18 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
     this.pageToLoad =
       formInfo.instances.meta.pagination.next?.number ?? currentPage;
     this.canShowLoadMoreOptions = lastPage !== currentPage;
-    const formInfoForUris = await this.fetchInstancesForUris(instanceUris);
-    if (formInfoForUris) {
+    if (instanceUris) {
+      const formInfoForUris = await this.fetchInstancesForUris(instanceUris);
       instances.push(...formInfoForUris.instances);
     }
 
-    const uniqueInstanceUris = [];
+    const addedInstanceUris = [];
     return instances
       .map((instance) => {
-        if (uniqueInstanceUris.includes(instance.uri)) {
+        if (addedInstanceUris.includes(instance.uri)) {
           return;
         } else {
-          uniqueInstanceUris.push(instance.uri);
+          addedInstanceUris.push(instance.uri);
         }
 
         let cleanedUpInstance = {};

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -143,7 +143,7 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
       { id: this.formType.id },
       filterParams
     );
-    instances.push(...[...formInfo.instances]);
+    instances.push(...formInfo.instances);
 
     this.summaryLabels = formInfo.labels;
     const currentPage = formInfo.instances.meta.pagination.self.number;

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -68,6 +68,8 @@ export default class CustomFormLinkToFormInstance extends InputFieldComponent {
       { id: this.formType.id },
       {
         labels: summaryLabels,
+        size: 9999, // FIXEM how can we paginate this? data-monitoring has an infinite list
+        page: 0,
       }
     );
     return formInfo.instances.map((instance) => {

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -60,6 +60,10 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
     const keysOfLabels = this.instanceDisplayLabels.map((label) => label.name);
     const uniqueInstanceIds = [];
     const instances = [];
+    if (this.isFetchingInstances) {
+      instances.push({ id: this.LOAD_MORE_ID, disabled: true });
+    }
+
     for (const instance of [
       ...this.instances,
       ...this.initialSelectedInstances,
@@ -79,10 +83,6 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
         instance,
         searchString: [...Object.values(instance), instance.id].join(';'),
       });
-    }
-
-    if (this.isFetchingInstances) {
-      instances.push({ id: this.LOAD_MORE_ID, disabled: true });
     }
 
     return instances;

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -22,17 +22,19 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
 
   @use(getAllFormLabels) getAllFormLabels;
   @use(getInstances) getInstances;
+  @use(getInitialSelectedInstances) getInitialSelectedInstances;
 
   @consume('form-context') formContext;
 
-  // @tracked formOptions = A([]);
-  // @tracked summaryLabels = [];
+  @tracked extraInstanceUris = [];
   @tracked selectedInstances = A([]);
   @tracked instanceDisplayLabels = [];
   @tracked pageToLoad = 0;
   @tracked searchFilter;
-  // @tracked isLoadingMoreOptions;
-  @tracked canShowLoadMoreOptions = true;
+  @tracked isLoadingMoreOptions;
+  @tracked areAllInstancesFetched;
+
+  LOAD_MORE_ID = 'load-more-instances';
 
   get formTypeId() {
     return this.storeOptions.store.any(
@@ -51,104 +53,83 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
     return this.getInstances?.value || [];
   }
 
+  get initialSelectedInstances() {
+    return this.getInitialSelectedInstances?.value || [];
+  }
+
   get instancesAsOptions() {
     const keysOfLabels = this.instanceDisplayLabels.map((label) => label.name);
-    return this.instances.map((instance) => {
-      return {
+    const uniqueInstanceIds = [];
+    const instances = [];
+    for (const instance of [
+      ...this.instances,
+      ...this.initialSelectedInstances,
+    ]) {
+      if (uniqueInstanceIds.includes(instance.id)) {
+        continue;
+      } else {
+        uniqueInstanceIds.push(instance.id);
+      }
+      instances.push({
         option: keysOfLabels.map((key) => {
           return {
             key: key,
             value: instance[key],
           };
         }),
-        id: instance.id,
-      };
-    });
+        uri: instance.uri,
+      });
+    }
+
+    if (!this.areAllInstancesFetched) {
+      instances.push({
+        id: this.LOAD_MORE_ID,
+      });
+    }
+
+    return instances;
   }
 
-  async loadOptions() {}
+  async loadOptions() {
+    const matches = triplesForPath(this.storeOptions);
+    if (matches.values.length > 0) {
+      this.extraInstanceUris.push(...matches.values.map((v) => v.value));
+    }
+  }
 
   @action
-  selectInstance(selectedInstances) {
+  async selectInstance(selectedInstances) {
+    if (
+      selectedInstances.filter((f) => f.id === this.LOAD_MORE_ID)?.length === 1
+    ) {
+      this.isLoadingMoreOptions = true;
+      // await this.setFormOptions();
+      this.isLoadingMoreOptions = false;
+      return;
+    }
+
     this.selectedInstances.clear();
     this.selectedInstances.pushObjects(selectedInstances);
     const matches = triplesForPath(this.storeOptions, true).values;
-    console.log({ matches });
     matches
       .filter(
-        (m) => !selectedInstances.find((instance) => m.value === instance.id)
+        (m) => !selectedInstances.find((instance) => m.value === instance.uri)
       )
       .forEach((m) => updateSimpleFormValue(this.storeOptions, undefined, m));
     selectedInstances
-      .filter((instance) => !matches.find((m) => instance.id === m.value))
+      .filter((instance) => !matches.find((m) => instance.uri === m.value))
       .forEach((option) =>
-        updateSimpleFormValue(this.storeOptions, new Literal(option.id))
+        updateSimpleFormValue(this.storeOptions, new Literal(option.uri))
       );
     super.updateSelectedItems();
   }
 
-  // @action
-  // async selectFormsOfType(forms) {
-  //   if (forms.filter((f) => f.id === 'load-more-options')?.length === 1) {
-  //     this.isLoadingMoreOptions = true;
-  //     await this.setFormOptions();
-  //     this.isLoadingMoreOptions = false;
-  //     return;
-  //   }
-  //   this.forms.clear();
-  //   this.forms.pushObjects(forms);
-  //   const matches = triplesForPath(this.storeOptions, true).values;
-  //   matches
-  //     .filter((m) => !forms.find((form) => m.value === form.uri))
-  //     .forEach((m) => updateSimpleFormValue(this.storeOptions, undefined, m));
-  //   forms
-  //     .filter((form) => !matches.find((m) => form.uri === m.value))
-  //     .forEach((option) =>
-  //       updateSimpleFormValue(this.storeOptions, new NamedNode(option.uri))
-  //     );
-  //   super.updateSelectedItems();
-  // }
-
-  // async setFormOptions(instanceUris = null) {
-  //   const formInstances = await this.fetchFormsForType(instanceUris);
-  //   if (!this.isLoadingMoreOptions) {
-  //     this.forms.clear();
-  //   }
-  //   if (formInstances.length === 0) {
-  //     return;
-  //   }
-  //   if (this.formOptions.length > 0) {
-  //     this.formOptions.popObject();
-  //   }
-  //   const addedOptionUris = this.formOptions.map((o) => o.instance?.uri);
-  //   const uniqueFormOptionsToAdd = formInstances.map((instance) => {
-  //     if (addedOptionUris.includes(instance.instance.uri)) {
-  //       return;
-  //     } else {
-  //       addedOptionUris.push(instance.instance.uri);
-  //     }
-  //     return {
-  //       id: instance.instance.id,
-  //       uri: instance.instance.uri,
-  //       values: Object.keys(instance.displayInstance).map((key) => {
-  //         return { key, value: instance.displayInstance[key] };
-  //       }),
-  //     };
-  //   });
-  //   this.formOptions.pushObjects(uniqueFormOptionsToAdd);
-  //   if (this.canShowLoadMoreOptions) {
-  //     this.formOptions.pushObject({
-  //       id: 'load-more-options',
-  //     });
-  //   }
-  // }
-
-  // @action
-  // preventCloseOnLoadMoreOptions() {
-  //   if (this.isLoadingMoreOptions) {
-  //     return false;
-  //   }
-  // }
+  @action
+  preventCloseOnLoadMoreOptions() {
+    if (this.isLoadingMoreOptions) {
+      return false;
+    }
+  }
 
   // searchForm = task({ restartable: true }, async (input) => {
   //   await timeout(INPUT_DEBOUNCE);
@@ -160,76 +141,6 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
   //   await this.setFormOptions();
   // });
 
-  // @action
-  // async fetchFormsForType(instanceUris = null) {
-  //   const allLabels = await this.semanticFormRepository.getHeaderLabels(
-  //     this.formTypeId
-  //   );
-  //   const summaryLabels = allLabels.filter((label) => label.isShownInSummary);
-  //   const filterParams = {
-  //     labels: summaryLabels,
-  //     page: this.pageToLoad,
-  //     size: 20,
-  //     filter: this.searchFilter,
-  //   };
-  //   if (!this.searchFilter) {
-  //     delete filterParams.filter;
-  //   }
-
-  //   const instances = [];
-  //   const formInfo = await this.semanticFormRepository.fetchInstances(
-  //     { id: this.formTypeId },
-  //     filterParams
-  //   );
-  //   instances.push(...formInfo.instances);
-
-  //   this.summaryLabels = formInfo.labels;
-  //   const currentPage = formInfo.instances.meta.pagination.self.number;
-  //   const lastPage = formInfo.instances.meta.pagination.last.number;
-  //   this.pageToLoad =
-  //     formInfo.instances.meta.pagination.next?.number ?? currentPage;
-  //   this.canShowLoadMoreOptions = lastPage !== currentPage;
-  //   if (instanceUris) {
-  //     const formInfoForUris = await this.fetchInstancesForUris(instanceUris);
-  //     instances.push(...formInfoForUris.instances);
-  //   }
-
-  //   const addedInstanceUris = [];
-  //   return instances
-  //     .map((instance) => {
-  //       if (addedInstanceUris.includes(instance.uri)) {
-  //         return;
-  //       } else {
-  //         addedInstanceUris.push(instance.uri);
-  //       }
-
-  //       let cleanedUpInstance = {};
-  //       for (const label of formInfo.labels) {
-  //         cleanedUpInstance[label.name] = instance[label.name];
-  //       }
-  //       return {
-  //         displayInstance: cleanedUpInstance,
-  //         instance,
-  //       };
-  //     })
-  //     .filter((isInstance) => isInstance);
-  // }
-
-  // async loadOptions() {
-  //   const matches = triplesForPath(this.storeOptions);
-  //   console.log('matches', matches);
-  //   if (matches.values.length > 0) {
-  //     const selectedFormUris = matches.values.map((v) => v.value);
-  //     console.log('formTypeId', this.formTypeId);
-  //     if (this.formTypeId) {
-  //       await this.setFormOptions(selectedFormUris);
-  //       this.forms.pushObjects(
-  //         this.formOptions.filter((form) => selectedFormUris.includes(form.uri))
-  //       );
-  //     }
-  //   }
-  // }
-
   async fetchInstancesForUris(uris) {
     const response = await fetch(
       `${API.FORM_CONTENT_SERVICE}/${this.formTypeId}/get-instances-by-uri`,
@@ -239,7 +150,7 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
           'Content-Type': JSON_API_TYPE,
         },
         body: JSON.stringify({
-          labels: this.summaryLabels,
+          labels: this.labelsForFormType,
           uris,
         }),
       }
@@ -251,12 +162,17 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
       return null;
     }
 
-    return await response.json();
+    const result = await response.json();
+    return result.instances;
   }
 }
 
 function getInstances() {
   return trackedFunction(async () => {
+    if (!this.formTypeId) {
+      return [];
+    }
+
     const filterParams = {
       labels: this.labelsForFormType,
       page: this.pageToLoad,
@@ -273,23 +189,15 @@ function getInstances() {
     const pagination = formInfo.instances.meta.pagination;
     console.log({ pagination });
     if (this.pageToLoad === pagination.last.number) {
-      console.log(`all instances fetched`);
-      this.canShowLoadMoreOptions = false;
+      this.areAllInstancesFetched = true;
     }
     this.pageToLoad = pagination.next?.number || this.pageToLoad;
     this.instanceDisplayLabels = formInfo.labels;
-
-    const availableInstanceIds = this.instances.map((i) => i.id);
-    if (availableInstanceIds.length === 0) {
-      return formInfo.instances;
-    }
-    const newInstances = formInfo.instances.filter(
-      (i) => !availableInstanceIds.includes(i.id)
+    const instancesWithoutLoadMoreOption = this.instances.filter(
+      (i) => i.id !== this.LOAD_MORE_ID
     );
-    const instances = [...this.instances, ...newInstances];
-    instances.meta.pagination = pagination;
 
-    return instances;
+    return [...instancesWithoutLoadMoreOption, ...formInfo.instances];
   });
 }
 
@@ -299,5 +207,14 @@ function getAllFormLabels() {
       this.formTypeId
     );
     return allLabels.filter((label) => label.isShownInSummary);
+  });
+}
+
+function getInitialSelectedInstances() {
+  return trackedFunction(async () => {
+    if (!this.formTypeId || this.extraInstanceUris.length === 0) {
+      return [];
+    }
+    return await this.fetchInstancesForUris(this.extraInstanceUris);
   });
 }

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -4,15 +4,21 @@ import { A } from '@ember/array';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
+import { trackedFunction } from 'reactiveweb/function';
+import { use } from 'ember-resources';
+
+import { API } from 'frontend-lmb/utils/constants';
 export default class CustomFormLinkToFormInstance extends Component {
   @tracked formType;
   @tracked form;
   @tracked fields = A([]);
   @tracked selectedFormFields = A([]);
 
+  @use(getFormTypes) getFormTypes;
+
   @action
   selectFormType(type) {
-    console.log({ type });
+    this.formType = type;
   }
 
   @action
@@ -26,7 +32,21 @@ export default class CustomFormLinkToFormInstance extends Component {
   }
 
   get formTypes() {
-    return [];
+    const types = this.getFormTypes?.value;
+
+    if (!types) {
+      return [];
+    }
+    return [
+      {
+        groupName: 'Eigen types',
+        options: types.customTypes,
+      },
+      {
+        groupName: 'Standaar types',
+        options: types.defaultTypes,
+      },
+    ];
   }
 
   get forms() {
@@ -36,4 +56,18 @@ export default class CustomFormLinkToFormInstance extends Component {
   get fieldOptions() {
     return [];
   }
+}
+
+function getFormTypes() {
+  return trackedFunction(async () => {
+    const response = await fetch(
+      `${API.FORM_CONTENT_SERVICE}/custom-form/form-types`
+    );
+
+    if (!response.ok) {
+      console.error('Er ging iets mis bij het ophalen van de formulier types');
+      return [];
+    }
+    return await response.json();
+  });
 }

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -1,0 +1,39 @@
+import Component from '@glimmer/component';
+
+import { A } from '@ember/array';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class CustomFormLinkToFormInstance extends Component {
+  @tracked formType;
+  @tracked form;
+  @tracked fields = A([]);
+  @tracked selectedFormFields = A([]);
+
+  @action
+  selectFormType(type) {
+    console.log({ type });
+  }
+
+  @action
+  selectFormOfType(form) {
+    console.log({ form });
+  }
+
+  @action
+  updateSelectedFields(selected) {
+    console.log({ selected });
+  }
+
+  get formTypes() {
+    return [];
+  }
+
+  get forms() {
+    return [];
+  }
+
+  get fieldOptions() {
+    return [];
+  }
+}

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -12,8 +12,6 @@ import {
 import { NamedNode } from 'rdflib';
 import { consume } from 'ember-provide-consume-context';
 import { task } from 'ember-concurrency';
-import { trackedFunction } from 'reactiveweb/function';
-import { use } from 'ember-resources';
 
 import { API, JSON_API_TYPE } from 'frontend-lmb/utils/constants';
 import { EXT } from 'frontend-lmb/rdf/namespaces';
@@ -22,8 +20,6 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
   @service store;
   @service semanticFormRepository;
 
-  @use(getAllFormLabels) getAllFormLabels;
-
   @consume('form-context') formContext;
 
   @tracked instanceObjectsOfOptions = [];
@@ -31,7 +27,7 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
   @tracked instances = A([]);
   @tracked selectedInstances = A([]);
   @tracked instanceDisplayLabels = [];
-  @tracked pageToLoad;
+  @tracked pageToLoad = 0;
   @tracked lastPageOfInstances;
   @tracked searchFilter;
   @tracked isLoadingMoreOptions;
@@ -45,17 +41,13 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
     this.isSettingInitialSelectedOptions.perform();
   }
 
-  get formTypeId() {
+  get formTypeUri() {
     return this.storeOptions.store.any(
       this.args.field.uri,
       EXT('linkedFormType'),
       undefined,
       this.storeOptions.formGraph
     )?.value;
-  }
-
-  get labelsForFormType() {
-    return this.getAllFormLabels?.value || [];
   }
 
   get isFetchingInstances() {
@@ -121,23 +113,23 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
     super.updateSelectedItems();
   }
 
-  async fetchInstancesForUris(uris) {
+  async fetchInstancesForUris(instanceUris) {
     const response = await fetch(
-      `${API.FORM_CONTENT_SERVICE}/${this.formTypeId}/get-instances-by-uri`,
+      `${API.FORM_CONTENT_SERVICE}/instances/by-form-definition-uri?page[number]=${this.pageToLoad}`,
       {
         method: 'POST',
         headers: {
           'Content-Type': JSON_API_TYPE,
         },
         body: JSON.stringify({
-          labels: this.labelsForFormType,
-          uris,
+          formDefinitionUri: this.formTypeUri,
+          instanceUris,
         }),
       }
     );
     if (!response.ok) {
       console.error(
-        `Er ging iets mis bij het ophalen van instances met uris ${uris.split(', ')}`
+        `Er ging iets mis bij het ophalen van instances met uris ${instanceUris.split(', ')}`
       );
       return null;
     }
@@ -172,14 +164,13 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
   });
 
   getInstances = task({ enqueue: true }, async (page = -1, lastPage = 1) => {
-    if (!this.formTypeId || !lastPage || page >= lastPage) {
+    if (!this.formTypeUri || !lastPage || page >= lastPage) {
       return;
     }
 
     page++;
 
     const filterParams = {
-      labels: this.labelsForFormType,
       page,
       size: 20,
       filter: this.searchFilter,
@@ -187,24 +178,12 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
     if (!this.searchFilter) {
       delete filterParams.filter;
     }
-    const formInfo = await this.semanticFormRepository.fetchInstances(
-      { id: this.formTypeId },
-      filterParams
-    );
+    const formInfo = await this.fetchInstancesForUris([], filterParams);
     this.instanceDisplayLabels = formInfo.labels;
     this.instances.pushObjects(formInfo.instances);
-    this.getInstances.perform(
-      page,
-      formInfo.instances.meta.pagination.last?.number
-    );
-  });
-}
-
-function getAllFormLabels() {
-  return trackedFunction(async () => {
-    const allLabels = await this.semanticFormRepository.getHeaderLabels(
-      this.formTypeId
-    );
-    return allLabels.filter((label) => label.isShownInSummary);
+    // this.getInstances.perform(
+    //   page,
+    //   formInfo.instances.meta.pagination.last?.number
+    // );
   });
 }

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -28,11 +28,6 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
   @tracked isLoadingMoreOptions;
   @tracked canShowLoadMoreOptions = true;
 
-  constructor() {
-    super(...arguments);
-    // this.setInitalValues.perform();
-  }
-
   @action
   async selectFormType(type) {
     this.formType = type;
@@ -47,9 +42,6 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
 
   @action
   async selectFormsOfType(forms) {
-    console.log({ forms });
-    console.log(this.forms);
-
     if (forms.filter((f) => f.id === 'load-more-options').length === 1) {
       this.isLoadingMoreOptions = true;
       await this.setFormOptions();

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -12,11 +12,12 @@ import {
 import { Literal } from 'rdflib';
 import { consume } from 'ember-provide-consume-context';
 import { task } from 'ember-concurrency';
+import { trackedFunction } from 'reactiveweb/function';
+import { use } from 'ember-resources';
 
 import { API, JSON_API_TYPE } from 'frontend-lmb/utils/constants';
 import { EXT } from 'frontend-lmb/rdf/namespaces';
-import { trackedFunction } from 'reactiveweb/function';
-import { use } from 'ember-resources';
+
 export default class CustomFormLinkToFormInstance extends SelectorComponent {
   @service store;
   @service semanticFormRepository;
@@ -166,7 +167,6 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
           )
           .includes(option.instance?.id)
       );
-      console.log({ selectedOptions });
       this.selectedInstances.pushObjects(selectedOptions);
     }
   });

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -1,4 +1,4 @@
-import Component from '@glimmer/component';
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 
 import { A } from '@ember/array';
 import { action } from '@ember/object';
@@ -9,7 +9,8 @@ import { trackedFunction } from 'reactiveweb/function';
 import { use } from 'ember-resources';
 
 import { API } from 'frontend-lmb/utils/constants';
-export default class CustomFormLinkToFormInstance extends Component {
+import { replaceSingleFormValue } from 'frontend-lmb/utils/replaceSingleFormValue';
+export default class CustomFormLinkToFormInstance extends InputFieldComponent {
   @service semanticFormRepository;
 
   @tracked formType;
@@ -21,7 +22,7 @@ export default class CustomFormLinkToFormInstance extends Component {
   @action
   async selectFormType(type) {
     this.formType = type;
-    this.form = null;
+    replaceSingleFormValue(this.storeOptions, null);
     this.formOptions.clear();
     this.formOptions.pushObjects(await this.fetchFormsForType());
   }
@@ -29,6 +30,9 @@ export default class CustomFormLinkToFormInstance extends Component {
   @action
   selectFormOfType(form) {
     this.form = form;
+    replaceSingleFormValue(this.storeOptions, form.uri);
+
+    super.updateValidations();
   }
 
   get formTypes() {
@@ -62,7 +66,12 @@ export default class CustomFormLinkToFormInstance extends Component {
     );
     let label = summaryLabels[0]?.name || 'uri';
 
-    return form.instances.map((instance) => instance[label] || instance.uri);
+    return form.instances.map((instance) => {
+      return {
+        label: instance[label] || instance.uri,
+        uri: instance.uri,
+      };
+    });
   }
 }
 

--- a/app/components/custom-form/link-to-form-instance.js
+++ b/app/components/custom-form/link-to-form-instance.js
@@ -9,7 +9,7 @@ import {
   triplesForPath,
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
-import { Literal } from 'rdflib';
+import { NamedNode } from 'rdflib';
 import { consume } from 'ember-provide-consume-context';
 import { task } from 'ember-concurrency';
 import { trackedFunction } from 'reactiveweb/function';
@@ -103,7 +103,7 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
   async selectInstance(selectedInstances) {
     this.selectedInstances.clear();
     this.selectedInstances.pushObjects(selectedInstances);
-    const matches = triplesForPath(this.storeOptions).values;
+    const matches = triplesForPath(this.storeOptions, true).values;
     matches
       .filter(
         (m) =>
@@ -115,7 +115,7 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
       .forEach((option) =>
         updateSimpleFormValue(
           this.storeOptions,
-          new Literal(option.instance.uri)
+          new NamedNode(option.instance.uri)
         )
       );
     super.updateSelectedItems();
@@ -146,7 +146,7 @@ export default class CustomFormLinkToFormInstance extends SelectorComponent {
   }
 
   isSettingInitialSelectedOptions = task(async () => {
-    const matches = triplesForPath(this.storeOptions);
+    const matches = triplesForPath(this.storeOptions, true);
     if (matches.values.length > 0) {
       const initialSelectedInstanceUris = matches.values.map((v) => v.value);
       const formInfo = await this.fetchInstancesForUris(

--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -32,6 +32,7 @@
         @onCloseModal={{this.formContext.onFormUpdate}}
         @form={{this.formContext.formDefinition}}
         @field={{@field}}
+        @isForFormExtension={{this.formContext.isForFormExtension}}
       />
     {{/if}}
     {{yield}}

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -93,6 +93,7 @@ export default class EditableFormComponent extends Component {
       onFieldClicked: (fieldModel) => this.setClickedField(fieldModel),
       formDefinition: this.currentForm,
       fieldsInForm: this.fields,
+      isForFormExtension: !!this.args.isForFormExtension,
     };
   }
 }

--- a/app/components/link-to-form/select-form-type.hbs
+++ b/app/components/link-to-form/select-form-type.hbs
@@ -1,0 +1,16 @@
+<PowerSelect
+  @labelText="Formulier type"
+  @loadingMessage="Aan het laden..."
+  @noMatchesMessage="Geen resultaten"
+  @searchMessage="Typ om te zoeken"
+  @searchEnabled={{true}}
+  @allowClear={{false}}
+  @placeholder="Formulier"
+  @searchField="label"
+  @selected={{this.selectedFormType}}
+  @onChange={{this.updateFormType}}
+  @options={{this.groupedFormTypes}}
+  as |form|
+>
+  {{form.label}}
+</PowerSelect>

--- a/app/components/link-to-form/select-form-type.hbs
+++ b/app/components/link-to-form/select-form-type.hbs
@@ -1,3 +1,4 @@
+<AuLabel @required={{true}} for="linked-form-type">Formulier type</AuLabel>
 <PowerSelect
   @labelText="Formulier type"
   @loadingMessage="Aan het laden..."

--- a/app/components/link-to-form/select-form-type.js
+++ b/app/components/link-to-form/select-form-type.js
@@ -22,7 +22,7 @@ function getFormTypes() {
     const formTypesWithoutSelf = formTypes.customTypes.filter(
       (t) => t.id !== this.args.formDefintionId
     );
-    if (formTypesWithoutSelf.lenght >= 1) {
+    if (formTypesWithoutSelf.length >= 1) {
       options.push(
         ...formTypesWithoutSelf.map((o) => {
           return {

--- a/app/components/link-to-form/select-form-type.js
+++ b/app/components/link-to-form/select-form-type.js
@@ -70,21 +70,17 @@ export default class LinkToFormSelectFormType extends Component {
   }
 
   get selectedFormType() {
-    if (!this.args.selectedFormTypeUri) {
+    if (!this.args.selectedFormTypeId) {
       return null;
     }
 
-    return this.formTypes.find((type) => {
-      if (!type.uri) {
-        return this.args.selectedFormTypeUri.startsWith(type.prefix);
-      }
-
-      return type.uri === this.args.selectedFormTypeUri;
-    });
+    return this.formTypes.find(
+      (type) => type.id === this.args.selectedFormTypeId
+    );
   }
 
   @action
   updateFormType(formTypeOption) {
-    this.args.onSelectedType?.(formTypeOption.uri || formTypeOption.prefix);
+    this.args.onSelectedType?.(formTypeOption.id);
   }
 }

--- a/app/components/link-to-form/select-form-type.js
+++ b/app/components/link-to-form/select-form-type.js
@@ -1,0 +1,90 @@
+import Component from '@glimmer/component';
+
+import { action } from '@ember/object';
+import { cached } from '@glimmer/tracking';
+
+import { API } from 'frontend-lmb/utils/constants';
+
+import { trackedFunction } from 'reactiveweb/function';
+import { use } from 'ember-resources';
+
+function getFormTypes() {
+  return trackedFunction(async () => {
+    const options = [];
+    const response = await fetch(
+      `${API.FORM_CONTENT_SERVICE}/custom-form/form-type-options`
+    );
+    if (!response.ok) {
+      console.error('Er ging iets mis bij het ophalen van de formulier types');
+      return [];
+    }
+    const formTypes = await response.json();
+    const formTypesWithoutSelf = formTypes.customTypes.filter(
+      (t) => t.id !== this.args.formDefintionId
+    );
+    if (formTypesWithoutSelf.lenght >= 1) {
+      options.push(
+        ...formTypesWithoutSelf.map((o) => {
+          return {
+            ...o,
+            isCustomType: true,
+          };
+        })
+      );
+    }
+    options.push(
+      ...formTypes.defaultTypes.map((o) => {
+        return {
+          ...o,
+          isDefaultType: true,
+        };
+      })
+    );
+    return options;
+  });
+}
+export default class LinkToFormSelectFormType extends Component {
+  @use(getFormTypes) getFormTypes;
+
+  @cached
+  get formTypes() {
+    return this.getFormTypes?.value || [];
+  }
+
+  get groupedFormTypes() {
+    const options = [];
+    const customTypes = this.formTypes.filter((t) => t.isCustomType);
+    if (customTypes.length >= 1) {
+      options.push({
+        groupName: 'Eigen types',
+        options: customTypes,
+      });
+    }
+    return [
+      ...options,
+      {
+        groupName: 'Standaard types',
+        options: this.formTypes.filter((t) => t.isDefaultType),
+      },
+    ];
+  }
+
+  get selectedFormType() {
+    if (!this.args.selectedFormTypeUri) {
+      return null;
+    }
+
+    return this.formTypes.find((type) => {
+      if (!type.uri) {
+        return this.args.selectedFormTypeUri.startsWith(type.prefix);
+      }
+
+      return type.uri === this.args.selectedFormTypeUri;
+    });
+  }
+
+  @action
+  updateFormType(formTypeOption) {
+    this.args.onSelectedType?.(formTypeOption.uri || formTypeOption.prefix);
+  }
+}

--- a/app/components/link-to-form/select-form-type.js
+++ b/app/components/link-to-form/select-form-type.js
@@ -70,17 +70,17 @@ export default class LinkToFormSelectFormType extends Component {
   }
 
   get selectedFormType() {
-    if (!this.args.selectedFormTypeId) {
+    if (!this.args.selectedFormTypeUri) {
       return null;
     }
 
     return this.formTypes.find(
-      (type) => type.id === this.args.selectedFormTypeId
+      (type) => type.uri === this.args.selectedFormTypeUri
     );
   }
 
   @action
   updateFormType(formTypeOption) {
-    this.args.onSelectedType?.(formTypeOption.id);
+    this.args.onSelectedType?.(formTypeOption.uri);
   }
 }

--- a/app/components/mandatarissen/mandataris-extra-info-card.hbs
+++ b/app/components/mandatarissen/mandataris-extra-info-card.hbs
@@ -56,6 +56,7 @@
       @onSave={{this.onSave}}
       @formInitialized={{fn (mut this.formInitialized) true}}
       @customHistoryMessage={{true}}
+      @isForFormExtension={{true}}
     />
     {{#unless this.formInitialized}}
       <Skeleton::Forms::MandatarisExtraInfo />

--- a/app/components/rdf-input-fields/crud-custom-field-modal.hbs
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.hbs
@@ -98,8 +98,8 @@
             {{#if this.displayType.isLinkToForm}}
               <LinkToForm::SelectFormType
                 @formDefintionId={{this.formContext.formDefinition.id}}
-                @selectedFormTypeId={{this.linkedFormTypeId}}
-                @onSelectedType={{this.updateLinkedFormTypeId}}
+                @selectedFormTypeUri={{this.linkedFormTypeUri}}
+                @onSelectedType={{this.updateLinkedFormTypeUri}}
               />
             {{/if}}
           </AuFormRow>

--- a/app/components/rdf-input-fields/crud-custom-field-modal.hbs
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.hbs
@@ -112,7 +112,7 @@
           >Maak veld verplicht
             <Shared::Tooltip
               @showTooltip={{true}}
-              @alignment="top-left"
+              @alignment="center"
               @tooltipText="Bij het aanmaken of aanpassen van items zal dit veld steeds ingevuld moeten worden."
             >
               <AuButton
@@ -120,9 +120,10 @@
                 @icon="circle-question"
                 @hideText={{true}}
                 @disabled={{true}}
-                class="au-u-padding-bottom-small au-u-padding-left-none"
+                class="au-u-padding-bottom-small au-u-padding-left-none au-u-padding-right-none"
               />
-            </Shared::Tooltip></AuToggleSwitch>
+            </Shared::Tooltip>
+          </AuToggleSwitch>
         </AuFormRow>
         {{#if this.isCustomForm}}
           <AuFormRow>
@@ -133,7 +134,7 @@
             >Toon in samenvatting
               <Shared::Tooltip
                 @showTooltip={{true}}
-                @alignment="top-left"
+                @alignment="center"
                 @tooltipText="Dit veld zal getoond worden in de samenvatting van een item, bijvoorbeeld bij het tonen van een lijst van items of bij een verwijzing naar een item."
               >
                 <AuButton

--- a/app/components/rdf-input-fields/crud-custom-field-modal.hbs
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.hbs
@@ -93,6 +93,17 @@
             </PowerSelect>
           </AuFormRow>
         {{/if}}
+        {{#if this.displayType.isLinkToForm}}
+          <AuFormRow class="au-form-row-full-width">
+            {{#if this.displayType.isLinkToForm}}
+              <LinkToForm::SelectFormType
+                @formDefintionId={{this.formContext.formDefinition.id}}
+                @selectedFormTypeId={{this.linkedFormTypeId}}
+                @onSelectedType={{this.updateLinkedFormTypeId}}
+              />
+            {{/if}}
+          </AuFormRow>
+        {{/if}}
         <AuFormRow>
           <AuToggleSwitch
             @disabled={{@show}}

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -67,10 +67,14 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
         sort: 'label',
       })
       .then((displayTypes) => {
-        const allowedTypes = displayTypes.filter(
-          (type) => type.uri !== LINK_TO_FORM_CUSTOM_DISPLAY_TYPE
-        );
-        this.displayTypes = allowedTypes;
+        if (this.args.isForFormExtension) {
+          const allowedTypes = displayTypes.filter(
+            (type) => type.uri !== LINK_TO_FORM_CUSTOM_DISPLAY_TYPE
+          );
+          this.displayTypes = allowedTypes;
+        } else {
+          this.displayTypes = displayTypes;
+        }
         this.displayType = this.displayTypes.find((t) => t.uri === withValue);
       });
   }

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -45,7 +45,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
   @tracked displayType;
   @tracked conceptScheme;
   @tracked conceptSchemeOnLoad;
-  @tracked linkedFormTypeId;
+  @tracked linkedFormTypeUri;
 
   constructor() {
     super(...arguments);
@@ -117,8 +117,8 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
   }
 
   @action
-  updateLinkedFormTypeId(id) {
-    this.linkedFormTypeId = id;
+  updateLinkedFormTypeUri(uri) {
+    this.linkedFormTypeUri = uri;
   }
 
   @action
@@ -162,7 +162,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
             isRequired: !!this.isFieldRequired,
             showInSummary: !!this.isShownInSummary,
             conceptScheme: this.conceptScheme?.uri,
-            linkedFormTypeUri: this.linkedFormTypeId,
+            linkedFormTypeUri: this.linkedFormTypeUri,
           }),
         }
       );
@@ -332,7 +332,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
       return true;
     }
 
-    return this.linkedFormTypeId;
+    return this.linkedFormTypeUri;
   }
 
   get fieldHasChanged() {

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -45,6 +45,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
   @tracked displayType;
   @tracked conceptScheme;
   @tracked conceptSchemeOnLoad;
+  @tracked linkedFormTypeId;
 
   constructor() {
     super(...arguments);
@@ -116,6 +117,11 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
   }
 
   @action
+  updateLinkedFormTypeId(id) {
+    this.linkedFormTypeId = id;
+  }
+
+  @action
   toggleIsRequired() {
     this.isFieldRequired = !this.isFieldRequired;
   }
@@ -156,6 +162,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
             isRequired: !!this.isFieldRequired,
             showInSummary: !!this.isShownInSummary,
             conceptScheme: this.conceptScheme?.uri,
+            linkedFormTypeUri: this.linkedFormTypeId,
           }),
         }
       );

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -311,7 +311,8 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
       return (
         this.hasValidFieldName &&
         this.libraryFieldType &&
-        this.hasConceptSchemeSelected
+        this.hasConceptSchemeSelected &&
+        this.hasLinkToFormSelected
       );
     }
 
@@ -324,6 +325,14 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
     }
 
     return this.conceptScheme;
+  }
+
+  get hasLinkToFormSelected() {
+    if (!this.displayType?.isLinkToForm) {
+      return true;
+    }
+
+    return this.linkedFormTypeId;
   }
 
   get fieldHasChanged() {

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -68,4 +68,5 @@
   @field={{@field}}
   @isRequiredField={{this.isRequired}}
   @isShownInSummary={{this.isShownInSummary}}
+  @isForFormExtension={{this.formContext.isForFormExtension}}
 />

--- a/app/models/display-type.js
+++ b/app/models/display-type.js
@@ -3,6 +3,7 @@ import Model, { attr } from '@ember-data/model';
 import {
   CONCEPT_SCHEME_MULTI_SELECTOR_CUSTOM_DISPLAY_TYPE,
   CONCEPT_SCHEME_SELECTOR_CUSTOM_DISPLAY_TYPE,
+  LINK_TO_FORM_CUSTOM_DISPLAY_TYPE,
 } from 'frontend-lmb/utils/well-known-uris';
 
 export default class DisplayTypeModel extends Model {
@@ -16,5 +17,9 @@ export default class DisplayTypeModel extends Model {
     ];
 
     return fieldUris.includes(this.uri);
+  }
+
+  get isLinkToForm() {
+    return this.uri === LINK_TO_FORM_CUSTOM_DISPLAY_TYPE;
   }
 }

--- a/app/routes/custom-forms/instances/instance.js
+++ b/app/routes/custom-forms/instances/instance.js
@@ -1,9 +1,26 @@
 import Route from '@ember/routing/route';
 
+import { service } from '@ember/service';
+
+import { showWarningToast } from 'frontend-lmb/utils/toasts';
+
 export default class CustomFormsInstancesInstanceRoute extends Route {
+  @service router;
+  @service toaster;
+
   async model(params) {
     const parent = this.modelFor('custom-forms.instances.index');
 
-    return { form: parent.formDefinition, instanceId: params.instance_id };
+    return { form: parent?.formDefinition, instanceId: params.instance_id };
+  }
+
+  afterModel(model) {
+    if (!model.form) {
+      showWarningToast(
+        this.toaster,
+        `Er liep iets mis met het ophalen van de gegevens voor formulier met id: ${model.instanceId}`
+      );
+      this.router.transitionTo('custom-forms.overview');
+    }
   }
 }

--- a/app/services/custom-forms.js
+++ b/app/services/custom-forms.js
@@ -75,6 +75,7 @@ export default class CustomFormsService extends Service {
       conceptSchemeUri,
       isRequired,
       isShownInSummary,
+      linkedFormTypeUri,
       formUri,
     }
   ) {
@@ -91,6 +92,7 @@ export default class CustomFormsService extends Service {
           isRequired: !!isRequired,
           showInSummary: !!isShownInSummary,
           conceptScheme: conceptSchemeUri,
+          linkedFormTypeUri: linkedFormTypeUri,
         }),
       });
 
@@ -101,6 +103,7 @@ export default class CustomFormsService extends Service {
         isRequired: !!isRequired,
         showInSummary: !!isShownInSummary,
         conceptScheme: conceptSchemeUri,
+        linkedFormTypeUri: linkedFormTypeUri,
         formUri,
       };
     } catch (error) {

--- a/app/utils/register-form-fields.js
+++ b/app/utils/register-form-fields.js
@@ -25,6 +25,7 @@ import RdfInputFieldsCustomNumberInputComponent from 'frontend-lmb/components/rd
 import RdfInputFieldsCustomTextInputComponent from 'frontend-lmb/components/rdf-input-fields/custom-text-input';
 import RdfInputFieldCustomConceptSchemeSelectorInput from 'frontend-lmb/components/rdf-input-fields/custom-concept-scheme-selector-input';
 import RdfInputFieldCustomConceptSchemeMultiSelectorInput from 'frontend-lmb/components/rdf-input-fields/custom-concept-scheme-multi-selector-input';
+import CustomFormLinkToFormInstance from 'frontend-lmb/components/custom-form/link-to-form-instance';
 
 export const registerCustomFormFields = () => {
   registerFormFields([
@@ -148,6 +149,11 @@ export const registerCustomFormFields = () => {
       displayType:
         'http://lblod.data.gift/display-types/lmb/custom-concept-scheme-multi-selector-input',
       edit: RdfInputFieldCustomConceptSchemeMultiSelectorInput,
+    },
+    {
+      displayType:
+        'http://lblod.data.gift/display-types/lmb/custom-link-to-form-selector-input',
+      edit: CustomFormLinkToFormInstance,
     },
   ]);
 };

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -109,6 +109,8 @@ export const CONCEPT_SCHEME_SELECTOR_CUSTOM_DISPLAY_TYPE =
   'http://lblod.data.gift/display-types/lmb/custom-concept-scheme-selector-input';
 export const CONCEPT_SCHEME_MULTI_SELECTOR_CUSTOM_DISPLAY_TYPE =
   'http://lblod.data.gift/display-types/lmb/custom-concept-scheme-multi-selector-input';
+export const LINK_TO_FORM_CUSTOM_DISPLAY_TYPE =
+  'http://lblod.data.gift/display-types/lmb/custom-link-to-form-selector-input';
 
 export const LIBRARY_ENTREES = [
   'http://data.lblod.info/id/lmb/form-library-entries/095d1329-a9fa-4d72-8c49-eb52aaf893de', // Verblijfsplaats

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
-        "@lblod/ember-semantic-forms": "0.1.0",
+        "@lblod/ember-semantic-forms": "0.1.1",
         "ember-data-table": "^2.1.0",
         "reactiveweb": "^1.4.0"
       },
@@ -3904,9 +3904,9 @@
       }
     },
     "node_modules/@lblod/ember-semantic-forms": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-semantic-forms/-/ember-semantic-forms-0.1.0.tgz",
-      "integrity": "sha512-CE6ztGKZKifncqrPzZUR2RLTtDteOP2Qu66f3DdqaizIjbPuwy8lBDnfKpzKjVfWk1n5YnaK9IBQhQxYS/Ud3w==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-semantic-forms/-/ember-semantic-forms-0.1.1.tgz",
+      "integrity": "sha512-pTFcOeZ7CQWWj7rnl7zKclravvx921o5E60fdsX21vkfWsay1DjrLKC5I+VV2afy9AB+mcLP3vP5P6nMKMWHHQ==",
       "dependencies": {
         "@lblod/submission-form-helpers": "~2.10.2",
         "ember-auto-import": "^2.7.2",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "webpack": "^5.95.0"
   },
   "dependencies": {
-    "@lblod/ember-semantic-forms": "0.1.0",
+    "@lblod/ember-semantic-forms": "0.1.1",
     "ember-data-table": "^2.1.0",
     "reactiveweb": "^1.4.0"
   },

--- a/tests/integration/components/custom-form/link-to-form-instance-test.js
+++ b/tests/integration/components/custom-form/link-to-form-instance-test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | custom-form/link-to-form-instance',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.set('myAction', function(val) { ... });
+
+      await render(hbs`<CustomForm::LinkToFormInstance />`);
+
+      assert.dom().hasText('');
+
+      // Template block usage:
+      await render(hbs`<CustomForm::LinkToFormInstance>
+  template block text
+</CustomForm::LinkToFormInstance>`);
+
+      assert.dom().hasText('template block text');
+    });
+  }
+);

--- a/tests/integration/components/link-to-form/select-form-type-test.js
+++ b/tests/integration/components/link-to-form/select-form-type-test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | link-to-form/select-form-type',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.set('myAction', function(val) { ... });
+
+      await render(hbs`<LinkToForm::SelectFormType />`);
+
+      assert.dom().hasText('');
+
+      // Template block usage:
+      await render(hbs`<LinkToForm::SelectFormType>
+  template block text
+</LinkToForm::SelectFormType>`);
+
+      assert.dom().hasText('template block text');
+    });
+  }
+);


### PR DESCRIPTION
## Description

We want a new custom field where the user can add a link to another form (default or custom forms). 

## How to test

1. Go to eigen gegeven and add a new form
2. Add a field "Link to formulier" to the form definition
3. See if all options are shown in the dropdown as expected (show in summary predicate)
5. Create a link between this form and the one you selected
6. This  new field can also be shown in summary for the instance table => URI

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/416
- https://github.com/lblod/form-content-service/pull/78
