### PR TITLE
fix check for person elected is meaningless if the organ has no elections

### DIFF
--- a/app/services/verkiezing.js
+++ b/app/services/verkiezing.js
@@ -6,6 +6,12 @@ export default class VerkiezingService extends Service {
   @service store;
 
   async checkIfPersonIsElected(personId, bestuursorgaan) {
+    const verkiezing = await bestuursorgaan.verkiezing;
+
+    if (!verkiezing) {
+      // here it doesn't matter if the person is elected or not because no elections are present
+      return true;
+    }
     const matches = await this.store.query('persoon', {
       include: [
         'verkiezingsresultaten',


### PR DESCRIPTION
## Description

fix check for person elected is meaningless if the organ has no elections
## How to test

add person to politieraad, add person to gemeenteraad notice you can do the gemeenteraad only for elected persons, but for politieraad it doesn't matter.