### PR TITLE
validatie improvements after final check

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 const OFFENDING_STATUS_CODES = [401, 403];
 
 export default class ApplicationAdapter extends JSONAPIAdapter {
+  @service validatie;
   constructor() {
     super(...arguments);
     this.monkeyPatchFetch();
@@ -12,10 +13,18 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
   monkeyPatchFetch() {
     const originalFetch = window.fetch;
     const router = this.router;
+    const validatie = this.validatie;
     window.fetch = async function () {
       const response = await originalFetch.apply(this, arguments);
       if (OFFENDING_STATUS_CODES.indexOf(response.status) > -1) {
         router.transitionTo('session-expired');
+      }
+      if (
+        arguments[1] &&
+        arguments[1].method != 'GET' &&
+        arguments[0].indexOf('validation-report-api/reports/generate') < 0
+      ) {
+        validatie.queueValidatie.perform();
       }
       return response;
     };

--- a/app/components/refresh-validations-button.js
+++ b/app/components/refresh-validations-button.js
@@ -7,7 +7,6 @@ import moment from 'moment';
 
 export default class RefreshValidationsButton extends Component {
   @service validatie;
-  @service currentSession;
   @service toaster;
   @service router;
 
@@ -40,7 +39,6 @@ export default class RefreshValidationsButton extends Component {
 
   @action
   async refresh() {
-    const bestuurseenheid = this.currentSession.group;
-    this.validatie.generateReport.perform(bestuurseenheid);
+    this.validatie.generateReport.perform();
   }
 }

--- a/app/components/shared/main-menu.hbs
+++ b/app/components/shared/main-menu.hbs
@@ -42,9 +42,32 @@
       {{/if}}
       {{#if (is-feature-enabled "shacl-report")}}
         <li class="au-c-list-navigation__item">
+
           <AuNavigationLink @route="report">
-            <AuIcon @icon={{this.validationIcon}} @alignment="left" />
-            {{this.validationText}}
+            <div>
+              {{#if (gt this.validationCount 0)}}
+                <AuPill
+                  @skin="warning"
+                  @size="small"
+                  @icon="alert-triangle"
+                  class="au-u-margin-bottom-tiny"
+                >
+                  {{this.validationCount}}
+                  Validatiefouten
+                </AuPill>
+
+              {{/if}}
+              <div class="au-u-flex">
+                <AuIcon
+                  @icon={{this.validationIcon}}
+                  @alignment="left"
+                  class="au-u-margin-top-tiny"
+                />
+                <span>
+                  Validatierapport
+                </span>
+              </div>
+            </div>
           </AuNavigationLink>
         </li>
       {{/if}}

--- a/app/components/shared/main-menu.js
+++ b/app/components/shared/main-menu.js
@@ -6,10 +6,8 @@ export default class SharedMainMenuComponent extends Component {
   @service currentSession;
   @service validatie;
 
-  get validationText() {
-    return this.validatie.latestValidationResults?.length > 0
-      ? `${this.validatie.latestValidationResults?.length} validatiefouten`
-      : 'Geen validatiefouten';
+  get validationCount() {
+    return this.validatie.latestValidationResults?.length || 0;
   }
 
   get validationIcon() {

--- a/app/components/validatie-table.js
+++ b/app/components/validatie-table.js
@@ -43,6 +43,9 @@ export default class ValidatieTable extends Component {
 
 function getOwnValidationErrors() {
   return trackedFunction(async () => {
-    return this.validatie.getIssuesForInstance(this.instance);
+    // entangle this property so the function reloads when it changes\
+    const _report = this.validatie.latestValidationReport;
+    // pass it along so it doesn't get optimized out, but the function ignores it
+    return this.validatie.getIssuesForInstance(this.instance, _report);
   });
 }

--- a/app/components/validations/overview-callout.hbs
+++ b/app/components/validations/overview-callout.hbs
@@ -1,36 +1,31 @@
-{{#if this.show}}
-  <AuAlert @skin="warning" @icon="alert-triangle" @size="small">
-    <div class="au-u-flex au-u-flex--between">
-      <AuHeading
-        @skin="5"
-        @level="2"
-        class="au-u-margin-bottom-tiny"
-      >{{this.validationErrorCount}}
-        validatiefout{{if (eq this.validationErrorCount 1) "" "en"}}
-        gevonden</AuHeading>
-      <RefreshValidationsButton @noMessage={{true}} @size="small" />
-    </div>
-    <div class="au-u-flex au-u-flex--start au-u-flex--spaced-tiny">
-      <p>Validatiefouten zijn mogelijke inconsistenties die we hebben gevonden
-        in de ingevulde gegevens. Deze validaties worden meerdere keren per week
-        uitgevoerd, maar je kan ze ook handmatig starten, bijvoorbeeld na een
-        rechtzetting.
-        <AuLink @route="report">Bekijk alle fouten en los ze op.</AuLink>
-      </p>
+<div class="au-u-box au-u-padding">
+  <div class="au-u-flex au-u-flex--between au-u-margin-bottom-small">
+    <AuHeading
+      @skin="5"
+      @level="2"
+      class="au-u-margin-bottom-tiny au-u-margin-bottom-none"
+    >{{this.validationErrorCount}}
+      validatiefout{{if (eq this.validationErrorCount 1) "" "en"}}
+      gevonden</AuHeading>
+  </div>
+  <div class="au-u-flex au-u-flex--start au-u-flex--spaced-tiny">
+    <p>Validatiefouten zijn mogelijke inconsistenties die we hebben gevonden in
+      de ingevulde gegevens. Deze validaties worden kort na elke aanpassing
+      uitgevoerd, maar je kan ze ook handmatig starten.
+    </p>
 
-    </div>
-    <div class="au-u-flex au-u-flex--start au-u-flex--spaced-tiny">
+  </div>
+  <div class="au-u-flex au-u-flex--start au-u-flex--spaced-tiny">
 
-      <p class="au-u-flex au-u-flex-self-end au-u-padding-top-small">Meer weten
-        over validatie fouten?</p>
-      <AuLinkExternal
-        class="au-u-flex au-u-flex-self-end"
-        href="https://abb-vlaanderen.gitbook.io/handleiding-lokaal-mandatenbeheer"
-      >
-        Bekijk de handleiding
-      </AuLinkExternal>
-    </div>
-  </AuAlert>
+    <p class="au-u-flex au-u-flex-self-end au-u-padding-top-small">Meer weten
+      over validatie fouten?</p>
+    <AuLinkExternal
+      class="au-u-flex au-u-flex-self-end"
+      href="https://abb-vlaanderen.gitbook.io/handleiding-lokaal-mandatenbeheer"
+    >
+      Bekijk de handleiding
+    </AuLinkExternal>
+  </div>
 
   {{yield}}
-{{/if}}
+</div>

--- a/app/components/validations/overview-callout.js
+++ b/app/components/validations/overview-callout.js
@@ -17,10 +17,6 @@ export default class ValidationsOverviewCallout extends Component {
   get hasValidationErrors() {
     return this.validationErrorCount > 0;
   }
-
-  get show() {
-    return this.features.isEnabled('shacl-report') && this.hasValidationErrors;
-  }
 }
 
 function getValidationResults() {

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -17,6 +17,13 @@ export default class ApplicationController extends Controller {
     return this.router.currentRouteName === 'index';
   }
 
+  get showSidebar() {
+    return (
+      this.router.currentRouteName === 'index' ||
+      this.router.currentRouteName === 'report'
+    );
+  }
+
   get notificationCount() {
     return this.systemNotifications.totalUnreadNotifications;
   }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -76,7 +76,7 @@
   </AuMainHeader>
   <Shared::NavigationBar />
   <AuMainContainer as |main|>
-    {{#if this.isIndex}}
+    {{#if this.showSidebar}}
       <main.sidebar>
         <div class="au-c-sidebar">
           <div class="au-c-sidebar__content">

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -16,7 +16,6 @@
     <AuHeading @level="2" @skin="3" class="au-u-margin-bottom">Beschikbare
       modules</AuHeading>
 
-    <Validations::OverviewCallout />
     <AdminOnlyModules />
     {{#if this.showRegularModules}}
       <ul class="au-o-grid au-o-grid--small">

--- a/app/templates/report.hbs
+++ b/app/templates/report.hbs
@@ -3,16 +3,15 @@
 <AuMainContainer as |main|>
   <main.content>
     <AuBodyContainer id="content" class="au-c-body-container--scroll">
-      <AuToolbar @size="large" as |Group|>
-        <Group>
+      <AuToolbar @size="large" class="au-u-padding-bottom-none" as |Group|>
+        <Group class="au-u-flex au-u-flex--between au-u-1-1">
           <AuHeading @skin="2">
             Validatierapport
           </AuHeading>
-        </Group>
-        <Group>
-          <RefreshValidationsButton />
+          <RefreshValidationsButton @noMessage={{true}} @size="small" />
         </Group>
       </AuToolbar>
+      <Validations::OverviewCallout />
       <div class="au-u-padding">
         {{#if this.isEmptyResult}}
           <AuAlert @skin="success" @icon="check">


### PR DESCRIPTION
## Description

- no shouty banner on homescreen for validaties, use tag on top of menu
- add sidebar to validaties screen
- auto trigger validaties 20s after any put/post/patch except one that triggers validaties
- add info on validatie resultaten page
## How to test

- go to a municipality (e.g. gent)
- remove a replacement for a mandataris
- wait 25 seconds
- see that a validation error is now found and shown
- add the replacement again
- wait 25 seconds
- the validation error is now gone again
- you can do the same and trigger manual validations while waiting, you should see the auto validation being queued after yours have finished