### PR TITLE
LMB-1478 | Add sidebar for edit form definition

### DIFF
--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -11,8 +11,60 @@
     @selected={{this.selectedField}}
     @onChange={{this.updateSelectedField}}
     id="select-custom-form-field"
+    class="au-u-margin-bottom"
     as |selected|
   >
     {{selected.label}}
   </PowerSelect>
+  <form class="au-c-form au-o-flow">
+    <AuFormRow @alignment="default">
+      <AuLabel @required={{true}} for="fieldName">Naam</AuLabel>
+      <AuInput
+        @width="block"
+        @iconAlignment="left"
+        value={{this.selectedField.label}}
+        id="fieldName"
+        {{on "input" this.updateFieldName}}
+      />
+    </AuFormRow>
+    <AuFormRow>
+      <AuToggleSwitch
+        @checked={{this.selectedField.isRequired}}
+        @onChange={{this.toggleIsRequired}}
+      >Maak veld verplicht
+        <Shared::Tooltip
+          @showTooltip={{true}}
+          @alignment="top-left"
+          @tooltipText="Bij het aanmaken of aanpassen van items zal dit veld steeds ingevuld moeten worden."
+        >
+          <AuButton
+            @skin="naked"
+            @icon="circle-question"
+            @hideText={{true}}
+            @disabled={{true}}
+            class="au-u-padding-bottom-small au-u-padding-left-none"
+          />
+        </Shared::Tooltip></AuToggleSwitch>
+    </AuFormRow>
+    <AuFormRow>
+      <AuToggleSwitch
+        @checked={{this.selectedField.isShownInSummary}}
+        @onChange={{this.toggleShowInSummary}}
+      >Toon in samenvatting
+        <Shared::Tooltip
+          @showTooltip={{true}}
+          @alignment="top-left"
+          @tooltipText="Dit veld zal getoond worden in de samenvatting van een item, bijvoorbeeld bij het tonen van een lijst van items of bij een verwijzing naar een item."
+        >
+          <AuButton
+            @skin="naked"
+            @icon="circle-question"
+            @hideText={{true}}
+            @disabled={{true}}
+            class="au-u-padding-bottom-small au-u-padding-left-none"
+          />
+        </Shared::Tooltip>
+      </AuToggleSwitch>
+    </AuFormRow>
+  </form>
 </div>

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -101,13 +101,6 @@
         >
           Pas aan
         </AuButton>
