### PR TITLE
LMB-1529 | Separate page for edit form

### DIFF
--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -14,10 +14,11 @@
     {{#if this.editableFormsEnabled}}
       {{#unless @isReadOnly}}
         <AuButton
-          @skin="link"
+          @skin="secondary"
+          @width="block"
           @icon="plus"
           {{on "click" (fn (mut this.showEditModal) true)}}
-          class="au-u-padding-left-none au-u-margin-bottom"
+          class="au-u-padding-left-none au-u-margin-bottom au-u-margin-top"
         >
           Voeg een veld toe
         </AuButton>

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -1,0 +1,15 @@
+import Controller from '@ember/controller';
+
+import { action } from '@ember/object';
+
+export default class CustomFormsInstancesDefinitionController extends Controller {
+  @action
+  onCancel() {
+    alert('todo on cancel');
+  }
+
+  @action
+  onSave() {
+    alert('todo on save');
+  }
+}

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -1,15 +1,49 @@
 import Controller from '@ember/controller';
 
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class CustomFormsInstancesDefinitionController extends Controller {
+  @tracked isEditFormModalOpen;
+
   @action
-  onCancel() {
-    alert('todo on cancel');
+  updateFormName(event) {
+    this.model.form.name = event.target?.value?.trim();
+  }
+
+  get formNameErrorMessage() {
+    if (!this.model.form.name) {
+      return 'Naam is verplicht.';
+    }
+    return null;
   }
 
   @action
-  onSave() {
-    alert('todo on save');
+  updateFormDescription(event) {
+    this.model.form.description = event.target?.value?.trim();
+  }
+
+  get isOverMaxCharacters() {
+    return this.model.form.description?.length > 250;
+  }
+
+  get descriptionCharacters() {
+    return `Karakters: ${this.model.form.description?.length || 0}/250`;
+  }
+
+  get saveButtonDisabled() {
+    return this.isOverMaxCharacters || this.formNameErrorMessage;
+  }
+
+  @action
+  async saveFormDetails() {
+    await this.model.form.save();
+    this.isEditFormModalOpen = false;
+  }
+
+  @action
+  cancelUpdateFormDetails() {
+    this.model.form.rollbackAttributes();
+    this.isEditFormModalOpen = false;
   }
 }

--- a/app/controllers/custom-forms/instances/index.js
+++ b/app/controllers/custom-forms/instances/index.js
@@ -20,7 +20,6 @@ export default class CustomFormsInstancesIndexController extends Controller {
   @tracked isDeleteModalOpen;
   @tracked isDeleting;
 
-  @tracked isEditFormDefinitionOpen;
   @tracked page = 0;
   @tracked sort = 'uri';
   @tracked filter = '';
@@ -58,16 +57,11 @@ export default class CustomFormsInstancesIndexController extends Controller {
   }
 
   @action
-  closeEditFormDefinitionModal() {
-    this.isEditFormDefinitionOpen = false;
-  }
-
-  @action
-  preventSave(ttl) {
-    if (!ttl) {
-      return;
-    }
-    throw new Error('Niet bewaren aub', ttl);
+  goToEditFormDefinition() {
+    this.router.transitionTo(
+      'custom-forms.instances.definition',
+      this.model.form.id
+    );
   }
 
   @action

--- a/app/router.js
+++ b/app/router.js
@@ -81,6 +81,7 @@ Router.map(function () {
       this.route('index', { path: '/:id' });
       this.route('instance', { path: '/:instance_id/instance' });
       this.route('new', { path: '/:id/new' });
+      this.route('definition', { path: '/:id/editeer-definitie' });
     });
   });
 

--- a/app/router.js
+++ b/app/router.js
@@ -81,7 +81,7 @@ Router.map(function () {
       this.route('index', { path: '/:id' });
       this.route('instance', { path: '/:instance_id/instance' });
       this.route('new', { path: '/:id/new' });
-      this.route('definition', { path: '/:id/editeer-definitie' });
+      this.route('definition', { path: '/:id/bewerk-formulier-definitie' });
     });
   });
 

--- a/app/routes/custom-forms/instances/definition.js
+++ b/app/routes/custom-forms/instances/definition.js
@@ -1,0 +1,15 @@
+import Route from '@ember/routing/route';
+
+import { service } from '@ember/service';
+
+export default class CustomFormsInstancesDefinitionRoute extends Route {
+  @service store;
+
+  async model({ id }) {
+    const form = await this.store.findRecord('form', id);
+
+    return {
+      form,
+    };
+  }
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -16,6 +16,7 @@ $mq-breakpoints: (
 @import "project/c-skeleton";
 @import "project/c-timeline";
 @import "project/c-custom-elements";
+@import "project/c-edit-form-definition";
 
 // PLUGINS
 @import "project/p-ember-promise-modals";

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -1,0 +1,19 @@
+.edit-form-defintion {
+  background-color: var(--au-blue-100);
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  height: 100%;
+  width: 100%;
+}
+
+.edit-form-defintion--form {
+  width: 70%;
+  border: 2px solid var(--au-gray-200);
+  border-radius: 5px;
+  background-color: var(--au-white);
+  margin: 2rem auto;
+}
+
+.edit-form-defintion--edit-panel {
+  padding: 2rem 1rem;
+}

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -17,3 +17,7 @@
 .edit-form-defintion--edit-panel {
   padding: 2rem 1rem;
 }
+
+.edit-form-defintion .semantic-forms-instance .au-c-toolbar {
+  display: none;
+}

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -1,14 +1,50 @@
 {{page-title "Editeer definitie"}}
-<div class="au-o-box">
-  <EditableForm
-    @instanceId={{this.model.form.id}}
-    @form={{this.model.form}}
-    @onCancel={{this.onCancel}}
-    @onSave={{this.onSave}}
-    @formInitialized={{fn (mut this.formInitialized) true}}
-    @customHistoryMessage={{true}}
-  />
-  {{#unless this.formInitialized}}
-    <AuLoader />
-  {{/unless}}
+<AuToolbar
+  @size="large"
+  class="au-u-padding-bottom-none au-u-margin-bottom"
+  as |Group|
+>
+  <Group>
+    <AuHeading @skin="2">{{this.model.form.name}}</AuHeading>
+  </Group>
+  <Group>
+    <AuButtonGroup>
+      <AuLink
+        @route="custom-forms.instances.index"
+        @model={{this.model.form.id}}
+        @skin="button-secondary"
+      >Annuleer</AuLink>
+      <AuLink
+        @route="custom-forms.instances.index"
+        @model={{this.model.form.id}}
+        @skin="button"
+      >Opslaan</AuLink>
+    </AuButtonGroup>
+  </Group>
+</AuToolbar>
+<AuToolbar
+  @size="large"
+  class="au-u-padding-bottom-none au-u-margin-bottom"
+  as |Group|
+>
+  <Group>
+    <p>{{this.model.form.description}}</p>
+  </Group>
+</AuToolbar>
+<div class="edit-form-defintion">
+  <div class="au-o-box edit-form-defintion--form">
+    <EditableForm
+      @instanceId={{this.model.form.id}}
+      @form={{this.model.form}}
+      @onCancel={{this.onCancel}}
+      @onSave={{this.onSave}}
+      @formInitialized={{fn (mut this.formInitialized) true}}
+      @customHistoryMessage={{true}}
+    />
+    {{#unless this.formInitialized}}
+      <AuLoader />
+    {{/unless}}
+  </div>
+  <div class="edit-form-defintion--edit-panel">
+  </div>
 </div>

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -1,0 +1,14 @@
+{{page-title "Editeer definitie"}}
+<div class="au-o-box">
+  <EditableForm
+    @instanceId={{this.model.form.id}}
+    @form={{this.model.form}}
+    @onCancel={{this.onCancel}}
+    @onSave={{this.onSave}}
+    @formInitialized={{fn (mut this.formInitialized) true}}
+    @customHistoryMessage={{true}}
+  />
+  {{#unless this.formInitialized}}
+    <AuLoader />
+  {{/unless}}
+</div>

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -5,7 +5,15 @@
   as |Group|
 >
   <Group>
-    <AuHeading @skin="2">{{this.model.form.name}}</AuHeading>
+    <AuHeading @skin="2">{{this.model.form.name}}
+      <AuButton
+        @skin="link-secondary"
+        @icon="pencil"
+        @hideText={{true}}
+        {{on "click" (fn (mut this.isEditFormModalOpen) true)}}
+      >
+        Pas aan
+      </AuButton></AuHeading>
   </Group>
   <Group>
     <AuButtonGroup>
@@ -13,12 +21,7 @@
         @route="custom-forms.instances.index"
         @model={{this.model.form.id}}
         @skin="button-secondary"
-      >Annuleer</AuLink>
-      <AuLink
-        @route="custom-forms.instances.index"
-        @model={{this.model.form.id}}
-        @skin="button"
-      >Opslaan</AuLink>
+      >Terug naar formulieren</AuLink>
     </AuButtonGroup>
   </Group>
 </AuToolbar>
@@ -36,8 +39,6 @@
     <EditableForm
       @instanceId={{this.model.form.id}}
       @form={{this.model.form}}
-      @onCancel={{this.onCancel}}
-      @onSave={{this.onSave}}
       @formInitialized={{fn (mut this.formInitialized) true}}
       @customHistoryMessage={{true}}
     />
@@ -48,3 +49,53 @@
   <div class="edit-form-defintion--edit-panel">
   </div>
 </div>
+
+<AuModal
+  @title="Bewerk formulier detail"
+  @modalOpen={{this.isEditFormModalOpen}}
+  @closable={{true}}
+  @closeModal={{this.cancelUpdateFormDetails}}
+>
+  <:body>
+    <div class="au-o-box">
+      <AuLabel @required={{true}} @error={{this.formNameErrorMessage}}>Naam
+        formulier</AuLabel>
+      <AuInput
+        @error={{this.formNameErrorMessage}}
+        value={{this.model.form.name}}
+        @width="block"
+        placeholder="Formulier naam"
+        {{on "input" this.updateFormName}}
+      />
+      {{#if this.formNameErrorMessage}}
+        <AuHelpText @error={{true}}>{{this.formNameErrorMessage}}</AuHelpText>
+      {{/if}}
+      <AuLabel class="au-u-margin-top">Beschrijving</AuLabel>
+      <AuTextarea
+        value={{this.model.form.description}}
+        @width="block"
+        @error={{this.isOverMaxCharacters}}
+        rows="5"
+        placeholder="Beschrijving van het formulier"
+        {{on "input" this.updateFormDescription}}
+      />
+      <AuHelpText
+        class="au-u-text-right"
+        @error={{this.isOverMaxCharacters}}
+      >{{this.descriptionCharacters}}</AuHelpText>
+    </div>
+  </:body>
+  <:footer>
+    <AuButtonGroup class="au-u-flex au-u-padding-left au-u-padding-right">
+      <AuButton
+        @loadingMessage="Aanpassen"
+        @disabled={{this.saveButtonDisabled}}
+        {{on "click" this.saveFormDetails}}
+      >Opslaan</AuButton>
+      <AuButton
+        @skin="secondary"
+        {{on "click" this.cancelUpdateFormDetails}}
+      >Annuleer</AuButton>
+    </AuButtonGroup>
+  </:footer>
+</AuModal>

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -1,4 +1,4 @@
-{{page-title "Editeer definitie"}}
+{{page-title "Bewerk formulier definitie"}}
 <AuToolbar
   @size="large"
   class="au-u-padding-bottom-none au-u-margin-bottom"

--- a/app/templates/custom-forms/instances/index.hbs
+++ b/app/templates/custom-forms/instances/index.hbs
@@ -33,7 +33,7 @@
             <AuButton
               role="menuitem"
               @skin="link"
-              {{on "click" (fn (mut this.isEditFormDefinitionOpen) true)}}
+              {{on "click" this.goToEditFormDefinition}}
             >
               Bewerk formulier definitie
             </AuButton>
@@ -49,28 +49,6 @@
     </AuBodyContainer>
   </main.content>
 </AuMainContainer>
-
-<AuModal
-  @title="Bewerk formulier definitie"
-  @modalOpen={{this.isEditFormDefinitionOpen}}
-  @closable={{true}}
-  @closeModal={{this.closeEditFormDefinitionModal}}
->
-  <div class="au-o-box">
-    <EditableForm
-      @beforeSave={{this.preventSave}}
-      @instanceId={{this.model.form.id}}
-      @form={{this.model.form}}
-      @onCancel={{this.closeEditFormDefinitionModal}}
-      @onSave={{this.closeEditFormDefinitionModal}}
-      @formInitialized={{fn (mut this.formInitialized) true}}
-      @customHistoryMessage={{true}}
-    />
-    {{#unless this.formInitialized}}
-      <AuLoader />
-    {{/unless}}
-  </div>
-</AuModal>
 
 <AuModal
   @title="Verwijder formulier"

--- a/tests/unit/controllers/custom-forms/instances/definition-test.js
+++ b/tests/unit/controllers/custom-forms/instances/definition-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-lmb/tests/helpers';
+
+module(
+  'Unit | Controller | custom-forms/instances/definition',
+  function (hooks) {
+    setupTest(hooks);
+
+    // TODO: Replace this with your real tests.
+    test('it exists', function (assert) {
+      let controller = this.owner.lookup(
+        'controller:custom-forms/instances/definition'
+      );
+      assert.ok(controller);
+    });
+  }
+);

--- a/tests/unit/routes/custom-forms/instances/definition-test.js
+++ b/tests/unit/routes/custom-forms/instances/definition-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-lmb/tests/helpers';
+
+module('Unit | Route | custom-forms/instances/definition', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:custom-forms/instances/definition');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
## Description

De form definition was shown in a modal when clicking the option. We want to show this on a separate page as shown in the designs.

## How to test

1. Can build form definition
2. Can edit name and description of the form

## Links to other PR's

- https://github.com/lblod/form-content-service/pull/79
