### PR TITLE
split person detail form

### DIFF
--- a/app/components/person/card.hbs
+++ b/app/components/person/card.hbs
@@ -30,10 +30,6 @@
     </div>
   </div>
   <div class="au-o-grid__item au-u-1-2 au-u-margin-bottom-small">
-    <div class="au-c-description-label">Roepnaam</div>
-    <div class="au-c-description-value">{{@persoon.alternatieveNaam}}</div>
-  </div>
-  <div class="au-o-grid__item au-u-1-2 au-u-margin-bottom-small">
     <p class="au-c-description-label">Geslacht</p>
     <p class="au-c-description-value">{{@persoon.geslacht.label}}</p>
   </div>

--- a/app/components/persoon/extra-info-card.hbs
+++ b/app/components/persoon/extra-info-card.hbs
@@ -1,0 +1,62 @@
+<AuToolbar @size="large" class="au-u-padding-none au-u-bottom-none" as |Group|>
+
+  <Group>
+    <AuHeading @skin="4">
+      Bijkomende informatie
+    </AuHeading>
+  </Group>
+  <Group>
+    <Shared::Tooltip
+      @showTooltip={{this.disabled}}
+      @tooltipText={{this.toolTipText}}
+      @alignment="right"
+    >
+      <AuButton
+        {{on "click" this.toggleModal}}
+        @disabled={{this.disabled}}
+      >Bewerk</AuButton>
+    </Shared::Tooltip>
+  </Group>
+</AuToolbar>
+
+<div class="au-o-box au-u-background-gray-100">
+  <div class="au-o-grid au-o-grid--small">
+    <div class="au-o-box au-u-padding-tiny person-extra-info">
+      <EditableForm
+        @isReadOnly={{true}}
+        @instanceId={{@persoon.id}}
+        @form={{@form}}
+        @onCancel={{this.noop}}
+        @onSave={{this.noop}}
+        @formInitialized={{fn (mut this.formInitialized) true}}
+        @customHistoryMessage={{true}}
+      />
+      {{#unless this.formInitialized}}
+        <Skeleton::Forms::MandatarisExtraInfo />
+      {{/unless}}
+      {{yield}}
+    </div>
+  </div>
+
+</div>
+
+<AuModal
+  @title="Bewerk bijkomende info persoon"
+  @modalOpen={{this.isModalActive}}
+  @closable={{true}}
+  @closeModal={{this.toggleModal}}
+>
+  <div class="au-o-box">
+    <EditableForm
+      @instanceId={{@persoon.id}}
+      @form={{@form}}
+      @onCancel={{this.toggleModal}}
+      @onSave={{this.onSave}}
+      @formInitialized={{fn (mut this.formInitialized) true}}
+      @customHistoryMessage={{true}}
+    />
+    {{#unless this.formInitialized}}
+      <Skeleton::Forms::MandatarisExtraInfo />
+    {{/unless}}
+  </div>
+</AuModal>

--- a/app/components/persoon/extra-info-card.hbs
+++ b/app/components/persoon/extra-info-card.hbs
@@ -30,6 +30,7 @@
         @onSave={{this.noop}}
         @formInitialized={{fn (mut this.formInitialized) true}}
         @customHistoryMessage={{true}}
+        @isForFormExtension={{true}}
       />
       {{#unless this.formInitialized}}
         <Skeleton::Forms::MandatarisExtraInfo />
@@ -54,6 +55,7 @@
       @onSave={{this.onSave}}
       @formInitialized={{fn (mut this.formInitialized) true}}
       @customHistoryMessage={{true}}
+      @isForFormExtension={{true}}
     />
     {{#unless this.formInitialized}}
       <Skeleton::Forms::MandatarisExtraInfo />

--- a/app/components/persoon/extra-info-card.js
+++ b/app/components/persoon/extra-info-card.js
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+
+export default class PersoonExtraInfoCard extends Component {
+  @service router;
+
+  @tracked formInitialized = false;
+  @tracked isModalActive = false;
+
+  @action
+  noop() {
+    return;
+  }
+  @action toggleModal() {
+    this.isModalActive = !this.isModalActive;
+  }
+  @action onSave() {
+    this.isModalActive = false;
+    this.router.refresh();
+  }
+}

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -2,7 +2,7 @@
   <div class={{this.styleClassForMainContainer}}>
     {{! template-lint-disable no-invalid-interactive }}
     <div
-      class="au-u-flex au-u-flex--row au-u-padding-small"
+      class="au-u-flex au-u-flex--row au-u-padding-small au-u-padding-left-none"
       {{on "click" this.passOnClickedField}}
     >
       <div class="flex-grow">

--- a/app/routes/mandatarissen/persoon/index.js
+++ b/app/routes/mandatarissen/persoon/index.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 
 import { service } from '@ember/service';
+import { PERSON_EXTRA_INFO_FORM_ID } from 'frontend-lmb/utils/well-known-ids';
 
 export default class MandatarissenPersoonIndexRoute extends Route {
   @service store;
@@ -9,6 +10,12 @@ export default class MandatarissenPersoonIndexRoute extends Route {
 
   async model() {
     const parentModel = await this.modelFor('mandatarissen.persoon');
+    const personExtraInfoForm =
+      await this.semanticFormRepository.getFormDefinition(
+        PERSON_EXTRA_INFO_FORM_ID,
+        true
+      );
+
     const usages = await this.customForms.getInstanceUsage(
       parentModel.persoon.uri
     );
@@ -22,6 +29,7 @@ export default class MandatarissenPersoonIndexRoute extends Route {
     );
     return {
       persoon: parentModel.persoon,
+      personExtraInfoForm,
       usages: usages,
     };
   }

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -439,7 +439,8 @@ main .au-c-main-container__content .au-u-wide-on-print {
     overflow: visible;
   }
 }
-.read-only-form {
+.read-only-form,
+.person-extra-info {
   .au-u-flex.au-u-flex--row.au-u-padding-small {
     padding: 0 !important;
   }

--- a/app/templates/mandatarissen/persoon/index.hbs
+++ b/app/templates/mandatarissen/persoon/index.hbs
@@ -18,6 +18,12 @@
   <div class="au-o-box">
     <Person::Card @persoon={{@model.persoon}} />
   </div>
+  <div class="au-o-box">
+    <Persoon::ExtraInfoCard
+      @persoon={{@model.persoon}}
+      @form={{@model.personExtraInfoForm}}
+    />
+  </div>
 
   {{#if this.canShowUsage}}
     <div class="au-u-box au-u-padding">
@@ -50,4 +56,5 @@
         {{/each}}
       {{/if}}
     </div>
-  {{/if}}</div>
+  {{/if}}
+</div>

--- a/app/utils/well-known-ids.js
+++ b/app/utils/well-known-ids.js
@@ -5,6 +5,7 @@ export const FRACTIE_FORM_ID = 'fractie';
 export const MANDAAT_FORM_ID = 'mandaat';
 export const MANDATARIS_EDIT_FORM_ID = 'mandataris-edit';
 export const MANDATARIS_EXTRA_INFO_FORM_ID = 'mandataris-extra-info';
+export const PERSON_EXTRA_INFO_FORM_ID = 'persoon-extra-info';
 export const MANDATARIS_NEW_FORM_ID = 'mandataris-new';
 export const MANDATARIS_EXTENDED_FORM = 'mandataris-ext';
 export const CONTACTINFO_FORM_ID = 'contactinfo';


### PR DESCRIPTION
## Description

split off foaf:name into separate, editable form that can then be extended for a person as 'extra information'
![image](https://github.com/user-attachments/assets/6484b76e-f797-4957-ba41-6c3d9a14d35d)

## How to test

Go to a person detail page and edit the foaf name, extend the form with your own fields
## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/426