-        <AuButton
-          @skin="secondary"
-          @disabled={{or (not this.selectedField) (not this.isChanged)}}
-          {{on "click" this.resetFieldValues}}
-        >
-          Reset
-        </AuButton>
       </AuButtonGroup>
     </AuFormRow>
   </form>

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -5,8 +5,13 @@
   {{#if this.selectedField}}
     <form class="au-c-form au-o-flow">
       <AuFormRow @alignment="default">
-        <AuLabel @required={{true}} for="fieldName">Naam</AuLabel>
+        <AuLabel
+          @required={{true}}
+          @error={{not this.isValidLabel}}
+          for="fieldName"
+        >Naam</AuLabel>
         <AuInput
+          @error={{not this.isValidLabel}}
           @disabled={{not this.selectedField}}
           @width="block"
           @iconAlignment="left"
@@ -14,6 +19,9 @@
           id="fieldName"
           {{on "input" this.updateFieldName}}
         />
+        {{#unless this.isValidLabel}}
+          <AuHelpText @error={{true}}>Label is verplicht</AuHelpText>
+        {{/unless}}
       </AuFormRow>
       <AuFormRow class="au-form-row-full-width">
         <AuLabel @required={{true}} for="display-type">Type</AuLabel>
@@ -64,7 +72,7 @@
         >Maak veld verplicht
           <Shared::Tooltip
             @showTooltip={{true}}
-            @alignment="top-left"
+            @alignment="center"
             @tooltipText="Bij het aanmaken of aanpassen van items zal dit veld steeds ingevuld moeten worden."
           >
             <AuButton
@@ -84,7 +92,7 @@
         >Toon in samenvatting
           <Shared::Tooltip
             @showTooltip={{true}}
-            @alignment="top-left"
+            @alignment="center"
             @tooltipText="Dit veld zal getoond worden in de samenvatting van een item, bijvoorbeeld bij het tonen van een lijst van items of bij een verwijzing naar een item."
           >
             <AuButton
@@ -100,7 +108,7 @@
       <AuFormRow>
         <AuButtonGroup>
           <AuButton
-            @disabled={{not this.isChanged}}
+            @disabled={{not this.canSaveChanges}}
             {{on "click" this.saveFieldChanges}}
           >
             Pas aan

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -40,7 +40,7 @@
         @searchMessage="Typ om te zoeken"
         @searchField="label"
         @options={{this.displayTypes}}
-        @selected={{this.selectedDisplayType}}
+        @selected={{this.displayType}}
         @onChange={{this.updateSelectedDisplayType}}
         id="display-type"
         as |selected|
@@ -48,6 +48,27 @@
         {{selected.label}}
       </PowerSelect>
     </AuFormRow>
+    {{#if this.displayType.isConceptSchemeSelector}}
+      <AuFormRow class="au-form-row-full-width">
+        <AuLabel @required={{true}} for="display-type">Codelijst</AuLabel>
+        <PowerSelect
+          @allowClear={{false}}
+          @renderInPlace={{false}}
+          @searchEnabled={{true}}
+          @loadingMessage="Aan het laden..."
+          @noMatchesMessage="Geen codelijsten gevonden"
+          @searchMessage="Typ om te zoeken"
+          @searchField="displayLabel"
+          @options={{this.conceptSchemes}}
+          @selected={{this.conceptScheme}}
+          @onChange={{this.updateSelectedConceptScheme}}
+          id="concept-scheme"
+          as |selected|
+        >
+          {{selected.displayLabel}}
+        </PowerSelect>
+      </AuFormRow>
+    {{/if}}
     <AuFormRow>
       <AuToggleSwitch
         @disabled={{not this.selectedField}}

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -1,107 +1,112 @@
 <div class="au-o-box edit-form-defintion--edit-panel-containter">
-  <form class="au-c-form au-o-flow">
-    <AuFormRow @alignment="default">
-      <AuLabel @required={{true}} for="fieldName">Naam</AuLabel>
-      <AuInput
-        @disabled={{not this.selectedField}}
-        @width="block"
-        @iconAlignment="left"
-        value={{this.label}}
-        id="fieldName"
-        {{on "input" this.updateFieldName}}
-      />
-    </AuFormRow>
-    <AuFormRow class="au-form-row-full-width">
-      <AuLabel @required={{true}} for="display-type">Type</AuLabel>
-      <PowerSelect
-        @allowClear={{false}}
-        @disabled={{not this.selectedField}}
-        @renderInPlace={{false}}
-        @searchEnabled={{true}}
-        @loadingMessage="Aan het laden..."
-        @noMatchesMessage="Geen types gevonden"
-        @searchMessage="Typ om te zoeken"
-        @searchField="label"
-        @options={{this.displayTypes}}
-        @selected={{this.displayType}}
-        @onChange={{this.updateSelectedDisplayType}}
-        id="display-type"
-        as |selected|
-      >
-        {{selected.label}}
-      </PowerSelect>
-    </AuFormRow>
-    {{#if this.displayType.isConceptSchemeSelector}}
+  {{#unless this.selectedField}}
+    <p>Selecteer een veld om aan te passen</p>
+  {{/unless}}
+  {{#if this.selectedField}}
+    <form class="au-c-form au-o-flow">
+      <AuFormRow @alignment="default">
+        <AuLabel @required={{true}} for="fieldName">Naam</AuLabel>
+        <AuInput
+          @disabled={{not this.selectedField}}
+          @width="block"
+          @iconAlignment="left"
+          value={{this.label}}
+          id="fieldName"
+          {{on "input" this.updateFieldName}}
+        />
+      </AuFormRow>
       <AuFormRow class="au-form-row-full-width">
-        <AuLabel @required={{true}} for="display-type">Codelijst</AuLabel>
+        <AuLabel @required={{true}} for="display-type">Type</AuLabel>
         <PowerSelect
           @allowClear={{false}}
+          @disabled={{not this.selectedField}}
           @renderInPlace={{false}}
           @searchEnabled={{true}}
           @loadingMessage="Aan het laden..."
-          @noMatchesMessage="Geen codelijsten gevonden"
+          @noMatchesMessage="Geen types gevonden"
           @searchMessage="Typ om te zoeken"
-          @searchField="displayLabel"
-          @options={{this.conceptSchemes}}
-          @selected={{this.conceptScheme}}
-          @onChange={{this.updateSelectedConceptScheme}}
-          id="concept-scheme"
+          @searchField="label"
+          @options={{this.displayTypes}}
+          @selected={{this.displayType}}
+          @onChange={{this.updateSelectedDisplayType}}
+          id="display-type"
           as |selected|
         >
-          {{selected.displayLabel}}
+          {{selected.label}}
         </PowerSelect>
       </AuFormRow>
-    {{/if}}
-    <AuFormRow>
-      <AuToggleSwitch
-        @disabled={{not this.selectedField}}
-        @checked={{this.isRequired}}
-        @onChange={{this.toggleIsRequired}}
-      >Maak veld verplicht
-        <Shared::Tooltip
-          @showTooltip={{true}}
-          @alignment="top-left"
-          @tooltipText="Bij het aanmaken of aanpassen van items zal dit veld steeds ingevuld moeten worden."
-        >
+      {{#if this.displayType.isConceptSchemeSelector}}
+        <AuFormRow class="au-form-row-full-width">
+          <AuLabel @required={{true}} for="display-type">Codelijst</AuLabel>
+          <PowerSelect
+            @allowClear={{false}}
+            @renderInPlace={{false}}
+            @searchEnabled={{true}}
+            @loadingMessage="Aan het laden..."
+            @noMatchesMessage="Geen codelijsten gevonden"
+            @searchMessage="Typ om te zoeken"
+            @searchField="displayLabel"
+            @options={{this.conceptSchemes}}
+            @selected={{this.conceptScheme}}
+            @onChange={{this.updateSelectedConceptScheme}}
+            id="concept-scheme"
+            as |selected|
+          >
+            {{selected.displayLabel}}
+          </PowerSelect>
+        </AuFormRow>
+      {{/if}}
+      <AuFormRow>
+        <AuToggleSwitch
+          @disabled={{not this.selectedField}}
+          @checked={{this.isRequired}}
+          @onChange={{this.toggleIsRequired}}
+        >Maak veld verplicht
+          <Shared::Tooltip
+            @showTooltip={{true}}
+            @alignment="top-left"
+            @tooltipText="Bij het aanmaken of aanpassen van items zal dit veld steeds ingevuld moeten worden."
+          >
+            <AuButton
+              @skin="naked"
+              @icon="circle-question"
+              @hideText={{true}}
+              @disabled={{true}}
+              class="au-u-padding-bottom-small au-u-padding-left-none"
+            />
+          </Shared::Tooltip></AuToggleSwitch>
+      </AuFormRow>
+      <AuFormRow>
+        <AuToggleSwitch
+          @disabled={{not this.selectedField}}
+          @checked={{this.isShownInSummary}}
+          @onChange={{this.toggleShowInSummary}}
+        >Toon in samenvatting
+          <Shared::Tooltip
+            @showTooltip={{true}}
+            @alignment="top-left"
+            @tooltipText="Dit veld zal getoond worden in de samenvatting van een item, bijvoorbeeld bij het tonen van een lijst van items of bij een verwijzing naar een item."
+          >
+            <AuButton
+              @skin="naked"
+              @icon="circle-question"
+              @hideText={{true}}
+              @disabled={{true}}
+              class="au-u-padding-bottom-small au-u-padding-left-none"
+            />
+          </Shared::Tooltip>
+        </AuToggleSwitch>
+      </AuFormRow>
+      <AuFormRow>
+        <AuButtonGroup>
           <AuButton
-            @skin="naked"
-            @icon="circle-question"
-            @hideText={{true}}
-            @disabled={{true}}
-            class="au-u-padding-bottom-small au-u-padding-left-none"
-          />
-        </Shared::Tooltip></AuToggleSwitch>
-    </AuFormRow>
-    <AuFormRow>
-      <AuToggleSwitch
-        @disabled={{not this.selectedField}}
-        @checked={{this.isShownInSummary}}
-        @onChange={{this.toggleShowInSummary}}
-      >Toon in samenvatting
-        <Shared::Tooltip
-          @showTooltip={{true}}
-          @alignment="top-left"
-          @tooltipText="Dit veld zal getoond worden in de samenvatting van een item, bijvoorbeeld bij het tonen van een lijst van items of bij een verwijzing naar een item."
-        >
-          <AuButton
-            @skin="naked"
-            @icon="circle-question"
-            @hideText={{true}}
-            @disabled={{true}}
-            class="au-u-padding-bottom-small au-u-padding-left-none"
-          />
-        </Shared::Tooltip>
-      </AuToggleSwitch>
-    </AuFormRow>
-    <AuFormRow>
-      <AuButtonGroup>
-        <AuButton
-          @disabled={{not this.isChanged}}
-          {{on "click" this.saveFieldChanges}}
-        >
-          Pas aan
-        </AuButton>
-      </AuButtonGroup>
-    </AuFormRow>
-  </form>
+            @disabled={{not this.isChanged}}
+            {{on "click" this.saveFieldChanges}}
+          >
+            Pas aan
+          </AuButton>
+        </AuButtonGroup>
+      </AuFormRow>
+    </form>
+  {{/if}}
 </div>

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -20,6 +20,7 @@
     <AuFormRow @alignment="default">
       <AuLabel @required={{true}} for="fieldName">Naam</AuLabel>
       <AuInput
+        @disabled={{not this.selectedField}}
         @width="block"
         @iconAlignment="left"
         value={{this.selectedField.label}}
@@ -27,8 +28,29 @@
         {{on "input" this.updateFieldName}}
       />
     </AuFormRow>
+    <AuFormRow class="au-form-row-full-width">
+      <AuLabel @required={{true}} for="display-type">Type</AuLabel>
+      <PowerSelect
+        @allowClear={{false}}
+        @disabled={{not this.selectedField}}
+        @renderInPlace={{false}}
+        @searchEnabled={{true}}
+        @loadingMessage="Aan het laden..."
+        @noMatchesMessage="Geen types gevonden"
+        @searchMessage="Typ om te zoeken"
+        @searchField="label"
+        @options={{this.displayTypes}}
+        @selected={{this.selectedDisplayType}}
+        @onChange={{this.updateSelectedDisplayType}}
+        id="display-type"
+        as |selected|
+      >
+        {{selected.label}}
+      </PowerSelect>
+    </AuFormRow>
     <AuFormRow>
       <AuToggleSwitch
+        @disabled={{not this.selectedField}}
         @checked={{this.selectedField.isRequired}}
         @onChange={{this.toggleIsRequired}}
       >Maak veld verplicht
@@ -48,6 +70,7 @@
     </AuFormRow>
     <AuFormRow>
       <AuToggleSwitch
+        @disabled={{not this.selectedField}}
         @checked={{this.selectedField.isShownInSummary}}
         @onChange={{this.toggleShowInSummary}}
       >Toon in samenvatting

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -1,5 +1,5 @@
 <div class="au-o-box edit-form-defintion--edit-panel-containter">
-  <AuLabel>Selecteer een veld</AuLabel>
+  {{!-- <AuLabel>Selecteer een veld</AuLabel>
   <PowerSelect
     @allowClear={{false}}
     @searchEnabled={{true}}
@@ -15,7 +15,7 @@
     as |selected|
   >
     {{selected.label}}
-  </PowerSelect>
+  </PowerSelect> --}}
   <form class="au-c-form au-o-flow">
     <AuFormRow @alignment="default">
       <AuLabel @required={{true}} for="fieldName">Naam</AuLabel>
@@ -23,7 +23,7 @@
         @disabled={{not this.selectedField}}
         @width="block"
         @iconAlignment="left"
-        value={{this.selectedField.label}}
+        value={{this.label}}
         id="fieldName"
         {{on "input" this.updateFieldName}}
       />

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -1,0 +1,3 @@
+<div class="edit-form-defintion--edit-panel-containter">
+
+</div>

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -1,3 +1,18 @@
-<div class="edit-form-defintion--edit-panel-containter">
-
+<div class="au-o-box edit-form-defintion--edit-panel-containter">
+  <AuLabel>Selecteer een veld</AuLabel>
+  <PowerSelect
+    @allowClear={{false}}
+    @searchEnabled={{true}}
+    @loadingMessage="Aan het laden..."
+    @noMatchesMessage="Geen velden gevonden"
+    @searchMessage="Typ om te zoeken"
+    @searchField="label"
+    @options={{this.fields}}
+    @selected={{this.selectedField}}
+    @onChange={{this.updateSelectedField}}
+    id="select-custom-form-field"
+    as |selected|
+  >
+    {{selected.label}}
+  </PowerSelect>
 </div>

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -72,7 +72,7 @@
     <AuFormRow>
       <AuToggleSwitch
         @disabled={{not this.selectedField}}
-        @checked={{this.selectedField.isRequired}}
+        @checked={{this.isRequired}}
         @onChange={{this.toggleIsRequired}}
       >Maak veld verplicht
         <Shared::Tooltip
@@ -92,7 +92,7 @@
     <AuFormRow>
       <AuToggleSwitch
         @disabled={{not this.selectedField}}
-        @checked={{this.selectedField.isShownInSummary}}
+        @checked={{this.isShownInSummary}}
         @onChange={{this.toggleShowInSummary}}
       >Toon in samenvatting
         <Shared::Tooltip
@@ -109,6 +109,23 @@
           />
         </Shared::Tooltip>
       </AuToggleSwitch>
+    </AuFormRow>
+    <AuFormRow>
+      <AuButtonGroup>
+        <AuButton
+          @disabled={{not this.isChanged}}
+          {{on "click" this.saveFieldChanges}}
+        >
+          Pas aan
+        </AuButton>
+        <AuButton
+          @skin="secondary"
+          @disabled={{or (not this.selectedField) (not this.isChanged)}}
+          {{on "click" this.resetFieldValues}}
+        >
+          Reset
+        </AuButton>
+      </AuButtonGroup>
     </AuFormRow>
   </form>
 </div>

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -105,15 +105,54 @@
           </Shared::Tooltip>
         </AuToggleSwitch>
       </AuFormRow>
-      <AuFormRow>
-        <AuButtonGroup>
+      {{#if this.isDeleteWarningShown}}
+        <div
+          class="au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--spaced-tiny warning-panel au-u-margin-top"
+        >
+          <AuBadge @icon="alert-triangle" @skin="error" @size="small" />
+          <span>Dit veld zal verwijderd worden voor
+            <strong>alle items</strong>
+            die bewerkt worden door dit formulier! Dit betekent dat u de
+            <strong>gegevens zal verliezen</strong>
+            die opgeslagen werd in dit veld! Wilt u nog steeds doorgaan?</span>
+        </div>
+      {{/if}}
+      <AuFormRow class="au-u-flex au-u-flex--between au-u-flex--row">
+        {{#if this.isDeleteWarningShown}}
           <AuButton
-            @disabled={{not this.canSaveChanges}}
+            @disabled={{this.isDeleting}}
+            @skin="secondary"
+            {{on "click" (fn (mut this.isDeleteWarningShown) false)}}
+          >
+            Annuleer
+          </AuButton>
+          <AuButton
+            @disabled={{or this.isDeleting this.isSaving}}
+            @alert={{true}}
+            @loading={{this.isDeleting}}
+            @loadingMessage="Verwijderen"
+            {{on "click" this.removeFormField}}
+          >
+            Definitief verwijderen
+          </AuButton>
+        {{else}}
+          <AuButton
+            @disabled={{or (not this.canSaveChanges) this.isSaving}}
+            @loading={{this.isSaving}}
+            @loadingMessage="Bewaren"
             {{on "click" this.saveFieldChanges}}
           >
             Pas aan
           </AuButton>
-        </AuButtonGroup>
+          <AuButton
+            @disabled={{or this.isDeleting this.isSaving}}
+            @alert={{true}}
+            @skin="secondary"
+            {{on "click" (fn (mut this.isDeleteWarningShown) true)}}
+          >
+            Verwijder
+          </AuButton>
+        {{/if}}
       </AuFormRow>
     </form>
   {{/if}}

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -1,21 +1,4 @@
 <div class="au-o-box edit-form-defintion--edit-panel-containter">
-  {{!-- <AuLabel>Selecteer een veld</AuLabel>
-  <PowerSelect
-    @allowClear={{false}}
-    @searchEnabled={{true}}
-    @loadingMessage="Aan het laden..."
-    @noMatchesMessage="Geen velden gevonden"
-    @searchMessage="Typ om te zoeken"
-    @searchField="label"
-    @options={{this.fields}}
-    @selected={{this.selectedField}}
-    @onChange={{this.updateSelectedField}}
-    id="select-custom-form-field"
-    class="au-u-margin-bottom"
-    as |selected|
-  >
-    {{selected.label}}
-  </PowerSelect> --}}
   <form class="au-c-form au-o-flow">
     <AuFormRow @alignment="default">
       <AuLabel @required={{true}} for="fieldName">Naam</AuLabel>

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -113,7 +113,7 @@ export default class CustomFormEditCustomField extends Component {
     if (this.args.onFieldUpdated) {
       this.resetFieldValues();
       this.getFieldsForForm.retry();
-      this.args.onFieldUpdated(this.selectedField.uri);
+      this.args.onFieldUpdated(this.args.selectedFieldUri);
     }
   }
 

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -113,7 +113,7 @@ export default class CustomFormEditCustomField extends Component {
     if (this.args.onFieldUpdated) {
       this.resetFieldValues();
       this.getFieldsForForm.retry();
-      this.args.onFieldUpdated();
+      this.args.onFieldUpdated(this.selectedField.uri);
     }
   }
 
@@ -170,8 +170,6 @@ function setSelectedField() {
     const field = this.fields.filter(
       (f) => f.uri === this.args.selectedFieldUri
     )[0];
-    console.log(this.fields);
-    console.log(`selectedField`, field);
     this.updateSelectedField(field);
     return field;
   });

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -22,6 +22,16 @@ export default class CustomFormEditCustomField extends Component {
   updateSelectedField(field) {
     this.selectedField = field;
   }
+
+  @action
+  toggleIsRequired() {
+    this.selectedField.isRequired = !this.selectedField.isRequired;
+  }
+
+  @action
+  toggleShowInSummary() {
+    this.selectedField.isShownInSummary = !this.selectedField.isShownInSummary;
+  }
 }
 
 function getFieldsForForm() {

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -1,0 +1,45 @@
+import Component from '@glimmer/component';
+
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+import { trackedFunction } from 'reactiveweb/function';
+import { use } from 'ember-resources';
+
+import { API } from 'frontend-lmb/utils/constants';
+import { showErrorToast } from 'frontend-lmb/utils/toasts';
+
+export default class CustomFormEditCustomField extends Component {
+  @use(getFieldsForForm) getFieldsForForm;
+
+  @tracked selectedField;
+
+  get fields() {
+    return this.getFieldsForForm?.value || [];
+  }
+
+  @action
+  updateSelectedField(field) {
+    this.selectedField = field;
+  }
+}
+
+function getFieldsForForm() {
+  return trackedFunction(async () => {
+    const response = await fetch(
+      `${API.FORM_CONTENT_SERVICE}/custom-form/${this.args.formDefinitionId}/fields`
+    );
+
+    if (!response.ok) {
+      showErrorToast(
+        this.toaster,
+        `Er liep iets mis bij het ophalen van de velden voor formulier met id: ${this.args.formDefinitionId}`,
+        'Formulier'
+      );
+    }
+
+    const result = await response.json();
+
+    return result.fields;
+  });
+}

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -16,10 +16,14 @@ export default class CustomFormEditCustomField extends Component {
   @use(getConceptSchemes) getConceptSchemes;
 
   @service store;
+  @service customForms;
 
   @tracked selectedField;
+  @tracked label;
   @tracked displayType;
   @tracked conceptScheme;
+  @tracked isRequired;
+  @tracked isShownInSummary;
 
   get fields() {
     return this.getFieldsForForm?.value || [];
@@ -35,9 +39,26 @@ export default class CustomFormEditCustomField extends Component {
     return this.getConceptSchemes?.value || [];
   }
 
+  get isChanged() {
+    if (!this.selectedField) {
+      return false;
+    }
+
+    return (
+      this.selectedField.label !== this.label ||
+      this.selectedField.displayType !== this.displayType?.uri ||
+      this.selectedField.conceptScheme !== this.conceptScheme?.uri ||
+      this.selectedField.isRequired !== this.isRequired ||
+      this.selectedField.isShownInSummary !== this.isShownInSummary
+    );
+  }
+
   @action
   updateSelectedField(field) {
     this.selectedField = field;
+    this.label = field.label;
+    this.isRequired = field.isRequired;
+    this.isShownInSummary = field.isShownInSummary;
     this.displayType = this.displayTypes.filter(
       (t) => t.uri === field.displayType
     )?.[0];
@@ -48,7 +69,7 @@ export default class CustomFormEditCustomField extends Component {
 
   @action
   updateFieldName(event) {
-    this.selectedField.label = event.target?.value;
+    this.label = event.target?.value;
   }
 
   @action
@@ -63,12 +84,32 @@ export default class CustomFormEditCustomField extends Component {
 
   @action
   toggleIsRequired() {
-    this.selectedField.isRequired = !this.selectedField.isRequired;
+    this.isRequired = !this.isRequired;
   }
 
   @action
   toggleShowInSummary() {
-    this.selectedField.isShownInSummary = !this.selectedField.isShownInSummary;
+    this.isShownInSummary = !this.isShownInSummary;
+  }
+
+  @action
+  async saveFieldChanges() {
+    await this.customForms.updateCustomFormField(
+      this.args.formDefinitionId,
+      this.selectedField.uri,
+      {
+        label: this.label,
+        displayTypeUri: this.displayType.uri,
+        conceptSchemeUri: this.conceptScheme?.uri,
+        isRequired: this.isRequired,
+        isShownInSummary: this.isShownInSummary,
+      }
+    );
+  }
+
+  @action
+  resetFieldValues() {
+    this.updateSelectedField(this.selectedField);
   }
 }
 

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -56,14 +56,14 @@ export default class CustomFormEditCustomField extends Component {
   @action
   updateSelectedField(field) {
     this.selectedField = field;
-    this.label = field.label;
-    this.isRequired = field.isRequired;
-    this.isShownInSummary = field.isShownInSummary;
+    this.label = field?.label;
+    this.isRequired = !!field?.isRequired;
+    this.isShownInSummary = !!field?.isShownInSummary;
     this.displayType = this.displayTypes.filter(
-      (t) => t.uri === field.displayType
+      (t) => t.uri === field?.displayType
     )?.[0];
     this.conceptScheme = this.conceptSchemes.filter(
-      (cs) => cs.uri === field.conceptScheme
+      (cs) => cs.uri === field?.conceptScheme
     )?.[0];
   }
 
@@ -105,6 +105,13 @@ export default class CustomFormEditCustomField extends Component {
         isShownInSummary: this.isShownInSummary,
       }
     );
+
+    if (this.args.onFieldUpdated) {
+      this.selectedField = null;
+      this.resetFieldValues();
+      this.getFieldsForForm.retry();
+      this.args.onFieldUpdated();
+    }
   }
 
   @action
@@ -128,6 +135,10 @@ function getFieldsForForm() {
     }
 
     const result = await response.json();
+
+    if (result.fields[0]) {
+      this.updateSelectedField(result.fields[0]);
+    }
 
     return result.fields;
   });

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { trackedFunction } from 'reactiveweb/function';
@@ -11,6 +12,9 @@ import { showErrorToast } from 'frontend-lmb/utils/toasts';
 
 export default class CustomFormEditCustomField extends Component {
   @use(getFieldsForForm) getFieldsForForm;
+  @use(getDisplayTypes) getDisplayTypes;
+
+  @service store;
 
   @tracked selectedField;
 
@@ -18,9 +22,33 @@ export default class CustomFormEditCustomField extends Component {
     return this.getFieldsForForm?.value || [];
   }
 
+  get displayTypes() {
+    return this.getDisplayTypes?.value || [];
+  }
+
+  get selectedDisplayType() {
+    if (!this.selectedField?.displayType) {
+      return null;
+    }
+
+    return this.displayTypes.filter(
+      (d) => d.uri === this.selectedField.displayType
+    )?.[0];
+  }
+
   @action
   updateSelectedField(field) {
     this.selectedField = field;
+  }
+
+  @action
+  updateFieldName(event) {
+    this.selectedField.label = event.target?.value;
+  }
+
+  @action
+  updateSelectedDisplayType(displayType) {
+    this.selectedField.displayType = displayType.uri;
   }
 
   @action
@@ -51,5 +79,13 @@ function getFieldsForForm() {
     const result = await response.json();
 
     return result.fields;
+  });
+}
+
+function getDisplayTypes() {
+  return trackedFunction(async () => {
+    return await this.store.query('display-type', {
+      sort: 'label',
+    });
   });
 }

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -7,11 +7,7 @@ import { tracked, cached } from '@glimmer/tracking';
 import { trackedFunction } from 'reactiveweb/function';
 import { use } from 'ember-resources';
 
-import { API } from 'frontend-lmb/utils/constants';
-import { showErrorToast } from 'frontend-lmb/utils/toasts';
-
 export default class CustomFormEditCustomField extends Component {
-  @use(getFieldsForForm) getFieldsForForm;
   @use(setSelectedField) setSelectedField;
   @use(getDisplayTypes) getDisplayTypes;
   @use(getConceptSchemes) getConceptSchemes;
@@ -98,7 +94,7 @@ export default class CustomFormEditCustomField extends Component {
 
   @action
   async saveFieldChanges() {
-    await this.customForms.updateCustomFormField(
+    const updatedField = await this.customForms.updateCustomFormField(
       this.args.formDefinitionId,
       this.selectedField.uri,
       {
@@ -111,36 +107,9 @@ export default class CustomFormEditCustomField extends Component {
     );
 
     if (this.args.onFieldUpdated) {
-      this.resetFieldValues();
-      this.getFieldsForForm.retry();
-      this.args.onFieldUpdated(this.args.selectedFieldUri);
+      this.args.onFieldUpdated(updatedField);
     }
   }
-
-  @action
-  resetFieldValues() {
-    this.updateSelectedField(this.selectedField);
-  }
-}
-
-function getFieldsForForm() {
-  return trackedFunction(async () => {
-    const response = await fetch(
-      `${API.FORM_CONTENT_SERVICE}/custom-form/${this.args.formDefinitionId}/fields`
-    );
-
-    if (!response.ok) {
-      showErrorToast(
-        this.toaster,
-        `Er liep iets mis bij het ophalen van de velden voor formulier met id: ${this.args.formDefinitionId}`,
-        'Formulier'
-      );
-    }
-
-    const result = await response.json();
-
-    return result.fields;
-  });
 }
 
 function getDisplayTypes() {
@@ -167,10 +136,8 @@ function getConceptSchemes() {
 
 function setSelectedField() {
   return trackedFunction(async () => {
-    const field = this.fields.filter(
-      (f) => f.uri === this.args.selectedFieldUri
-    )[0];
-    this.updateSelectedField(field);
-    return field;
+    this.updateSelectedField(this.args.selectedField);
+
+    return this.args.selectedField;
   });
 }

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -119,6 +119,7 @@ export default class CustomFormEditCustomField extends Component {
         conceptSchemeUri: this.conceptScheme?.uri,
         isRequired: this.isRequired,
         isShownInSummary: this.isShownInSummary,
+        formUri: this.args.selectedField.formUri,
       }
     );
     this.isSaving = false;
@@ -133,7 +134,7 @@ export default class CustomFormEditCustomField extends Component {
     this.isDeleting = true;
     await this.customForms.removeFormField(
       this.selectedField.uri,
-      this.args.formDefinitionId
+      this.selectedField.formUri
     );
     this.isDeleteWarningShown = false;
     this.isDeleting = false;

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -15,12 +15,15 @@ export default class CustomFormEditCustomField extends Component {
   @service store;
   @service customForms;
 
-  // @tracked selectedField;
   @tracked label;
   @tracked displayType;
   @tracked conceptScheme;
   @tracked isRequired;
   @tracked isShownInSummary;
+
+  @tracked isSaving;
+  @tracked isDeleteWarningShown;
+  @tracked isDeleting;
 
   get fields() {
     return this.getFieldsForForm?.value || [];
@@ -73,6 +76,10 @@ export default class CustomFormEditCustomField extends Component {
     this.conceptScheme = this.conceptSchemes.filter(
       (cs) => cs.uri === field?.conceptScheme
     )?.[0];
+
+    this.isSaving = false;
+    this.isDeleteWarningShown = false;
+    this.isDeleting = false;
   }
 
   @action
@@ -102,6 +109,7 @@ export default class CustomFormEditCustomField extends Component {
 
   @action
   async saveFieldChanges() {
+    this.isSaving = true;
     const updatedField = await this.customForms.updateCustomFormField(
       this.args.formDefinitionId,
       this.selectedField.uri,
@@ -113,9 +121,24 @@ export default class CustomFormEditCustomField extends Component {
         isShownInSummary: this.isShownInSummary,
       }
     );
+    this.isSaving = false;
 
     if (this.args.onFieldUpdated) {
       this.args.onFieldUpdated(updatedField);
+    }
+  }
+
+  @action
+  async removeFormField() {
+    this.isDeleting = true;
+    await this.customForms.removeFormField(
+      this.selectedField.uri,
+      this.args.formDefinitionId
+    );
+    this.isDeleteWarningShown = false;
+    this.isDeleting = false;
+    if (this.args.onFieldUpdated) {
+      this.args.onFieldUpdated(null);
     }
   }
 }

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -12,13 +12,14 @@ import { showErrorToast } from 'frontend-lmb/utils/toasts';
 
 export default class CustomFormEditCustomField extends Component {
   @use(getFieldsForForm) getFieldsForForm;
+  @use(setSelectedField) setSelectedField;
   @use(getDisplayTypes) getDisplayTypes;
   @use(getConceptSchemes) getConceptSchemes;
 
   @service store;
   @service customForms;
 
-  @tracked selectedField;
+  // @tracked selectedField;
   @tracked label;
   @tracked displayType;
   @tracked conceptScheme;
@@ -39,6 +40,10 @@ export default class CustomFormEditCustomField extends Component {
     return this.getConceptSchemes?.value || [];
   }
 
+  get selectedField() {
+    return this.setSelectedField?.value;
+  }
+
   get isChanged() {
     if (!this.selectedField) {
       return false;
@@ -55,7 +60,6 @@ export default class CustomFormEditCustomField extends Component {
 
   @action
   updateSelectedField(field) {
-    this.selectedField = field;
     this.label = field?.label;
     this.isRequired = !!field?.isRequired;
     this.isShownInSummary = !!field?.isShownInSummary;
@@ -107,7 +111,6 @@ export default class CustomFormEditCustomField extends Component {
     );
 
     if (this.args.onFieldUpdated) {
-      this.selectedField = null;
       this.resetFieldValues();
       this.getFieldsForForm.retry();
       this.args.onFieldUpdated();
@@ -136,10 +139,6 @@ function getFieldsForForm() {
 
     const result = await response.json();
 
-    if (result.fields[0]) {
-      this.updateSelectedField(result.fields[0]);
-    }
-
     return result.fields;
   });
 }
@@ -163,5 +162,17 @@ function getConceptSchemes() {
           a.displayLabel.localeCompare(b.displayLabel)
         );
       });
+  });
+}
+
+function setSelectedField() {
+  return trackedFunction(async () => {
+    const field = this.fields.filter(
+      (f) => f.uri === this.args.selectedFieldUri
+    )[0];
+    console.log(this.fields);
+    console.log(`selectedField`, field);
+    this.updateSelectedField(field);
+    return field;
   });
 }

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -40,6 +40,14 @@ export default class CustomFormEditCustomField extends Component {
     return this.setSelectedField?.value;
   }
 
+  get isValidLabel() {
+    return this.label?.trim() !== '';
+  }
+
+  get canSaveChanges() {
+    return this.isChanged && this.isValidLabel && this.displayType;
+  }
+
   get isChanged() {
     if (!this.selectedField) {
       return false;

--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -18,6 +18,7 @@
           @width="block"
           @icon="plus"
           {{on "click" (fn (mut this.showEditModal) true)}}
+          class="au-u-margin-bottom"
         >
           Voeg een veld toe
         </AuButton>

--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -12,7 +12,7 @@
     @saveTitle={{@saveTitle}}
   >
     {{#if this.editableFormsEnabled}}
-      {{#unless @isReadOnly}}
+      {{#if this.formState.isAddFieldShownInForm}}
         <AuButton
           @skin="secondary"
           @width="block"
@@ -22,7 +22,7 @@
         >
           Voeg een veld toe
         </AuButton>
-      {{/unless}}
+      {{/if}}
 
       {{yield}}
 

--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -18,7 +18,7 @@
           @width="block"
           @icon="plus"
           {{on "click" (fn (mut this.showEditModal) true)}}
-          class="au-u-margin-bottom"
+          class="au-u-margin-bottom au-u-margin-top"
         >
           Voeg een veld toe
         </AuButton>

--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -18,7 +18,6 @@
           @width="block"
           @icon="plus"
           {{on "click" (fn (mut this.showEditModal) true)}}
-          class="au-u-padding-left-none au-u-margin-bottom au-u-margin-top"
         >
           Voeg een veld toe
         </AuButton>

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -68,14 +68,17 @@ export default class EditableFormComponent extends Component {
 
   @provide('form-state')
   get formState() {
+    const canEditFieldsInlineInForm =
+      this.args.editFieldsInForm == undefined
+        ? true
+        : !!this.args.editFieldsInForm;
     return {
-      editFieldsInForm:
-        this.args.editFieldsInForm == undefined
-          ? true
-          : !!this.args.editFieldsInForm,
+      editFieldsInForm: canEditFieldsInlineInForm,
       canSelectField: !!this.args.canSelectField,
       clickedField: this.clickedField,
       isReadOnly: this.args.isReadOnly,
+      isFieldEditPencilShown:
+        canEditFieldsInlineInForm && !this.args.toReceiveUserInput,
     };
   }
 

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -79,6 +79,8 @@ export default class EditableFormComponent extends Component {
       isReadOnly: this.args.isReadOnly,
       isFieldEditPencilShown:
         canEditFieldsInlineInForm && !this.args.toReceiveUserInput,
+      isAddFieldShownInForm:
+        !this.args.toReceiveUserInput && !this.args.isReadOnly,
     };
   }
 

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -37,9 +37,6 @@ export default class EditableFormComponent extends Component {
 
   @action
   setClickedField(field) {
-    if (!this.formContext.canSelectField) {
-      return;
-    }
     this.clickedField = field;
     if (this.args.onFieldSelected) {
       this.args.onFieldSelected(field.uri.value);
@@ -50,15 +47,21 @@ export default class EditableFormComponent extends Component {
     return this.features.isEnabled('editable-forms');
   }
 
+  @provide('form-state')
+  get formState() {
+    return {
+      canSelectField: !!this.args.canSelectField,
+      clickedField: this.clickedField,
+      isReadOnly: this.args.isReadOnly,
+    };
+  }
+
   @provide('form-context')
   get formContext() {
     return {
       onFormUpdate: () => this.updateForm(),
       onFieldClicked: (field) => this.setClickedField(field),
-      canSelectField: !!this.args.canSelectField,
       formDefinition: this.currentForm,
-      clickedField: this.clickedField,
-      isReadOnly: this.args.isReadOnly,
     };
   }
 }

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -37,6 +37,9 @@ export default class EditableFormComponent extends Component {
 
   @action
   setClickedField(field) {
+    if (!this.formContext.canSelectField) {
+      return;
+    }
     this.clickedField = field;
     if (this.args.onFieldSelected) {
       this.args.onFieldSelected(field.uri.value);
@@ -52,6 +55,7 @@ export default class EditableFormComponent extends Component {
     return {
       onFormUpdate: () => this.updateForm(),
       onFieldClicked: (field) => this.setClickedField(field),
+      canSelectField: !!this.args.canSelectField,
       formDefinition: this.currentForm,
       clickedField: this.clickedField,
       isReadOnly: this.args.isReadOnly,

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -81,6 +81,8 @@ export default class EditableFormComponent extends Component {
         canEditFieldsInlineInForm && !this.args.toReceiveUserInput,
       isAddFieldShownInForm:
         !this.args.toReceiveUserInput && !this.args.isReadOnly,
+      canMoveFieldsInForm:
+        !this.args.toReceiveUserInput && !this.args.isReadOnly,
     };
   }
 

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 
 import { action } from '@ember/object';
-import { tracked, cached } from '@glimmer/tracking';
+import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
 import { provide } from 'ember-provide-consume-context';
@@ -45,7 +45,6 @@ export default class EditableFormComponent extends Component {
     this.showEditModal = false;
   }
 
-  @cached
   get fields() {
     return this.getFieldsForForm?.value || [];
   }

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -48,15 +48,16 @@ export default class EditableFormComponent extends Component {
   }
 
   @action
-  async setClickedField(clickedField) {
-    this.clickedField = clickedField;
-    if (this.args.onFieldSelected) {
+  async setClickedField(fieldModel) {
+    this.clickedField = fieldModel;
+    if (this.args.onFieldSelected && fieldModel) {
       await this.getFieldsForForm.retry();
       const field = this.fields.filter(
-        (f) => f.uri === clickedField.uri?.value
+        (f) => f.uri === fieldModel.uri?.value
       )[0];
-      this.args.onFieldSelected(field);
+      this.clickedField = field;
     }
+    this.args.onFieldSelected(this.clickedField);
   }
 
   get editableFormsEnabled() {
@@ -76,7 +77,7 @@ export default class EditableFormComponent extends Component {
   get formContext() {
     return {
       onFormUpdate: () => this.updateForm(),
-      onFieldClicked: (field) => this.setClickedField(field),
+      onFieldClicked: (fieldModel) => this.setClickedField(fieldModel),
       formDefinition: this.currentForm,
     };
   }
@@ -95,13 +96,12 @@ function getFieldsForForm() {
     if (!response.ok) {
       showErrorToast(
         this.toaster,
-        `Er liep iets mis bij het ophalen van de velden voor formulier met id: ${this.args.formDefinitionId}`,
+        `Er liep iets mis bij het ophalen van de velden voor formulier met id: ${this.currentForm?.id}`,
         'Formulier'
       );
     }
 
     const result = await response.json();
-    console.log(`fields`, result.fields);
     return result.fields;
   });
 }

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -92,6 +92,7 @@ export default class EditableFormComponent extends Component {
       onFormUpdate: () => this.updateForm(),
       onFieldClicked: (fieldModel) => this.setClickedField(fieldModel),
       formDefinition: this.currentForm,
+      fieldsInForm: this.fields,
     };
   }
 }
@@ -115,6 +116,10 @@ function getFieldsForForm() {
     }
 
     const result = await response.json();
+
+    if (this.args.onFieldsSet) {
+      this.args.onFieldsSet(result.fields);
+    }
     return result.fields;
   });
 }

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 
+import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
@@ -14,6 +15,7 @@ export default class EditableFormComponent extends Component {
   @service features;
 
   @tracked showEditModal;
+  @tracked clickedField;
 
   constructor() {
     super(...arguments);
@@ -33,6 +35,14 @@ export default class EditableFormComponent extends Component {
     this.showEditModal = false;
   }
 
+  @action
+  setClickedField(field) {
+    this.clickedField = field;
+    if (this.args.onFieldSelected) {
+      this.args.onFieldSelected(field.uri.value);
+    }
+  }
+
   get editableFormsEnabled() {
     return this.features.isEnabled('editable-forms');
   }
@@ -41,7 +51,9 @@ export default class EditableFormComponent extends Component {
   get formContext() {
     return {
       onFormUpdate: () => this.updateForm(),
+      onFieldClicked: (field) => this.setClickedField(field),
       formDefinition: this.currentForm,
+      clickedField: this.clickedField,
       isReadOnly: this.args.isReadOnly,
     };
   }

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -26,6 +26,9 @@ export default class EditableFormComponent extends Component {
   constructor() {
     super(...arguments);
     this.updateForm();
+    if (this.args.selectedField) {
+      this.clickedField = this.args.selectedField;
+    }
   }
 
   async updateForm() {

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -67,6 +67,10 @@ export default class EditableFormComponent extends Component {
   @provide('form-state')
   get formState() {
     return {
+      editFieldsInForm:
+        this.args.editFieldsInForm == undefined
+          ? true
+          : !!this.args.editFieldsInForm,
       canSelectField: !!this.args.canSelectField,
       clickedField: this.clickedField,
       isReadOnly: this.args.isReadOnly,

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -197,16 +197,10 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
       return;
     }
     this.isRemovingField = true;
-    await fetch(`/form-content/fields`, {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': JSON_API_TYPE,
-      },
-      body: JSON.stringify({
-        fieldUri: this.args.field.uri.value,
-        formUri: this.args.form.uri,
-      }),
-    });
+    await this.customForms.removeFormField(
+      this.args.field.uri.value,
+      this.args.form.uri
+    );
     this.formContext.onFormUpdate();
     this.isRemovingField = false;
   }

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -26,6 +26,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
   @service store;
   @service toaster;
   @service formReplacements;
+  @service customForms;
 
   @tracked isRemovingField;
   @tracked isFieldRequired;
@@ -110,32 +111,18 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
   }
 
   updateField = task(async () => {
-    try {
-      await fetch(
-        `/form-content/${this.formContext.formDefinition.id}/fields`,
-        {
-          method: 'PUT',
-          headers: {
-            'Content-Type': JSON_API_TYPE,
-          },
-          body: JSON.stringify({
-            field: this.args.field.uri.value,
-            displayType: this.displayType.uri,
-            name: this.fieldName,
-            isRequired: !!this.isFieldRequired,
-            showInSummary: !!this.isShownInSummary,
-            conceptScheme: this.conceptScheme?.uri,
-          }),
-        }
-      );
-      this.formContext.onFormUpdate();
-    } catch (error) {
-      showErrorToast(
-        this.toaster,
-        'Er ging iets mis bij het opslaan van het veld.'
-      );
-      return;
-    }
+    await this.customForms.updateCustomFormField(
+      this.formContext.formDefinition.id,
+      this.args.field.uri.value,
+      {
+        label: this.fieldName,
+        displayTypeUri: this.displayType.uri,
+        conceptSchemeUri: this.conceptScheme?.uri,
+        isRequired: this.isRequired,
+        isShownInSummary: this.isShownInSummary,
+      }
+    );
+    this.formContext.onFormUpdate();
   });
 
   createField = task(async () => {

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -9,7 +9,7 @@
         <div class="au-u-flex au-u-flex--row">
           {{#unless this.formState.isReadOnly}}
             <AuLabel @required={{this.isRequired}}>{{this.title}}</AuLabel>
-            {{#if this.formState.editFieldsInForm}}
+            {{#if this.formState.isFieldEditPencilShown}}
               <AuButton
                 @skin="link-secondary"
                 @icon="pencil"

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -36,7 +36,7 @@
           </div>
         </div>
       </div>
-      {{#unless this.formState.isReadOnly}}
+      {{#if this.formState.canMoveFieldsInForm}}
         <div class="au-u-flex au-u-flex--column au-u-flex--vertical-center">
           <AuButton
             @skin="naked"
@@ -55,7 +55,7 @@
             Naar onder
           </AuButton>
         </div>
-      {{/unless}}
+      {{/if}}
     </div>
   </div>
 {{/unless}}

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -7,7 +7,7 @@
     >
       <div class="flex-grow">
         <div class="au-u-flex au-u-flex--row">
-          {{#unless this.formContext.isReadOnly}}
+          {{#unless this.formState.isReadOnly}}
             <AuLabel @required={{this.isRequired}}>{{this.title}}</AuLabel>
             <AuButton
               @skin="link-secondary"
@@ -34,7 +34,7 @@
           </div>
         </div>
       </div>
-      {{#unless this.formContext.isReadOnly}}
+      {{#unless this.formState.isReadOnly}}
         <div class="au-u-flex au-u-flex--column au-u-flex--vertical-center">
           <AuButton
             @skin="naked"

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -9,14 +9,16 @@
         <div class="au-u-flex au-u-flex--row">
           {{#unless this.formState.isReadOnly}}
             <AuLabel @required={{this.isRequired}}>{{this.title}}</AuLabel>
-            <AuButton
-              @skin="link-secondary"
-              @icon="pencil"
-              @hideText={{true}}
-              {{on "click" (fn (mut this.showModal) true)}}
-            >
-              Pas aan
-            </AuButton>
+            {{#if this.formState.editFieldsInForm}}
+              <AuButton
+                @skin="link-secondary"
+                @icon="pencil"
+                @hideText={{true}}
+                {{on "click" (fn (mut this.showModal) true)}}
+              >
+                Pas aan
+              </AuButton>
+            {{/if}}
           {{/unless}}
         </div>
         <div

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -1,54 +1,66 @@
 {{#unless this.removed}}
-  <div class="au-u-flex au-u-flex--between">
-    <div class="flex-grow">
-      <div class="au-u-flex au-u-flex--row">
-        {{#unless this.formContext.isReadOnly}}
-          <AuLabel @required={{this.isRequired}}>{{this.title}}</AuLabel>
-          <AuButton
-            @skin="link-secondary"
-            @icon="pencil"
-            @hideText={{true}}
-            {{on "click" (fn (mut this.showModal) true)}}
-          >
-            Pas aan
-          </AuButton>
-        {{/unless}}
-      </div>
-      <div
-        class="au-u-flex au-u-flex--between au-u-flex--vertical-start au-u-flex--spaced-tiny"
-      >
-        <div class="flex-grow">
-          {{#if this.isFieldReadOnly}}
-            <ReadOnlyFieldForDisplayType
-              @field={{@field}}
-              @storeOptions={{this.storeOptions}}
-            />
-          {{else}}
-            {{yield}}
-          {{/if}}
+  <div
+    class={{if
+      this.isFieldSelected
+      "custom-form-field--selected"
+      "custom-form-field"
+    }}
+  >
+    {{! template-lint-disable no-invalid-interactive }}
+    <div
+      class="au-u-flex au-u-flex--row au-u-padding-small"
+      {{on "click" this.passOnClickedField}}
+    >
+      <div class="flex-grow">
+        <div class="au-u-flex au-u-flex--row">
+          {{#unless this.formContext.isReadOnly}}
+            <AuLabel @required={{this.isRequired}}>{{this.title}}</AuLabel>
+            <AuButton
+              @skin="link-secondary"
+              @icon="pencil"
+              @hideText={{true}}
+              {{on "click" (fn (mut this.showModal) true)}}
+            >
+              Pas aan
+            </AuButton>
+          {{/unless}}
+        </div>
+        <div
+          class="au-u-flex au-u-flex--between au-u-flex--vertical-start au-u-flex--spaced-tiny"
+        >
+          <div class="flex-grow">
+            {{#if this.isFieldReadOnly}}
+              <ReadOnlyFieldForDisplayType
+                @field={{@field}}
+                @storeOptions={{this.storeOptions}}
+              />
+            {{else}}
+              {{yield}}
+            {{/if}}
+          </div>
         </div>
       </div>
+      {{#unless this.formContext.isReadOnly}}
+        <div class="au-u-flex au-u-flex--column au-u-flex--vertical-center">
+          <AuButton
+            @skin="naked"
+            @icon="nav-up"
+            @hideText={{true}}
+            {{on "click" (perform this.moveField "up")}}
+          >
+            Naar boven
+          </AuButton>
+          <AuButton
+            @skin="naked"
+            @icon="nav-down"
+            @hideText={{true}}
+            {{on "click" (perform this.moveField "down")}}
+          >
+            Naar onder
+          </AuButton>
+        </div>
+      {{/unless}}
     </div>
-    {{#unless this.formContext.isReadOnly}}
-      <div class="au-u-flex au-u-flex--column au-u-flex--vertical-center">
-        <AuButton
-          @skin="naked"
-          @icon="nav-up"
-          @hideText={{true}}
-          {{on "click" (perform this.moveField "up")}}
-        >
-          Naar boven
-        </AuButton>
-        <AuButton
-          @skin="naked"
-          @icon="nav-down"
-          @hideText={{true}}
-          {{on "click" (perform this.moveField "down")}}
-        >
-          Naar onder
-        </AuButton>
-      </div>
-    {{/unless}}
   </div>
 {{/unless}}
 

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -1,11 +1,5 @@
 {{#unless this.removed}}
-  <div
-    class={{if
-      this.isFieldSelected
-      "custom-form-field--selected"
-      "custom-form-field"
-    }}
-  >
+  <div class={{this.styleClassForMainContainer}}>
     {{! template-lint-disable no-invalid-interactive }}
     <div
       class="au-u-flex au-u-flex--row au-u-padding-small"

--- a/app/components/rdf-input-fields/custom-field-wrapper.js
+++ b/app/components/rdf-input-fields/custom-field-wrapper.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 
+import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 import { consume } from 'ember-provide-consume-context';
@@ -23,6 +24,17 @@ export default class RdfInputFieldsCustomFieldWrapperComponent extends Component
       this.formContext.isReadOnly &&
       ![ADRES_CUSTOM_DISPLAY_TYPE].includes(this.args.field.displayType)
     );
+  }
+
+  get isFieldSelected() {
+    return (
+      this.formContext.clickedField?.uri.value === this.args.field.uri.value
+    );
+  }
+
+  @action
+  passOnClickedField() {
+    this.formContext.onFieldClicked(this.args.field);
   }
 
   moveField = task(async (direction) => {

--- a/app/components/rdf-input-fields/custom-field-wrapper.js
+++ b/app/components/rdf-input-fields/custom-field-wrapper.js
@@ -32,8 +32,25 @@ export default class RdfInputFieldsCustomFieldWrapperComponent extends Component
     );
   }
 
+  get styleClassForMainContainer() {
+    if (!this.formContext.canSelectField) {
+      return '';
+    }
+
+    const classes = ['custom-form-field'];
+
+    if (this.isFieldSelected) {
+      classes.push('custom-form-field--selected');
+    }
+
+    return classes.join(' ');
+  }
+
   @action
   passOnClickedField() {
+    if (!this.formContext.canSelectField) {
+      return;
+    }
     this.formContext.onFieldClicked(this.args.field);
   }
 

--- a/app/components/rdf-input-fields/custom-field-wrapper.js
+++ b/app/components/rdf-input-fields/custom-field-wrapper.js
@@ -22,17 +22,17 @@ export default class RdfInputFieldsCustomFieldWrapperComponent extends Component
 
   get isFieldReadOnly() {
     return (
-      this.formState.isReadOnly &&
+      this.formState?.isReadOnly &&
       ![ADRES_CUSTOM_DISPLAY_TYPE].includes(this.args.field.displayType)
     );
   }
 
   get isFieldSelected() {
-    return this.formState.clickedField?.uri === this.args.field.uri.value;
+    return this.formState?.clickedField?.uri === this.args.field.uri.value;
   }
 
   get styleClassForMainContainer() {
-    if (!this.formState.canSelectField) {
+    if (!this.formState?.canSelectField) {
       return '';
     }
 
@@ -47,7 +47,7 @@ export default class RdfInputFieldsCustomFieldWrapperComponent extends Component
 
   @action
   passOnClickedField() {
-    if (!this.formState.canSelectField) {
+    if (!this.formState?.canSelectField) {
       return;
     }
 

--- a/app/components/rdf-input-fields/custom-field-wrapper.js
+++ b/app/components/rdf-input-fields/custom-field-wrapper.js
@@ -76,6 +76,7 @@ export default class RdfInputFieldsCustomFieldWrapperComponent extends Component
 
     if (result.ok) {
       this.formContext.onFormUpdate();
+      this.formContext.onFieldClicked(null);
     }
   });
 

--- a/app/components/rdf-input-fields/custom-field-wrapper.js
+++ b/app/components/rdf-input-fields/custom-field-wrapper.js
@@ -12,6 +12,7 @@ import { ADRES_CUSTOM_DISPLAY_TYPE } from 'frontend-lmb/utils/well-known-uris';
 
 export default class RdfInputFieldsCustomFieldWrapperComponent extends Component {
   @consume('form-context') formContext;
+  @consume('form-state') formState;
 
   @tracked showModal;
 
@@ -21,19 +22,17 @@ export default class RdfInputFieldsCustomFieldWrapperComponent extends Component
 
   get isFieldReadOnly() {
     return (
-      this.formContext.isReadOnly &&
+      this.formState.isReadOnly &&
       ![ADRES_CUSTOM_DISPLAY_TYPE].includes(this.args.field.displayType)
     );
   }
 
   get isFieldSelected() {
-    return (
-      this.formContext.clickedField?.uri.value === this.args.field.uri.value
-    );
+    return this.formState.clickedField?.uri.value === this.args.field.uri.value;
   }
 
   get styleClassForMainContainer() {
-    if (!this.formContext.canSelectField) {
+    if (!this.formState.canSelectField) {
       return '';
     }
 
@@ -48,7 +47,7 @@ export default class RdfInputFieldsCustomFieldWrapperComponent extends Component
 
   @action
   passOnClickedField() {
-    if (!this.formContext.canSelectField) {
+    if (!this.formState.canSelectField) {
       return;
     }
     this.formContext.onFieldClicked(this.args.field);

--- a/app/components/rdf-input-fields/custom-field-wrapper.js
+++ b/app/components/rdf-input-fields/custom-field-wrapper.js
@@ -28,7 +28,7 @@ export default class RdfInputFieldsCustomFieldWrapperComponent extends Component
   }
 
   get isFieldSelected() {
-    return this.formState.clickedField?.uri.value === this.args.field.uri.value;
+    return this.formState.clickedField?.uri === this.args.field.uri.value;
   }
 
   get styleClassForMainContainer() {
@@ -50,7 +50,12 @@ export default class RdfInputFieldsCustomFieldWrapperComponent extends Component
     if (!this.formState.canSelectField) {
       return;
     }
-    this.formContext.onFieldClicked(this.args.field);
+
+    let clickedField = null;
+    if (this.formState.clickedField?.uri !== this.args.field.uri.value) {
+      clickedField = this.args.field;
+    }
+    this.formContext.onFieldClicked(clickedField);
   }
 
   moveField = task(async (direction) => {

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -43,9 +43,8 @@ export default class CustomFormsInstancesDefinitionController extends Controller
   }
 
   @action
-  setSelectedField(fielduri) {
-    console.log({ fielduri });
-    this.selectedFieldUri = fielduri;
+  setSelectedField(fieldUri) {
+    this.selectedFieldUri = fieldUri;
   }
 
   @action
@@ -55,10 +54,11 @@ export default class CustomFormsInstancesDefinitionController extends Controller
   }
 
   @action
-  async updateFormContent() {
+  async updateFormContent(fieldUri) {
     this.isRefreshForm = true;
     await timeout(100);
     this.isRefreshForm = false;
+    this.setSelectedField(fieldUri);
   }
 
   @action

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -3,11 +3,15 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
+import { consume } from 'ember-provide-consume-context';
 import { timeout } from 'ember-concurrency';
 
 export default class CustomFormsInstancesDefinitionController extends Controller {
+  @consume('form-context') formContext;
+
   @tracked isEditFormModalOpen;
   @tracked isRefreshForm;
+  @tracked selectedFieldUri;
 
   @action
   updateFormName(event) {
@@ -36,6 +40,12 @@ export default class CustomFormsInstancesDefinitionController extends Controller
 
   get saveButtonDisabled() {
     return this.isOverMaxCharacters || this.formNameErrorMessage;
+  }
+
+  @action
+  setSelectedField(fielduri) {
+    console.log({ fielduri });
+    this.selectedFieldUri = fielduri;
   }
 
   @action

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -62,6 +62,15 @@ export default class CustomFormsInstancesDefinitionController extends Controller
   }
 
   @action
+  updateSelectedFieldData(fields) {
+    if (this.selectedField) {
+      this.selectedField = fields.filter(
+        (f) => f.uri === this.selectedField.uri
+      )[0];
+    }
+  }
+
+  @action
   cancelUpdateFormDetails() {
     this.model.form.rollbackAttributes();
     this.isEditFormModalOpen = false;

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -31,11 +31,11 @@ export default class CustomFormsInstancesDefinitionController extends Controller
   }
 
   get isOverMaxCharacters() {
-    return this.model.form.description?.length > 250;
+    return this.model.form.description?.length > 500;
   }
 
   get descriptionCharacters() {
-    return `Karakters: ${this.model.form.description?.length || 0}/250`;
+    return `Karakters: ${this.model.form.description?.length || 0}/500`;
   }
 
   get saveButtonDisabled() {

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -55,7 +55,6 @@ export default class CustomFormsInstancesDefinitionController extends Controller
 
   @action
   async updateFormContent(field) {
-    console.log('updatedformcontent', field);
     this.isRefreshForm = true;
     await timeout(100);
     this.setSelectedField(field);

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -3,8 +3,11 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
+import { timeout } from 'ember-concurrency';
+
 export default class CustomFormsInstancesDefinitionController extends Controller {
   @tracked isEditFormModalOpen;
+  @tracked isRefreshForm;
 
   @action
   updateFormName(event) {
@@ -39,6 +42,13 @@ export default class CustomFormsInstancesDefinitionController extends Controller
   async saveFormDetails() {
     await this.model.form.save();
     this.isEditFormModalOpen = false;
+  }
+
+  @action
+  async updateFormContent() {
+    this.isRefreshForm = true;
+    await timeout(100);
+    this.isRefreshForm = false;
   }
 
   @action

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -57,8 +57,8 @@ export default class CustomFormsInstancesDefinitionController extends Controller
   async updateFormContent(fieldUri) {
     this.isRefreshForm = true;
     await timeout(100);
-    this.isRefreshForm = false;
     this.setSelectedField(fieldUri);
+    this.isRefreshForm = false;
   }
 
   @action

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -11,7 +11,7 @@ export default class CustomFormsInstancesDefinitionController extends Controller
 
   @tracked isEditFormModalOpen;
   @tracked isRefreshForm;
-  @tracked selectedFieldUri;
+  @tracked selectedField;
 
   @action
   updateFormName(event) {
@@ -43,8 +43,8 @@ export default class CustomFormsInstancesDefinitionController extends Controller
   }
 
   @action
-  setSelectedField(fieldUri) {
-    this.selectedFieldUri = fieldUri;
+  setSelectedField(field) {
+    this.selectedField = field;
   }
 
   @action
@@ -54,10 +54,11 @@ export default class CustomFormsInstancesDefinitionController extends Controller
   }
 
   @action
-  async updateFormContent(fieldUri) {
+  async updateFormContent(field) {
+    console.log('updatedformcontent', field);
     this.isRefreshForm = true;
     await timeout(100);
-    this.setSelectedField(fieldUri);
+    this.setSelectedField(field);
     this.isRefreshForm = false;
   }
 

--- a/app/services/custom-forms.js
+++ b/app/services/custom-forms.js
@@ -86,6 +86,15 @@ export default class CustomFormsService extends Service {
           conceptScheme: conceptSchemeUri,
         }),
       });
+
+      return {
+        uri: fieldUri,
+        displayType: displayTypeUri,
+        label,
+        isRequired: !!isRequired,
+        showInSummary: !!isShownInSummary,
+        conceptScheme: conceptSchemeUri,
+      };
     } catch (error) {
       showErrorToast(
         this.toaster,

--- a/app/services/custom-forms.js
+++ b/app/services/custom-forms.js
@@ -1,5 +1,7 @@
 import Service from '@ember/service';
 
+import { service } from '@ember/service';
+
 import { timeout } from 'ember-concurrency';
 
 import {
@@ -8,8 +10,11 @@ import {
   RESOURCE_CACHE_TIMEOUT,
   STATUS_CODE,
 } from 'frontend-lmb/utils/constants';
+import { showErrorToast } from 'frontend-lmb/utils/toasts';
 
 export default class CustomFormsService extends Service {
+  @service toaster;
+
   async createEmptyDefinition(formName, description) {
     const response = await fetch(`${API.FORM_CONTENT_SERVICE}/definition/new`, {
       method: 'POST',
@@ -59,5 +64,34 @@ export default class CustomFormsService extends Service {
     }
     await form.destroyRecord();
     await timeout(RESOURCE_CACHE_TIMEOUT);
+  }
+
+  async updateCustomFormField(
+    formDefinitionId,
+    fieldUri,
+    { label, displayTypeUri, conceptSchemeUri, isRequired, isShownInSummary }
+  ) {
+    try {
+      await fetch(`/form-content/${formDefinitionId}/fields`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': JSON_API_TYPE,
+        },
+        body: JSON.stringify({
+          field: fieldUri,
+          displayType: displayTypeUri,
+          name: label,
+          isRequired: !!isRequired,
+          showInSummary: !!isShownInSummary,
+          conceptScheme: conceptSchemeUri,
+        }),
+      });
+    } catch (error) {
+      showErrorToast(
+        this.toaster,
+        'Er ging iets mis bij het opslaan van het veld.'
+      );
+      return;
+    }
   }
 }

--- a/app/services/custom-forms.js
+++ b/app/services/custom-forms.js
@@ -69,7 +69,14 @@ export default class CustomFormsService extends Service {
   async updateCustomFormField(
     formDefinitionId,
     fieldUri,
-    { label, displayTypeUri, conceptSchemeUri, isRequired, isShownInSummary }
+    {
+      label,
+      displayTypeUri,
+      conceptSchemeUri,
+      isRequired,
+      isShownInSummary,
+      formUri,
+    }
   ) {
     try {
       await fetch(`/form-content/${formDefinitionId}/fields`, {
@@ -94,6 +101,7 @@ export default class CustomFormsService extends Service {
         isRequired: !!isRequired,
         showInSummary: !!isShownInSummary,
         conceptScheme: conceptSchemeUri,
+        formUri,
       };
     } catch (error) {
       showErrorToast(

--- a/app/services/custom-forms.js
+++ b/app/services/custom-forms.js
@@ -103,4 +103,25 @@ export default class CustomFormsService extends Service {
       return;
     }
   }
+
+  async removeFormField(fieldUri, formUri) {
+    try {
+      await fetch(`/form-content/fields`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': JSON_API_TYPE,
+        },
+        body: JSON.stringify({
+          fieldUri,
+          formUri,
+        }),
+      });
+    } catch (error) {
+      showErrorToast(
+        this.toaster,
+        'Er ging iets mis bij het verwijderen van het veld.'
+      );
+      return;
+    }
+  }
 }

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -3,12 +3,10 @@
   display: flex;
   flex-direction: row;
   gap: 1rem;
-  height: 100%;
-  width: 100%;
   padding: 2rem;
 }
 
-@media (max-width: 730px) {
+@media (max-width: 750px) {
   .edit-form-defintion {
     flex-direction: column-reverse;
   }

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -34,5 +34,5 @@
 .custom-form-field--selected {
   border-radius: 2px;
   background-color: var(--au-blue-200);
-  border: 2px solid var(--au-blue-300);
+  outline: 2px solid var(--au-blue-300);
 }

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -1,9 +1,10 @@
 .edit-form-defintion {
   background-color: var(--au-blue-100);
   display: grid;
-  grid-template-columns: 3fr 1fr;
+  grid-template-columns: 2.5fr 1fr;
   height: 100%;
   width: 100%;
+  padding: 0 3rem;
 }
 
 .edit-form-defintion--form {
@@ -16,6 +17,13 @@
 
 .edit-form-defintion--edit-panel {
   padding: 2rem 1rem;
+}
+.edit-form-defintion--edit-panel-containter {
+  border: 2px solid var(--au-gray-200);
+  border-radius: 5px;
+  background-color: var(--au-white);
+  height: 100%;
+  width: 100%;
 }
 
 .edit-form-defintion .semantic-forms-instance .au-c-toolbar {

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -1,28 +1,34 @@
 .edit-form-defintion {
   background-color: var(--au-blue-100);
-  display: grid;
-  grid-template-columns: 2.5fr 1fr;
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
   height: 100%;
   width: 100%;
-  padding: 0 3rem;
+  padding: 2rem;
+}
+
+@media (max-width: 730px) {
+  .edit-form-defintion {
+    flex-direction: column-reverse;
+  }
 }
 
 .edit-form-defintion--form {
-  width: 70%;
+  min-width: 70vw;
   border: 2px solid var(--au-gray-200);
   border-radius: 5px;
   background-color: var(--au-white);
-  margin: 2rem auto;
 }
 
 .edit-form-defintion--edit-panel {
-  padding: 2rem 1rem;
+  width: 100%;
 }
+
 .edit-form-defintion--edit-panel-containter {
   border: 2px solid var(--au-gray-200);
   border-radius: 5px;
   background-color: var(--au-white);
-  height: 100%;
   width: 100%;
 }
 

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: row;
   gap: 1rem;
+  height: 100%;
   padding: 2rem;
 }
 

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -29,3 +29,10 @@
 .edit-form-defintion .semantic-forms-instance .au-c-toolbar {
   display: none;
 }
+
+.custom-form-field:hover,
+.custom-form-field--selected {
+  border-radius: 2px;
+  background-color: var(--au-blue-200);
+  border: 2px solid var(--au-blue-300);
+}

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -46,6 +46,7 @@
     {{/unless}}
   </div>
   <div class="edit-form-defintion--edit-panel">
+    <CustomForm::EditCustomField />
   </div>
 </div>
 

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -43,6 +43,7 @@
         @editFieldsInForm={{false}}
         @canSelectField={{true}}
         @onFieldSelected={{this.setSelectedField}}
+        @selectedField={{this.selectedField}}
       />
     {{/if}}
   </div>

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -44,17 +44,8 @@
         @canSelectField={{true}}
         @onFieldSelected={{this.setSelectedField}}
         @selectedField={{this.selectedField}}
-        @onFieldsSet={{this.updateSelectedFieldData}}
       />
-    {{/if}}
-  </div>
-  <div class="edit-form-defintion--edit-panel">
-    <CustomForm::EditCustomField
-      @formDefinitionId={{this.model.form.id}}
-      @onFieldUpdated={{this.updateFormContent}}
-      @isLoading={{this.isRefreshForm}}
-      @selectedField={{this.selectedField}}
-    />
+    </div>
   </div>
 </div>
 

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -46,7 +46,7 @@
     {{/unless}}
   </div>
   <div class="edit-form-defintion--edit-panel">
-    <CustomForm::EditCustomField />
+    <CustomForm::EditCustomField @formDefinitionId={{this.model.form.id}} />
   </div>
 </div>
 

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -42,7 +42,7 @@
       @customHistoryMessage={{true}}
     />
     {{#unless this.formInitialized}}
-      <AuLoader />
+      <AuLoader @hideMessage={{true}} />
     {{/unless}}
   </div>
   <div class="edit-form-defintion--edit-panel">

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -40,6 +40,7 @@
         @instanceId={{this.model.form.id}}
         @form={{this.model.form}}
         @customHistoryMessage={{true}}
+        @editFieldsInForm={{false}}
         @canSelectField={{true}}
         @onFieldSelected={{this.setSelectedField}}
       />

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -33,20 +33,22 @@
 </AuToolbar>
 <div class="edit-form-defintion">
   <div class="au-o-box edit-form-defintion--form">
-    <EditableForm
-      @instanceId={{this.model.form.id}}
-      @form={{this.model.form}}
-      @onCancel={{this.onCancel}}
-      @onSave={{this.onSave}}
-      @formInitialized={{fn (mut this.formInitialized) true}}
-      @customHistoryMessage={{true}}
-    />
-    {{#unless this.formInitialized}}
+    {{#if this.isRefreshForm}}
       <AuLoader @hideMessage={{true}} />
-    {{/unless}}
+    {{else}}
+      <EditableForm
+        @instanceId={{this.model.form.id}}
+        @form={{this.model.form}}
+        @customHistoryMessage={{true}}
+      />
+    {{/if}}
   </div>
   <div class="edit-form-defintion--edit-panel">
-    <CustomForm::EditCustomField @formDefinitionId={{this.model.form.id}} />
+    <CustomForm::EditCustomField
+      @formDefinitionId={{this.model.form.id}}
+      @onFieldUpdated={{this.updateFormContent}}
+      @isLoading={{this.isRefreshForm}}
+    />
   </div>
 </div>
 

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -1,48 +1,62 @@
 {{page-title "Bewerk formulier definitie"}}
-<AuToolbar
-  @size="large"
-  class="au-u-padding-bottom-none au-u-margin-bottom"
-  as |Group|
->
-  <Group>
-    <AuHeading @skin="2">{{this.model.form.name}}</AuHeading>
-  </Group>
-  <Group>
-    <AuButtonGroup>
-      <AuLink
-        @route="custom-forms.instances.index"
-        @model={{this.model.form.id}}
-        @skin="button-secondary"
-      >Annuleer</AuLink>
-      <AuLink
-        @route="custom-forms.instances.index"
-        @model={{this.model.form.id}}
-        @skin="button"
-      >Opslaan</AuLink>
-    </AuButtonGroup>
-  </Group>
-</AuToolbar>
-<AuToolbar
-  @size="large"
-  class="au-u-padding-bottom-none au-u-margin-bottom"
-  as |Group|
->
-  <Group>
-    <p>{{this.model.form.description}}</p>
-  </Group>
-</AuToolbar>
-<div class="edit-form-defintion">
-  <div class="au-o-box edit-form-defintion--form">
-    {{#if this.isRefreshForm}}
-      <AuLoader @hideMessage={{true}} />
-    {{else}}
-      <EditableForm
-        @instanceId={{this.model.form.id}}
-        @form={{this.model.form}}
-        @customHistoryMessage={{true}}
-        @editFieldsInForm={{false}}
-        @canSelectField={{true}}
-        @onFieldSelected={{this.setSelectedField}}
+<div class="au-c-body-container au-c-body-container--scroll">
+  <AuToolbar
+    @size="large"
+    class="au-u-padding-bottom-none au-u-margin-bottom"
+    as |Group|
+  >
+    <Group>
+      <AuHeading @skin="2">{{this.model.form.name}}
+        <AuButton
+          @skin="link-secondary"
+          @icon="pencil"
+          @hideText={{true}}
+          {{on "click" (fn (mut this.isEditFormModalOpen) true)}}
+        >
+          Pas aan
+        </AuButton></AuHeading>
+    </Group>
+    <Group>
+      <AuButtonGroup>
+        <AuLink
+          @route="custom-forms.instances.index"
+          @model={{this.model.form.id}}
+          @skin="button-secondary"
+        >Terug naar formulieren</AuLink>
+      </AuButtonGroup>
+    </Group>
+  </AuToolbar>
+  <AuToolbar
+    @size="large"
+    class="au-u-padding-bottom-none au-u-margin-bottom"
+    as |Group|
+  >
+    <Group>
+      <p>{{this.model.form.description}}</p>
+    </Group>
+  </AuToolbar>
+  <div class="edit-form-defintion">
+    <div class="au-o-box edit-form-defintion--form">
+      {{#if this.isRefreshForm}}
+        <AuLoader @hideMessage={{true}} />
+      {{else}}
+        <EditableForm
+          @instanceId={{this.model.form.id}}
+          @form={{this.model.form}}
+          @customHistoryMessage={{true}}
+          @editFieldsInForm={{false}}
+          @canSelectField={{true}}
+          @onFieldSelected={{this.setSelectedField}}
+          @selectedField={{this.selectedField}}
+          @onFieldsSet={{this.updateSelectedFieldData}}
+        />
+      {{/if}}
+    </div>
+    <div class="edit-form-defintion--edit-panel">
+      <CustomForm::EditCustomField
+        @formDefinitionId={{this.model.form.id}}
+        @onFieldUpdated={{this.updateFormContent}}
+        @isLoading={{this.isRefreshForm}}
         @selectedField={{this.selectedField}}
       />
     </div>

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -44,6 +44,7 @@
         @canSelectField={{true}}
         @onFieldSelected={{this.setSelectedField}}
         @selectedField={{this.selectedField}}
+        @onFieldsSet={{this.updateSelectedFieldData}}
       />
     {{/if}}
   </div>

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -50,7 +50,7 @@
       @formDefinitionId={{this.model.form.id}}
       @onFieldUpdated={{this.updateFormContent}}
       @isLoading={{this.isRefreshForm}}
-      @selectedFieldUri={{this.selectedFieldUri}}
+      @selectedField={{this.selectedField}}
     />
   </div>
 </div>

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -40,6 +40,7 @@
         @instanceId={{this.model.form.id}}
         @form={{this.model.form}}
         @customHistoryMessage={{true}}
+        @canSelectField={{true}}
         @onFieldSelected={{this.setSelectedField}}
       />
     {{/if}}

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -5,15 +5,7 @@
   as |Group|
 >
   <Group>
-    <AuHeading @skin="2">{{this.model.form.name}}
-      <AuButton
-        @skin="link-secondary"
-        @icon="pencil"
-        @hideText={{true}}
-        {{on "click" (fn (mut this.isEditFormModalOpen) true)}}
-      >
-        Pas aan
-      </AuButton></AuHeading>
+    <AuHeading @skin="2">{{this.model.form.name}}</AuHeading>
   </Group>
   <Group>
     <AuButtonGroup>
@@ -21,7 +13,12 @@
         @route="custom-forms.instances.index"
         @model={{this.model.form.id}}
         @skin="button-secondary"
-      >Terug naar formulieren</AuLink>
+      >Annuleer</AuLink>
+      <AuLink
+        @route="custom-forms.instances.index"
+        @model={{this.model.form.id}}
+        @skin="button"
+      >Opslaan</AuLink>
     </AuButtonGroup>
   </Group>
 </AuToolbar>
@@ -39,6 +36,8 @@
     <EditableForm
       @instanceId={{this.model.form.id}}
       @form={{this.model.form}}
+      @onCancel={{this.onCancel}}
+      @onSave={{this.onSave}}
       @formInitialized={{fn (mut this.formInitialized) true}}
       @customHistoryMessage={{true}}
     />

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -40,6 +40,7 @@
         @instanceId={{this.model.form.id}}
         @form={{this.model.form}}
         @customHistoryMessage={{true}}
+        @onFieldSelected={{this.setSelectedField}}
       />
     {{/if}}
   </div>
@@ -48,6 +49,7 @@
       @formDefinitionId={{this.model.form.id}}
       @onFieldUpdated={{this.updateFormContent}}
       @isLoading={{this.isRefreshForm}}
+      @selectedFieldUri={{this.selectedFieldUri}}
     />
   </div>
 </div>

--- a/app/templates/custom-forms/instances/instance.hbs
+++ b/app/templates/custom-forms/instances/instance.hbs
@@ -2,6 +2,7 @@
 
 <div class="au-o-box">
   <EditableForm
+    @toReceiveUserInput={{true}}
     @instanceId={{this.model.instanceId}}
     @form={{this.model.form}}
     @onCancel={{this.onCancel}}

--- a/app/templates/custom-forms/instances/instance.hbs
+++ b/app/templates/custom-forms/instances/instance.hbs
@@ -1,6 +1,5 @@
 {{page-title "Instance"}}
-
-<div class="au-o-box">
+<div class="au-o-box au-c-body-container au-c-body-container--scroll">
   <EditableForm
     @toReceiveUserInput={{true}}
     @instanceId={{this.model.instanceId}}

--- a/tests/integration/components/custom-form/edit-custom-field-test.js
+++ b/tests/integration/components/custom-form/edit-custom-field-test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | custom-form/edit-custom-field',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.set('myAction', function(val) { ... });
+
+      await render(hbs`<CustomForm::EditCustomField />`);
+
+      assert.dom().hasText('');
+
+      // Template block usage:
+      await render(hbs`<CustomForm::EditCustomField>
+  template block text
+</CustomForm::EditCustomField>`);
+
+      assert.dom().hasText('template block text');
+    });
+  }
+);


### PR DESCRIPTION
## Description

Finish up the page where users can edit the form definition of their own forms.

## How to test

1. Go edit a schepen extension form
2. Go and edit the form definition of a form of "eigen gegevens"
3. Create an instance for the form and fill in the data

## Attachments
![image](https://github.com/user-attachments/assets/e45d1636-3a42-4ced-9ad2-700acfb0d19b)


## Links to other PR's

- https://github.com/lblod/form-content-service/pull/80
