### PR TITLE
LMB-1515 | Make the forms more user friendly

### DIFF
--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -115,7 +115,7 @@
       </AuFormRow>
       {{#if this.isDeleteWarningShown}}
         <div
-          class="au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--spaced-tiny warning-panel au-u-margin-top"
+          class="au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--spaced-tiny warning-panel"
         >
           <AuBadge @icon="alert-triangle" @skin="error" @size="small" />
           <span>Dit veld zal verwijderd worden voor

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -92,27 +92,29 @@
           </Shared::Tooltip>
         </AuToggleSwitch>
       </AuFormRow>
-      <AuFormRow>
-        <AuToggleSwitch
-          @disabled={{this.isShowInSummaryToggleDisabled}}
-          @checked={{this.isShownInSummary}}
-          @onChange={{this.toggleShowInSummary}}
-        >Toon in samenvatting
-          <Shared::Tooltip
-            @showTooltip={{true}}
-            @alignment="center"
-            @tooltipText="Dit veld zal getoond worden in de samenvatting van een item, bijvoorbeeld bij het tonen van een lijst van items of bij een verwijzing naar een item."
-          >
-            <AuButton
-              @skin="naked"
-              @icon="circle-question"
-              @hideText={{true}}
-              @disabled={{true}}
-              class="au-u-padding-bottom-small au-u-padding-left-none"
-            />
-          </Shared::Tooltip>
-        </AuToggleSwitch>
-      </AuFormRow>
+      {{#unless @canShowInSummaryButton}}
+        <AuFormRow>
+          <AuToggleSwitch
+            @disabled={{this.isShowInSummaryToggleDisabled}}
+            @checked={{this.isShownInSummary}}
+            @onChange={{this.toggleShowInSummary}}
+          >Toon in samenvatting
+            <Shared::Tooltip
+              @showTooltip={{true}}
+              @alignment="center"
+              @tooltipText="Dit veld zal getoond worden in de samenvatting van een item, bijvoorbeeld bij het tonen van een lijst van items of bij een verwijzing naar een item."
+            >
+              <AuButton
+                @skin="naked"
+                @icon="circle-question"
+                @hideText={{true}}
+                @disabled={{true}}
+                class="au-u-padding-bottom-small au-u-padding-left-none"
+              />
+            </Shared::Tooltip>
+          </AuToggleSwitch>
+        </AuFormRow>
+      {{/unless}}
       {{#if this.isDeleteWarningShown}}
         <div
           class="au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--spaced-tiny warning-panel"

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -94,7 +94,7 @@
       </AuFormRow>
       <AuFormRow>
         <AuToggleSwitch
-          @disabled={{not this.selectedField}}
+          @disabled={{this.isShowInSummaryToggleDisabled}}
           @checked={{this.isShownInSummary}}
           @onChange={{this.toggleShowInSummary}}
         >Toon in samenvatting

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -53,12 +53,26 @@ export default class CustomFormEditCustomField extends Component {
   get isShowInSummaryToggleDisabled() {
     return (
       !this.selectedField ||
-      this.selectedField.displayType === LINK_TO_FORM_CUSTOM_DISPLAY_TYPE
+      this.selectedField.displayType === LINK_TO_FORM_CUSTOM_DISPLAY_TYPE ||
+      this.displayType?.isLinkToForm
     );
   }
 
+  get isLinkFormTypeSelected() {
+    if (!this.displayType?.isLinkToForm) {
+      return true;
+    }
+
+    return this.linkedFormTypeUri;
+  }
+
   get canSaveChanges() {
-    return this.isChanged && this.isValidLabel && this.displayType;
+    return (
+      this.isChanged &&
+      this.isValidLabel &&
+      this.displayType &&
+      this.isLinkFormTypeSelected
+    );
   }
 
   get isChanged() {
@@ -127,6 +141,11 @@ export default class CustomFormEditCustomField extends Component {
   @action
   async saveFieldChanges() {
     this.isSaving = true;
+
+    if (this.displayType?.isLinkToForm) {
+      this.isShownInSummary = false;
+    }
+
     const updatedField = await this.customForms.updateCustomFormField(
       this.args.formDefinitionId,
       this.selectedField.uri,

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -7,6 +7,8 @@ import { tracked, cached } from '@glimmer/tracking';
 import { trackedFunction } from 'reactiveweb/function';
 import { use } from 'ember-resources';
 
+import { LINK_TO_FORM_CUSTOM_DISPLAY_TYPE } from 'frontend-lmb/utils/well-known-uris';
+
 export default class CustomFormEditCustomField extends Component {
   @use(setSelectedField) setSelectedField;
   @use(getDisplayTypes) getDisplayTypes;
@@ -46,6 +48,13 @@ export default class CustomFormEditCustomField extends Component {
 
   get isValidLabel() {
     return this.label?.trim() !== '';
+  }
+
+  get isShowInSummaryToggleDisabled() {
+    return (
+      !this.selectedField ||
+      this.selectedField.displayType === LINK_TO_FORM_CUSTOM_DISPLAY_TYPE
+    );
   }
 
   get canSaveChanges() {

--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -1,10 +1,14 @@
 {{#unless this.loading}}
-  {{#if this.formState.canEditFormDefinition}}
+  {{#if (and this.editableFormsEnabled this.formState.canEditFormDefinition)}}
     <div class="au-u-flex au-u-flex--end">
       <AuLink
         @model={{@form.id}}
         @route="custom-forms.instances.definition"
-        @query={{hash fullScreenEdit=true isFormExtension=@isFormExtension instanceId=@instanceId}}
+        @query={{hash
+          fullScreenEdit=true
+          isFormExtension=@isFormExtension
+          instanceId=@instanceId
+        }}
         @icon="pencil"
         class=""
       >

--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -13,15 +13,17 @@
   >
     {{#if this.editableFormsEnabled}}
       {{#if this.formState.isAddFieldShownInForm}}
-        <AuButton
-          @skin="secondary"
-          @width="block"
-          @icon="plus"
-          {{on "click" (fn (mut this.showEditModal) true)}}
-          class="au-u-margin-bottom au-u-margin-top"
-        >
-          Voeg een veld toe
-        </AuButton>
+        <div class="add-custom-field">
+          <AuButton
+            @skin="secondary"
+            @width="block"
+            @icon="plus"
+            {{on "click" (fn (mut this.showEditModal) true)}}
+            class="au-u-margin-bottom au-u-margin-top"
+          >
+            Voeg een veld toe
+          </AuButton>
+        </div>
       {{/if}}
 
       {{yield}}

--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -4,7 +4,7 @@
       <AuLink
         @model={{@form.id}}
         @route="custom-forms.instances.definition"
-        @query={{hash fullScreenEdit=true}}
+        @query={{hash fullScreenEdit=true isFormExtension=@isFormExtension instanceId=@instanceId}}
         @icon="pencil"
         class=""
       >

--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -34,7 +34,6 @@
         @onCloseModal={{this.formContext.onFormUpdate}}
         @form={{this.formContext.formDefinition}}
         @field={{@field}}
-        @isForFormExtension={{this.formContext.isForFormExtension}}
       />
     {{/if}}
     {{yield}}

--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -1,4 +1,17 @@
 {{#unless this.loading}}
+  {{#if this.formState.canEditFormDefinition}}
+    <div class="au-u-flex au-u-flex--end">
+      <AuLink
+        @model={{@form.id}}
+        @route="custom-forms.instances.definition"
+        @query={{hash fullScreenEdit=true}}
+        @icon="pencil"
+        class=""
+      >
+        Bewerk formulier definitie
+      </AuLink>
+    </div>
+  {{/if}}
   <SemanticForms::Instance
     @show={{@isReadOnly}}
     @instanceId={{@instanceId}}
@@ -12,7 +25,8 @@
     @saveTitle={{@saveTitle}}
   >
     {{#if this.editableFormsEnabled}}
-      {{#if this.formState.isAddFieldShownInForm}}
+      {{#if this.formState.isEditFormDefinitionForm}}
+        {{! TODO this would be handy if it was in the <CustomForm::EditCustomField> component }}
         <div class="add-custom-field">
           <AuButton
             @skin="secondary"

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -8,12 +8,11 @@ import { provide } from 'ember-provide-consume-context';
 import { trackedFunction } from 'reactiveweb/function';
 import { use } from 'ember-resources';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
-import { NamedNode, Literal } from 'rdflib';
 
 import { API } from 'frontend-lmb/utils/constants';
 import { showErrorToast } from 'frontend-lmb/utils/toasts';
-import { EXT } from 'frontend-lmb/rdf/namespaces';
 import { SOURCE_GRAPH } from 'frontend-lmb/utils/constants';
+import { isCustomForm } from 'frontend-lmb/utils/form-properties';
 
 export default class EditableFormComponent extends Component {
   @use(getFieldsForForm) getFieldsForForm;
@@ -98,16 +97,7 @@ function getFieldsForForm() {
 
       const forkingStore = new ForkingStore();
       forkingStore.parse(this.currentForm.formTtl, SOURCE_GRAPH, 'text/turtle');
-      const isCustomForm = forkingStore.any(
-        null,
-        EXT('isCustomForm'),
-        new Literal(
-          'true',
-          null,
-          new NamedNode('http://www.w3.org/2001/XMLSchema#boolean')
-        )
-      );
-      if (!isCustomForm) {
+      if (!isCustomForm(forkingStore)) {
         return [];
       }
 

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -24,14 +24,10 @@ export default class EditableFormComponent extends Component {
   @service features;
 
   @tracked showEditModal;
-  @tracked clickedField;
 
   constructor() {
     super(...arguments);
     this.updateForm();
-    if (this.args.selectedField) {
-      this.clickedField = this.args.selectedField;
-    }
   }
 
   async updateForm() {
@@ -52,17 +48,18 @@ export default class EditableFormComponent extends Component {
     return this.getFieldsForForm?.value || [];
   }
 
+  get clickedField() {
+    return this.args.selectedField;
+  }
+
   @action
   async setClickedField(fieldModel) {
-    this.clickedField = fieldModel;
+    let field = fieldModel;
     if (this.args.onFieldSelected && fieldModel) {
       await this.getFieldsForForm.retry();
-      const field = this.fields.filter(
-        (f) => f.uri === fieldModel.uri?.value
-      )[0];
-      this.clickedField = field;
+      field = this.fields.filter((f) => f.uri === fieldModel.uri?.value)[0];
     }
-    this.args.onFieldSelected(this.clickedField);
+    this.args.onFieldSelected(field);
   }
 
   get editableFormsEnabled() {

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -95,12 +95,12 @@ function getFieldsForForm() {
         return [];
       }
 
-      const forkingStore = new ForkingStore();
-      forkingStore.parse(this.currentForm.formTtl, SOURCE_GRAPH, 'text/turtle');
-      const isCustomForm = forkingStore.any(null, EXT('isCustomForm'), true);
-      if (!isCustomForm) {
-        return [];
-      }
+      // const forkingStore = new ForkingStore();
+      // forkingStore.parse(this.currentForm.formTtl, SOURCE_GRAPH, 'text/turtle');
+      // const isCustomForm = forkingStore.any(null, EXT('isCustomForm'), true);
+      // if (!isCustomForm) {
+      //   return [];
+      // }
 
       const response = await fetch(
         `${API.FORM_CONTENT_SERVICE}/custom-form/${this.currentForm.id}/fields`

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -69,6 +69,8 @@ export default class EditableFormComponent extends Component {
   @provide('form-state')
   get formState() {
     return {
+      isEditFormDefinitionForm: !!this.args.isEditFormDefinitionForm,
+      canEditFormDefinition: !!this.args.canEditFormDefinition,
       canSelectField: !!this.args.canSelectField,
       clickedField: this.clickedField,
       isReadOnly: this.args.isReadOnly,

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -7,12 +7,13 @@ import { service } from '@ember/service';
 import { provide } from 'ember-provide-consume-context';
 import { trackedFunction } from 'reactiveweb/function';
 import { use } from 'ember-resources';
+import { ForkingStore } from '@lblod/ember-submission-form-fields';
+import { NamedNode, Literal } from 'rdflib';
 
 import { API } from 'frontend-lmb/utils/constants';
 import { showErrorToast } from 'frontend-lmb/utils/toasts';
 import { EXT } from 'frontend-lmb/rdf/namespaces';
 import { SOURCE_GRAPH } from 'frontend-lmb/utils/constants';
-import { ForkingStore } from '@lblod/ember-submission-form-fields';
 
 export default class EditableFormComponent extends Component {
   @use(getFieldsForForm) getFieldsForForm;
@@ -95,12 +96,20 @@ function getFieldsForForm() {
         return [];
       }
 
-      // const forkingStore = new ForkingStore();
-      // forkingStore.parse(this.currentForm.formTtl, SOURCE_GRAPH, 'text/turtle');
-      // const isCustomForm = forkingStore.any(null, EXT('isCustomForm'), true);
-      // if (!isCustomForm) {
-      //   return [];
-      // }
+      const forkingStore = new ForkingStore();
+      forkingStore.parse(this.currentForm.formTtl, SOURCE_GRAPH, 'text/turtle');
+      const isCustomForm = forkingStore.any(
+        null,
+        EXT('isCustomForm'),
+        new Literal(
+          'true',
+          null,
+          new NamedNode('http://www.w3.org/2001/XMLSchema#boolean')
+        )
+      );
+      if (!isCustomForm) {
+        return [];
+      }
 
       const response = await fetch(
         `${API.FORM_CONTENT_SERVICE}/custom-form/${this.currentForm.id}/fields`

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -68,21 +68,10 @@ export default class EditableFormComponent extends Component {
 
   @provide('form-state')
   get formState() {
-    const canEditFieldsInlineInForm =
-      this.args.editFieldsInForm == undefined
-        ? true
-        : !!this.args.editFieldsInForm;
     return {
-      editFieldsInForm: canEditFieldsInlineInForm,
       canSelectField: !!this.args.canSelectField,
       clickedField: this.clickedField,
       isReadOnly: this.args.isReadOnly,
-      isFieldEditPencilShown:
-        canEditFieldsInlineInForm && !this.args.toReceiveUserInput,
-      isAddFieldShownInForm:
-        !this.args.toReceiveUserInput && !this.args.isReadOnly,
-      canMoveFieldsInForm:
-        !this.args.toReceiveUserInput && !this.args.isReadOnly,
     };
   }
 
@@ -93,7 +82,6 @@ export default class EditableFormComponent extends Component {
       onFieldClicked: (fieldModel) => this.setClickedField(fieldModel),
       formDefinition: this.currentForm,
       fieldsInForm: this.fields,
-      isForFormExtension: !!this.args.isForFormExtension,
     };
   }
 }

--- a/app/components/mandatarissen/mandataris-extra-info-card.hbs
+++ b/app/components/mandatarissen/mandataris-extra-info-card.hbs
@@ -57,6 +57,7 @@
       @formInitialized={{fn (mut this.formInitialized) true}}
       @customHistoryMessage={{true}}
       @canEditFormDefinition={{true}}
+      @isFormExtension={{true}}
     />
     {{#unless this.formInitialized}}
       <Skeleton::Forms::MandatarisExtraInfo />

--- a/app/components/mandatarissen/mandataris-extra-info-card.hbs
+++ b/app/components/mandatarissen/mandataris-extra-info-card.hbs
@@ -56,6 +56,7 @@
       @onSave={{this.onSave}}
       @formInitialized={{fn (mut this.formInitialized) true}}
       @customHistoryMessage={{true}}
+      @canEditFormDefinition={{true}}
     />
     {{#unless this.formInitialized}}
       <Skeleton::Forms::MandatarisExtraInfo />

--- a/app/components/mandatarissen/mandataris-extra-info-card.hbs
+++ b/app/components/mandatarissen/mandataris-extra-info-card.hbs
@@ -56,7 +56,6 @@
       @onSave={{this.onSave}}
       @formInitialized={{fn (mut this.formInitialized) true}}
       @customHistoryMessage={{true}}
-      @isForFormExtension={{true}}
     />
     {{#unless this.formInitialized}}
       <Skeleton::Forms::MandatarisExtraInfo />

--- a/app/components/persoon/extra-info-card.hbs
+++ b/app/components/persoon/extra-info-card.hbs
@@ -54,6 +54,8 @@
       @onSave={{this.onSave}}
       @formInitialized={{fn (mut this.formInitialized) true}}
       @customHistoryMessage={{true}}
+      @canEditFormDefinition={{true}}
+      @isFormExtension={{true}}
     />
     {{#unless this.formInitialized}}
       <Skeleton::Forms::MandatarisExtraInfo />

--- a/app/components/persoon/extra-info-card.hbs
+++ b/app/components/persoon/extra-info-card.hbs
@@ -30,7 +30,6 @@
         @onSave={{this.noop}}
         @formInitialized={{fn (mut this.formInitialized) true}}
         @customHistoryMessage={{true}}
-        @isForFormExtension={{true}}
       />
       {{#unless this.formInitialized}}
         <Skeleton::Forms::MandatarisExtraInfo />
@@ -55,7 +54,6 @@
       @onSave={{this.onSave}}
       @formInitialized={{fn (mut this.formInitialized) true}}
       @customHistoryMessage={{true}}
-      @isForFormExtension={{true}}
     />
     {{#unless this.formInitialized}}
       <Skeleton::Forms::MandatarisExtraInfo />

--- a/app/components/rdf-input-fields/beleidsdomein-code-selector.hbs
+++ b/app/components/rdf-input-fields/beleidsdomein-code-selector.hbs
@@ -1,52 +1,65 @@
-{{#if @show}}
-  <AuLabel class="au-c-description-label">
-    {{@field.label}}
-  </AuLabel>
-  <p class="au-c-description-value">
-    {{#each this.selected as |beleidsdomein index|}}
-      {{beleidsdomein.label}}
-      {{#if (not-eq index (dec this.selected.length))}}
-        ,
-      {{/if}}
-    {{/each}}
-  </p>
-{{else}}
-  {{#if this.shouldRender}}
-    {{#unless @inTable}}
-      <AuLabel
-        @error={{this.hasErrors}}
-        @required={{this.isRequired}}
-        @warning={{this.hasWarnings}}
-        for={{this.inputId}}
-      >
-        {{@field.label}}
-      </AuLabel>
-    {{/unless}}
-    <div class={{if this.hasErrors "ember-power-select--error"}}>
-      <Mandatarissen::ConceptSelectorWithCreate
-        @multiple={{true}}
-        @type={{@field.options.type}}
-        @conceptScheme={{this.conceptScheme}}
-        @search={{this.search}}
-        @searchEnabled={{this.searchEnabled}}
-        @selected={{this.selected}}
-        @options={{this.options}}
-        @onClose={{fn (mut this.hasBeenFocused) true}}
-        @onChange={{this.updateSelection}}
-        @onCreate={{this.add}}
-        @disabled={{@show}}
-        as |concept|
-      >
-        {{concept.label}}
-      </Mandatarissen::ConceptSelectorWithCreate>
-    </div>
+<RdfInputFields::StandardFieldWrapper
+  @inline={{true}}
+  @field={{@field}}
+  @form={{@form}}
+  @graphs={{@graphs}}
+  @formStore={{@formStore}}
+  as |wrapper|
+>
+  {{#if @show}}
+    <AuLabel class="au-c-description-label">
+      {{@field.label}}
+    </AuLabel>
+    <p class="au-c-description-value">
+      {{#each this.selected as |beleidsdomein index|}}
+        {{beleidsdomein.label}}
+        {{#if (not-eq index (dec this.selected.length))}}
+          ,
+        {{/if}}
+      {{/each}}
+    </p>
+  {{else}}
+    {{#if this.shouldRender}}
+      <div class={{if this.hasErrors "ember-power-select--error"}}>
+        <Mandatarissen::ConceptSelectorWithCreate
+          @multiple={{true}}
+          @type={{@field.options.type}}
+          @conceptScheme={{this.conceptScheme}}
+          @search={{this.search}}
+          @searchEnabled={{this.searchEnabled}}
+          @selected={{this.selected}}
+          @options={{this.options}}
+          @onClose={{fn (mut this.hasBeenFocused) true}}
+          @onChange={{this.updateSelection}}
+          @onCreate={{this.add}}
+          @disabled={{@show}}
+          as |concept|
+        >
+          {{concept.label}}
+        </Mandatarissen::ConceptSelectorWithCreate>
+      </div>
 
-    {{#each this.errors as |error|}}
-      <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
-    {{/each}}
+      {{#each this.errors as |error|}}
+        <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
+      {{/each}}
 
-    {{#each this.warnings as |warning|}}
-      <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
-    {{/each}}
+      {{#each this.warnings as |warning|}}
+        <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
+      {{/each}}
+    {{else}}
+      <RdfInputFields::ConceptSchemeMultiSelector
+        @showLabel={{false}}
+        @showFieldLabel={{false}}
+        @field={{@field}}
+        @form={{@form}}
+        @formStore={{@formStore}}
+        @graphs={{@graphs}}
+        @sourceNode={{@sourceNode}}
+        @forceShowErrors={{@forceShowErrors}}
+        @cacheConditionals={{@cacheConditionals}}
+        @show={{@show}}
+        @onInteractedWithField={{wrapper.onInteractedWithField}}
+      />
+    {{/if}}
   {{/if}}
-{{/if}}
+</RdfInputFields::StandardFieldWrapper>

--- a/app/components/rdf-input-fields/beleidsdomein-code-selector.hbs
+++ b/app/components/rdf-input-fields/beleidsdomein-code-selector.hbs
@@ -4,7 +4,6 @@
   @form={{@form}}
   @graphs={{@graphs}}
   @formStore={{@formStore}}
-  as |wrapper|
 >
   {{#if @show}}
     <AuLabel class="au-c-description-label">
@@ -46,20 +45,6 @@
       {{#each this.warnings as |warning|}}
         <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
       {{/each}}
-    {{else}}
-      <RdfInputFields::ConceptSchemeMultiSelector
-        @showLabel={{false}}
-        @showFieldLabel={{false}}
-        @field={{@field}}
-        @form={{@form}}
-        @formStore={{@formStore}}
-        @graphs={{@graphs}}
-        @sourceNode={{@sourceNode}}
-        @forceShowErrors={{@forceShowErrors}}
-        @cacheConditionals={{@cacheConditionals}}
-        @show={{@show}}
-        @onInteractedWithField={{wrapper.onInteractedWithField}}
-      />
     {{/if}}
   {{/if}}
 </RdfInputFields::StandardFieldWrapper>

--- a/app/components/rdf-input-fields/crud-custom-field-modal.hbs
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.hbs
@@ -128,7 +128,7 @@
         {{#if this.isCustomForm}}
           <AuFormRow>
             <AuToggleSwitch
-              @disabled={{@show}}
+              @disabled={{this.isShowInSummaryToggleDisabled}}
               @checked={{this.isShownInSummary}}
               @onChange={{this.toggleShowInSummary}}
             >Toon in samenvatting

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -20,6 +20,7 @@ import { isCustomForm } from 'frontend-lmb/utils/form-properties';
 import { NamedNode } from 'rdflib';
 import { trackedFunction } from 'reactiveweb/function';
 import { use } from 'ember-resources';
+import LibraryEntryModel from 'frontend-lmb/models/library-entry';
 
 export default class RdfInputFieldCrudCustomFieldModalComponent extends Component {
   @consume('form-context') formContext;
@@ -35,14 +36,10 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
   @tracked isShownInSummary;
   @tracked wantsToRemove;
 
-  customFieldEntry = this.store.createRecord('library-entry', {
-    name: 'Eigen veld',
-  });
-
   @tracked displayTypes = [];
 
   @tracked fieldName;
-  @tracked libraryFieldType = this.customFieldEntry;
+  @tracked libraryFieldType;
   @tracked displayType;
   @tracked conceptScheme;
   @tracked conceptSchemeOnLoad;
@@ -50,6 +47,8 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
 
   constructor() {
     super(...arguments);
+
+    this.libraryFieldType = LibraryEntryModel.ensureFakeEntry(this.store);
 
     let withValue = TEXT_CUSTOM_DISPLAY_TYPE;
     if (!this.args.isCreating) {
@@ -342,7 +341,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
 
   get canSelectTypeForEntry() {
     if (this.args.isCreating) {
-      return this.libraryFieldType === this.customFieldEntry;
+      return this.libraryFieldType.isNew; // so the fake one we created
     }
 
     return !LIBRARY_ENTREES.includes(this.libraryEntryUri);
@@ -367,6 +366,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
 
 function getLibraryFieldOptions() {
   return trackedFunction(async () => {
+    const customFieldEntry = LibraryEntryModel.ensureFakeEntry(this.store);
     const allOptions = await this.store.query('library-entry', {
       sort: 'name',
       include: 'display-type',
@@ -377,6 +377,6 @@ function getLibraryFieldOptions() {
     const unused = allOptions.filter((entry) => {
       return entry.uri && usedOptions.indexOf(entry.uri) < 0;
     });
-    return [this.customFieldEntry, ...unused];
+    return [customFieldEntry, ...unused];
   });
 }

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -13,7 +13,6 @@ import { FIELD_OPTION, FORM, EXT, PROV } from 'frontend-lmb/rdf/namespaces';
 import { showErrorToast } from 'frontend-lmb/utils/toasts';
 import {
   LIBRARY_ENTREES,
-  LINK_TO_FORM_CUSTOM_DISPLAY_TYPE,
   TEXT_CUSTOM_DISPLAY_TYPE,
 } from 'frontend-lmb/utils/well-known-uris';
 import { Literal, NamedNode } from 'rdflib';
@@ -68,14 +67,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
         sort: 'label',
       })
       .then((displayTypes) => {
-        if (this.args.isForFormExtension) {
-          const allowedTypes = displayTypes.filter(
-            (type) => type.uri !== LINK_TO_FORM_CUSTOM_DISPLAY_TYPE
-          );
-          this.displayTypes = allowedTypes;
-        } else {
-          this.displayTypes = displayTypes;
-        }
+        this.displayTypes = displayTypes;
         this.displayType = this.displayTypes.find((t) => t.uri === withValue);
       });
   }

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -15,7 +15,9 @@ import {
   LIBRARY_ENTREES,
   TEXT_CUSTOM_DISPLAY_TYPE,
 } from 'frontend-lmb/utils/well-known-uris';
-import { Literal, NamedNode } from 'rdflib';
+import { isCustomForm } from 'frontend-lmb/utils/form-properties';
+
+import { NamedNode } from 'rdflib';
 import { trackedFunction } from 'reactiveweb/function';
 import { use } from 'ember-resources';
 
@@ -273,15 +275,8 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
   get isCustomForm() {
     const forkingStore = this.forkingStore;
     return (
-      forkingStore.any(
-        null,
-        EXT('isCustomForm'),
-        new Literal(
-          'true',
-          null,
-          new NamedNode('http://www.w3.org/2001/XMLSchema#boolean')
-        )
-      ) && !forkingStore.any(null, EXT('extendsForm'), null, SOURCE_GRAPH)
+      isCustomForm(forkingStore) &&
+      !forkingStore.any(null, EXT('extendsForm'), null, SOURCE_GRAPH)
     );
   }
 

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -107,6 +107,10 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
     return models.at(0) ?? null;
   }
 
+  get isShowInSummaryToggleDisabled() {
+    return this.args.show || this.displayType?.isLinkToForm;
+  }
+
   get deleteWillLoseData() {
     return this.libraryFieldType?.uri !== null;
   }

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -12,16 +12,14 @@
               @required={{this.isRequired}}
               @error={{this.hasErrors}}
             >{{this.title}}</AuLabel>
-            {{#if this.formState.isFieldEditPencilShown}}
-              <AuButton
-                @skin="link-secondary"
-                @icon="pencil"
-                @hideText={{true}}
-                {{on "click" (fn (mut this.showModal) true)}}
-              >
-                Pas aan
-              </AuButton>
-            {{/if}}
+            <AuButton
+              @skin="link-secondary"
+              @icon="pencil"
+              @hideText={{true}}
+              {{on "click" (fn (mut this.showModal) true)}}
+            >
+              Pas aan
+            </AuButton>
           {{/unless}}
         </div>
         <div
@@ -39,26 +37,24 @@
           </div>
         </div>
       </div>
-      {{#if this.formState.canMoveFieldsInForm}}
-        <div class="au-u-flex au-u-flex--column au-u-flex--vertical-center">
-          <AuButton
-            @skin="naked"
-            @icon="nav-up"
-            @hideText={{true}}
-            {{on "click" (perform this.moveField "up")}}
-          >
-            Naar boven
-          </AuButton>
-          <AuButton
-            @skin="naked"
-            @icon="nav-down"
-            @hideText={{true}}
-            {{on "click" (perform this.moveField "down")}}
-          >
-            Naar onder
-          </AuButton>
-        </div>
-      {{/if}}
+      <div class="au-u-flex au-u-flex--column au-u-flex--vertical-center">
+        <AuButton
+          @skin="naked"
+          @icon="nav-up"
+          @hideText={{true}}
+          {{on "click" (perform this.moveField "up")}}
+        >
+          Naar boven
+        </AuButton>
+        <AuButton
+          @skin="naked"
+          @icon="nav-down"
+          @hideText={{true}}
+          {{on "click" (perform this.moveField "down")}}
+        >
+          Naar onder
+        </AuButton>
+      </div>
     </div>
   </div>
 {{/unless}}
@@ -71,5 +67,4 @@
   @field={{@field}}
   @isRequiredField={{this.isRequired}}
   @isShownInSummary={{this.isShownInSummary}}
-  @isForFormExtension={{this.formContext.isForFormExtension}}
 />

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -13,6 +13,16 @@
               @error={{this.hasErrors}}
             >{{this.title}}</AuLabel>
           {{/unless}}
+          {{#if
+            (and
+              this.formState.isEditFormDefinitionForm this.isFieldShownInSummary
+            )
+          }}
+            <AuPill
+              class="au-u-margin-left-tiny au-u-margin-bottom-tiny"
+              @skin="link"
+            >In samenvatting</AuPill>
+          {{/if}}
         </div>
         <div
           class="au-u-flex au-u-flex--between au-u-flex--vertical-start au-u-flex--spaced-tiny"

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -12,14 +12,6 @@
               @required={{this.isRequired}}
               @error={{this.hasErrors}}
             >{{this.title}}</AuLabel>
-            <AuButton
-              @skin="link-secondary"
-              @icon="pencil"
-              @hideText={{true}}
-              {{on "click" (fn (mut this.showModal) true)}}
-            >
-              Pas aan
-            </AuButton>
           {{/unless}}
         </div>
         <div
@@ -37,34 +29,26 @@
           </div>
         </div>
       </div>
-      <div class="au-u-flex au-u-flex--column au-u-flex--vertical-center">
-        <AuButton
-          @skin="naked"
-          @icon="nav-up"
-          @hideText={{true}}
-          {{on "click" (perform this.moveField "up")}}
-        >
-          Naar boven
-        </AuButton>
-        <AuButton
-          @skin="naked"
-          @icon="nav-down"
-          @hideText={{true}}
-          {{on "click" (perform this.moveField "down")}}
-        >
-          Naar onder
-        </AuButton>
-      </div>
+      {{#if (and this.formState.isEditFormDefinitionForm this.isFieldSelected)}}
+        <div class="au-u-flex au-u-flex--column au-u-flex--vertical-center">
+          <AuButton
+            @skin="naked"
+            @icon="nav-up"
+            @hideText={{true}}
+            {{on "click" (perform this.moveField "up")}}
+          >
+            Naar boven
+          </AuButton>
+          <AuButton
+            @skin="naked"
+            @icon="nav-down"
+            @hideText={{true}}
+            {{on "click" (perform this.moveField "down")}}
+          >
+            Naar onder
+          </AuButton>
+        </div>
+      {{/if}}
     </div>
   </div>
 {{/unless}}
-
-<RdfInputFields::CrudCustomFieldModal
-  @isCreating={{false}}
-  @showModal={{this.showModal}}
-  @onCloseModal={{fn (mut this.showModal) false}}
-  @form={{@form}}
-  @field={{@field}}
-  @isRequiredField={{this.isRequired}}
-  @isShownInSummary={{this.isShownInSummary}}
-/>

--- a/app/components/rdf-input-fields/custom-field-wrapper.js
+++ b/app/components/rdf-input-fields/custom-field-wrapper.js
@@ -16,6 +16,7 @@ import {
   PERSON_CUSTOM_DISPLAY_TYPE,
   PERSON_MULTI_CUSTOM_DISPLAY_TYPE,
 } from 'frontend-lmb/utils/well-known-uris';
+import { isFieldShownInSummmary } from 'frontend-lmb/utils/form-properties';
 
 export default class RdfInputFieldsCustomFieldWrapperComponent extends Component {
   @consume('form-context') formContext;
@@ -102,6 +103,13 @@ export default class RdfInputFieldsCustomFieldWrapperComponent extends Component
       this.formContext.onFieldClicked(null);
     }
   });
+
+  get isFieldShownInSummary() {
+    return isFieldShownInSummmary(
+      this.storeOptions.store,
+      this.args.field?.uri
+    );
+  }
 
   // From ember-submission-form-fields component: input-field.js
   // We cannot access these properties as they are in the component itself and this is just a wrapper

--- a/app/components/rdf-input-fields/custom-field-wrapper.js
+++ b/app/components/rdf-input-fields/custom-field-wrapper.js
@@ -21,7 +21,6 @@ export default class RdfInputFieldsCustomFieldWrapperComponent extends Component
   @consume('form-context') formContext;
   @consume('form-state') formState;
 
-  @tracked showModal;
   @tracked hasErrors;
 
   get title() {

--- a/app/components/rdf-input-fields/standard-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/standard-field-wrapper.hbs
@@ -6,7 +6,7 @@
       {{/unless}}
     </div>
     <div
-      class="au-u-flex au-u-flex--between au-u-flex--vertical-start au-u-flex--spaced-tiny au-u-margin-right"
+      class="au-u-flex au-u-flex--between au-u-flex--vertical-start au-u-flex--spaced-tiny au-u-margin-right-small"
     >
       <div class="flex-grow">
         {{yield}}

--- a/app/components/rdf-input-fields/standard-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/standard-field-wrapper.hbs
@@ -9,7 +9,14 @@
       class="au-u-flex au-u-flex--between au-u-flex--vertical-start au-u-flex--spaced-tiny au-u-margin-right-small"
     >
       <div class="flex-grow">
-        {{yield}}
+        {{#if this.isFieldReadOnly}}
+          <ReadOnlyFieldForDisplayType
+            @field={{@field}}
+            @storeOptions={{this.storeOptions}}
+          />
+        {{else}}
+          {{yield}}
+        {{/if}}
       </div>
     </div>
   </div>

--- a/app/components/rdf-input-fields/standard-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/standard-field-wrapper.hbs
@@ -1,0 +1,16 @@
+{{#unless this.removed}}
+  <div class="standard-form-field">
+    <div class="au-u-flex au-u-flex--row">
+      {{#unless this.formState.isReadOnly}}
+        <AuLabel @required={{this.isRequired}}>{{this.title}}</AuLabel>
+      {{/unless}}
+    </div>
+    <div
+      class="au-u-flex au-u-flex--between au-u-flex--vertical-start au-u-flex--spaced-tiny au-u-margin-right"
+    >
+      <div class="flex-grow">
+        {{yield}}
+      </div>
+    </div>
+  </div>
+{{/unless}}

--- a/app/components/rdf-input-fields/standard-field-wrapper.js
+++ b/app/components/rdf-input-fields/standard-field-wrapper.js
@@ -1,0 +1,87 @@
+import Component from '@glimmer/component';
+
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+import { consume } from 'ember-provide-consume-context';
+import { validationsForFieldWithType } from '@lblod/submission-form-helpers';
+
+import {
+  ADRES_CUSTOM_DISPLAY_TYPE,
+  PERSON_CUSTOM_DISPLAY_TYPE,
+  PERSON_MULTI_CUSTOM_DISPLAY_TYPE,
+} from 'frontend-lmb/utils/well-known-uris';
+
+export default class RdfInputFieldsStandardFieldWrapperComponent extends Component {
+  @consume('form-context') formContext;
+  @consume('form-state') formState;
+
+  @tracked showModal;
+  @tracked hasErrors;
+
+  get title() {
+    return this.args.field?.label;
+  }
+
+  get isFieldReadOnly() {
+    return (
+      this.formState?.isReadOnly &&
+      ![
+        ADRES_CUSTOM_DISPLAY_TYPE,
+        PERSON_CUSTOM_DISPLAY_TYPE,
+        PERSON_MULTI_CUSTOM_DISPLAY_TYPE,
+      ].includes(this.args.field.displayType)
+    );
+  }
+
+  get isFieldSelected() {
+    return this.formState?.clickedField?.uri === this.args.field.uri.value;
+  }
+
+  @action
+  interactedWithField() {
+    this.hasErrors = this.errors.length;
+  }
+
+  @action
+  passOnClickedField() {
+    if (!this.formState?.canSelectField) {
+      return;
+    }
+
+    let clickedField = null;
+    if (this.formState.clickedField?.uri !== this.args.field.uri.value) {
+      clickedField = this.args.field;
+    }
+    this.formContext.onFieldClicked(clickedField);
+  }
+
+  // From ember-submission-form-fields component: input-field.js
+  // We cannot access these properties as they are in the component itself and this is just a wrapper
+  get isRequired() {
+    return (
+      !this.args.show &&
+      this.constraints.some(
+        (constraint) =>
+          constraint.type.value ===
+          'http://lblod.data.gift/vocabularies/forms/RequiredConstraint'
+      )
+    );
+  }
+
+  get constraints() {
+    return validationsForFieldWithType(this.args.field.uri, this.storeOptions);
+  }
+
+  get storeOptions() {
+    return {
+      formGraph: this.args.graphs.formGraph,
+      sourceGraph: this.args.graphs.sourceGraph,
+      metaGraph: this.args.graphs.metaGraph,
+      sourceNode: this.args.sourceNode,
+      store: this.args.formStore,
+      path: this.args.field.rdflibPath,
+      scope: this.args.field.rdflibScope,
+    };
+  }
+}

--- a/app/components/rdf-input-fields/standard-string-input.hbs
+++ b/app/components/rdf-input-fields/standard-string-input.hbs
@@ -1,0 +1,24 @@
+<RdfInputFields::StandardFieldWrapper
+  @inline={{true}}
+  @field={{@field}}
+  @form={{@form}}
+  @graphs={{@graphs}}
+  @formStore={{@formStore}}
+>
+  {{#if @show}}
+    <AuLabel class="au-c-description-label">
+      {{@field.label}}
+    </AuLabel>
+  {{/if}}
+  <RdfInputFields::Input
+    @inTable={{true}}
+    @field={{@field}}
+    @form={{@form}}
+    @formStore={{@formStore}}
+    @graphs={{@graphs}}
+    @sourceNode={{@sourceNode}}
+    @forceShowErrors={{@forceShowErrors}}
+    @cacheConditionals={{@cacheConditionals}}
+    @show={{@show}}
+  />
+</RdfInputFields::StandardFieldWrapper>

--- a/app/components/read-only-field-for-display-type.hbs
+++ b/app/components/read-only-field-for-display-type.hbs
@@ -1,10 +1,8 @@
 <span ...attributes>
-  {{#if this.value}}
-    <div class="au-u-flex au-u-flex--column">
-      <AuLabel class="au-c-description-label">
-        {{@field.label}}
-      </AuLabel>
-      <p class="au-c-description-value">{{this.value}}</p>
-    </div>
-  {{/if}}
+  <div class="au-u-flex au-u-flex--column">
+    <AuLabel class="au-c-description-label">
+      {{@field.label}}
+    </AuLabel>
+    <p class="au-c-description-value">{{or this.value "Onbekend"}}</p>
+  </div>
 </span>

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -46,6 +46,10 @@ export default class CustomFormsInstancesDefinitionController extends Controller
 
   @action
   setSelectedField(field) {
+    if (!field) {
+      return;
+    }
+
     this.selectedField = field;
   }
 
@@ -65,7 +69,10 @@ export default class CustomFormsInstancesDefinitionController extends Controller
 
   @action
   updateSelectedFieldData(fields) {
-    if (this.selectedField) {
+    if (
+      this.selectedField &&
+      fields.map((f) => f.uri).includes(this.selectedField.uri)
+    ) {
       this.selectedField = fields.filter(
         (f) => f.uri === this.selectedField.uri
       )[0];

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { consume } from 'ember-provide-consume-context';
 import { timeout } from 'ember-concurrency';
+import { isCustomDisplayType } from 'frontend-lmb/models/display-type';
 
 export default class CustomFormsInstancesDefinitionController extends Controller {
   @consume('form-context') formContext;
@@ -69,7 +70,9 @@ export default class CustomFormsInstancesDefinitionController extends Controller
         (f) => f.uri === this.selectedField.uri
       )[0];
     } else {
-      this.selectedField = fields[0] || null;
+      this.selectedField = fields.filter((f) =>
+        isCustomDisplayType(f.displayType)
+      )?.[0];
     }
     this.isShownInSummaryAddedToFields = fields.every(
       (f) => !f.isShownInSummary

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -67,6 +67,8 @@ export default class CustomFormsInstancesDefinitionController extends Controller
       this.selectedField = fields.filter(
         (f) => f.uri === this.selectedField.uri
       )[0];
+    } else {
+      this.selectedField = fields[0] || null;
     }
   }
 

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -12,6 +12,7 @@ export default class CustomFormsInstancesDefinitionController extends Controller
   @tracked isEditFormModalOpen;
   @tracked isRefreshForm;
   @tracked selectedField;
+  @tracked isShownInSummaryAddedToFields;
 
   @action
   updateFormName(event) {
@@ -70,6 +71,9 @@ export default class CustomFormsInstancesDefinitionController extends Controller
     } else {
       this.selectedField = fields[0] || null;
     }
+    this.isShownInSummaryAddedToFields = fields.every(
+      (f) => !f.isShownInSummary
+    );
   }
 
   @action

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { consume } from 'ember-provide-consume-context';
@@ -9,6 +10,8 @@ import { isCustomDisplayType } from 'frontend-lmb/models/display-type';
 
 export default class CustomFormsInstancesDefinitionController extends Controller {
   @consume('form-context') formContext;
+
+  @service router;
 
   @tracked isEditFormModalOpen;
   @tracked isRefreshForm;
@@ -90,5 +93,10 @@ export default class CustomFormsInstancesDefinitionController extends Controller
   cancelUpdateFormDetails() {
     this.model.form.rollbackAttributes();
     this.isEditFormModalOpen = false;
+  }
+
+  @action
+  goBackToLastRoute() {
+    this.router.location.history.back();
   }
 }

--- a/app/models/display-type.js
+++ b/app/models/display-type.js
@@ -1,9 +1,14 @@
 import Model, { attr } from '@ember-data/model';
 
 import {
+  ADRES_CUSTOM_DISPLAY_TYPE,
   CONCEPT_SCHEME_MULTI_SELECTOR_CUSTOM_DISPLAY_TYPE,
   CONCEPT_SCHEME_SELECTOR_CUSTOM_DISPLAY_TYPE,
+  DATE_CUSTOM_DISPLAY_TYPE,
   LINK_TO_FORM_CUSTOM_DISPLAY_TYPE,
+  PERSON_CUSTOM_DISPLAY_TYPE,
+  PERSON_MULTI_CUSTOM_DISPLAY_TYPE,
+  TEXT_CUSTOM_DISPLAY_TYPE,
 } from 'frontend-lmb/utils/well-known-uris';
 
 export default class DisplayTypeModel extends Model {
@@ -22,4 +27,17 @@ export default class DisplayTypeModel extends Model {
   get isLinkToForm() {
     return this.uri === LINK_TO_FORM_CUSTOM_DISPLAY_TYPE;
   }
+}
+
+export function isCustomDisplayType(uri) {
+  return [
+    TEXT_CUSTOM_DISPLAY_TYPE,
+    DATE_CUSTOM_DISPLAY_TYPE,
+    ADRES_CUSTOM_DISPLAY_TYPE,
+    PERSON_CUSTOM_DISPLAY_TYPE,
+    PERSON_MULTI_CUSTOM_DISPLAY_TYPE,
+    CONCEPT_SCHEME_SELECTOR_CUSTOM_DISPLAY_TYPE,
+    CONCEPT_SCHEME_MULTI_SELECTOR_CUSTOM_DISPLAY_TYPE,
+    LINK_TO_FORM_CUSTOM_DISPLAY_TYPE,
+  ].includes(uri);
 }

--- a/app/models/library-entry.js
+++ b/app/models/library-entry.js
@@ -12,3 +12,13 @@ export default class LibraryEntryModel extends Model {
   })
   displayType;
 }
+
+LibraryEntryModel.ensureFakeEntry = (store) => {
+  if (LibraryEntryModel.fakeEntry) {
+    return LibraryEntryModel.fakeEntry;
+  }
+  LibraryEntryModel.fakeEntry = store.createRecord('library-entry', {
+    name: 'Eigen veld',
+  });
+  return LibraryEntryModel.fakeEntry;
+};

--- a/app/routes/custom-forms/instances/definition.js
+++ b/app/routes/custom-forms/instances/definition.js
@@ -18,7 +18,6 @@ export default class CustomFormsInstancesDefinitionRoute extends Route {
     let formInstanceId = form.id;
 
     if (isFormExtension && fullScreenEdit === 'true') {
-      console.log({ instanceId });
       formInstanceId = instanceId;
       const currentFormId = this.formReplacements.getReplacement(id);
       form = await this.semanticFormRepository.getFormDefinition(

--- a/app/routes/custom-forms/instances/definition.js
+++ b/app/routes/custom-forms/instances/definition.js
@@ -5,11 +5,16 @@ import { service } from '@ember/service';
 export default class CustomFormsInstancesDefinitionRoute extends Route {
   @service store;
 
-  async model({ id }) {
+  queryParams = {
+    fullScreenEdit: {},
+  };
+
+  async model({ id, fullScreenEdit }) {
     const form = await this.store.findRecord('form', id);
 
     return {
       form,
+      fullScreenEdit: fullScreenEdit && fullScreenEdit === 'true',
     };
   }
 }

--- a/app/routes/custom-forms/instances/definition.js
+++ b/app/routes/custom-forms/instances/definition.js
@@ -34,7 +34,7 @@ export default class CustomFormsInstancesDefinitionRoute extends Route {
         true
       );
     }
-    console.log(`ext?`, isFormExtensionAsBool);
+
     return {
       form,
       instanceId: formInstanceId,

--- a/app/routes/custom-forms/instances/definition.js
+++ b/app/routes/custom-forms/instances/definition.js
@@ -4,16 +4,32 @@ import { service } from '@ember/service';
 
 export default class CustomFormsInstancesDefinitionRoute extends Route {
   @service store;
+  @service formReplacements;
+  @service semanticFormRepository;
 
   queryParams = {
     fullScreenEdit: {},
+    isFormExtension: {},
+    instanceId: {},
   };
 
-  async model({ id, fullScreenEdit }) {
-    const form = await this.store.findRecord('form', id);
+  async model({ id, fullScreenEdit, isFormExtension, instanceId }) {
+    let form = await this.store.findRecord('form', id);
+    let formInstanceId = form.id;
+
+    if (isFormExtension && fullScreenEdit === 'true') {
+      console.log({ instanceId });
+      formInstanceId = instanceId;
+      const currentFormId = this.formReplacements.getReplacement(id);
+      form = await this.semanticFormRepository.getFormDefinition(
+        currentFormId,
+        true
+      );
+    }
 
     return {
       form,
+      instanceId: formInstanceId,
       fullScreenEdit: fullScreenEdit && fullScreenEdit === 'true',
     };
   }

--- a/app/routes/custom-forms/instances/definition.js
+++ b/app/routes/custom-forms/instances/definition.js
@@ -14,8 +14,13 @@ export default class CustomFormsInstancesDefinitionRoute extends Route {
   };
 
   async model({ id, fullScreenEdit, isFormExtension, instanceId }) {
-    let form = await this.store.findRecord('form', id);
-    let formInstanceId = form.id;
+    let form = null;
+    let formInstanceId = null;
+
+    if (!isFormExtension) {
+      form = await this.store.findRecord('form', id);
+      formInstanceId = form.id;
+    }
 
     if (isFormExtension && fullScreenEdit === 'true') {
       formInstanceId = instanceId;

--- a/app/routes/custom-forms/instances/definition.js
+++ b/app/routes/custom-forms/instances/definition.js
@@ -16,13 +16,17 @@ export default class CustomFormsInstancesDefinitionRoute extends Route {
   async model({ id, fullScreenEdit, isFormExtension, instanceId }) {
     let form = null;
     let formInstanceId = null;
+    const isFullScreenAsBool = !!(fullScreenEdit && fullScreenEdit === 'true');
+    const isFormExtensionAsBool = !!(
+      isFormExtension && isFormExtension === 'true'
+    );
 
-    if (!isFormExtension) {
+    if (!isFormExtensionAsBool) {
       form = await this.store.findRecord('form', id);
       formInstanceId = form.id;
     }
 
-    if (isFormExtension && fullScreenEdit === 'true') {
+    if (isFormExtensionAsBool && isFullScreenAsBool) {
       formInstanceId = instanceId;
       const currentFormId = this.formReplacements.getReplacement(id);
       form = await this.semanticFormRepository.getFormDefinition(
@@ -30,11 +34,12 @@ export default class CustomFormsInstancesDefinitionRoute extends Route {
         true
       );
     }
-
+    console.log(`ext?`, isFormExtensionAsBool);
     return {
       form,
       instanceId: formInstanceId,
-      fullScreenEdit: fullScreenEdit && fullScreenEdit === 'true',
+      fullScreenEdit: isFullScreenAsBool,
+      isFormExtension: isFormExtensionAsBool,
     };
   }
 }

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -18,6 +18,13 @@
   border: 2px solid var(--au-gray-200);
   border-radius: 5px;
   background-color: var(--au-white);
+
+  .custom-form-field {
+    padding-left: $au-unit;
+  }
+  .add-custom-field {
+    margin: 0 $au-unit;
+  }
 }
 
 .edit-form-defintion--edit-panel {

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -25,6 +25,10 @@
   .add-custom-field {
     margin: 0 $au-unit;
   }
+
+  .standard-form-field {
+    padding-left: $au-unit;
+  }
 }
 
 .edit-form-defintion--edit-panel {

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -4,6 +4,7 @@
   flex-direction: row;
   gap: 1rem;
   padding: 2rem;
+  height: 100%;
 }
 
 @media (max-width: 750px) {

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -26,15 +26,25 @@
       </AuButtonGroup>
     </Group>
   </AuToolbar>
-  <AuToolbar
-    @size="large"
-    class="au-u-padding-bottom-none au-u-margin-bottom"
-    as |Group|
-  >
+  <AuToolbar @size="large" class="au-u-padding-bottom-none" as |Group|>
     <Group>
       <p>{{this.model.form.description}}</p>
     </Group>
   </AuToolbar>
+  {{#if this.isShownInSummaryAddedToFields}}
+    <div class="au-o-box">
+      <AuAlert
+        @title="Toon in samenvatting"
+        @skin="warning"
+        @icon="alert-triangle"
+      >
+        Er werd geen veld aangeduid dat getoont zal worden in het overzicht.
+        Hierdoor vind je mogelijk instanties van dit formulier niet meer terug.
+        <br />
+        Zorg ervoor dat voor een van de velden in het formulier "Toon in
+        samenvatting" aan staat.</AuAlert>
+    </div>
+  {{/if}}
   <div class="edit-form-defintion">
     <div class="au-o-box edit-form-defintion--form">
       {{#if this.isRefreshForm}}

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -1,50 +1,53 @@
 {{page-title "Bewerk formulier definitie"}}
 <div class="au-c-body-container au-c-body-container--scroll">
-  <AuToolbar
-    @size="large"
-    class="au-u-padding-bottom-none au-u-margin-bottom"
-    as |Group|
-  >
-    <Group>
-      <AuHeading @skin="2">{{this.model.form.name}}
-        <AuButton
-          @skin="link-secondary"
-          @icon="pencil"
-          @hideText={{true}}
-          {{on "click" (fn (mut this.isEditFormModalOpen) true)}}
+  {{#unless this.model.fullScreenEdit}}
+    <AuToolbar
+      @size="large"
+      class="au-u-padding-bottom-none au-u-margin-bottom"
+      as |Group|
+    >
+      <Group>
+        <AuHeading @skin="2">{{this.model.form.name}}
+          <AuButton
+            @skin="link-secondary"
+            @icon="pencil"
+            @hideText={{true}}
+            {{on "click" (fn (mut this.isEditFormModalOpen) true)}}
+          >
+            Pas aan
+          </AuButton></AuHeading>
+      </Group>
+      <Group>
+        <AuButtonGroup>
+          <AuLink
+            @route="custom-forms.instances.index"
+            @model={{this.model.form.id}}
+            @skin="button-secondary"
+          >Terug naar formulieren</AuLink>
+        </AuButtonGroup>
+      </Group>
+    </AuToolbar>
+    <AuToolbar @size="large" class="au-u-padding-bottom-none" as |Group|>
+      <Group>
+        <p>{{this.model.form.description}}</p>
+      </Group>
+    </AuToolbar>
+    {{#if this.isShownInSummaryAddedToFields}}
+      <div class="au-o-box">
+        <AuAlert
+          @title="Toon in samenvatting"
+          @skin="warning"
+          @icon="alert-triangle"
         >
-          Pas aan
-        </AuButton></AuHeading>
-    </Group>
-    <Group>
-      <AuButtonGroup>
-        <AuLink
-          @route="custom-forms.instances.index"
-          @model={{this.model.form.id}}
-          @skin="button-secondary"
-        >Terug naar formulieren</AuLink>
-      </AuButtonGroup>
-    </Group>
-  </AuToolbar>
-  <AuToolbar @size="large" class="au-u-padding-bottom-none" as |Group|>
-    <Group>
-      <p>{{this.model.form.description}}</p>
-    </Group>
-  </AuToolbar>
-  {{#if this.isShownInSummaryAddedToFields}}
-    <div class="au-o-box">
-      <AuAlert
-        @title="Toon in samenvatting"
-        @skin="warning"
-        @icon="alert-triangle"
-      >
-        Er werd geen veld aangeduid dat getoont zal worden in het overzicht.
-        Hierdoor vind je mogelijk instanties van dit formulier niet meer terug.
-        <br />
-        Zorg ervoor dat voor een van de velden in het formulier "Toon in
-        samenvatting" aan staat.</AuAlert>
-    </div>
-  {{/if}}
+          Er werd geen veld aangeduid dat getoont zal worden in het overzicht.
+          Hierdoor vind je mogelijk instanties van dit formulier niet meer
+          terug.
+          <br />
+          Zorg ervoor dat voor een van de velden in het formulier "Toon in
+          samenvatting" aan staat.</AuAlert>
+      </div>
+    {{/if}}
+  {{/unless}}
   <div class="edit-form-defintion">
     <div class="au-o-box edit-form-defintion--form">
       {{#if this.isRefreshForm}}

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -1,6 +1,24 @@
 {{page-title "Bewerk formulier definitie"}}
 <div class="au-c-body-container au-c-body-container--scroll">
-  {{#unless this.model.fullScreenEdit}}
+  {{#if this.model.fullScreenEdit}}
+    <AuToolbar
+      @size="large"
+      class="au-u-padding-bottom-none au-u-margin-bottom"
+      as |Group|
+    >
+      <Group>
+        {{! for styling }}
+      </Group>
+      <Group>
+        <AuButtonGroup>
+          <AuButton
+            @skin="secondary"
+            {{on "click" this.goBackToLastRoute}}
+          >Terug naar vorige pagina</AuButton>
+        </AuButtonGroup>
+      </Group>
+    </AuToolbar>
+  {{else}}
     <AuToolbar
       @size="large"
       class="au-u-padding-bottom-none au-u-margin-bottom"
@@ -47,7 +65,7 @@
           samenvatting" aan staat.</AuAlert>
       </div>
     {{/if}}
-  {{/unless}}
+  {{/if}}
   <div class="edit-form-defintion">
     <div class="au-o-box edit-form-defintion--form">
       {{#if this.isRefreshForm}}

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -57,7 +57,6 @@
           @instanceId={{this.model.form.id}}
           @form={{this.model.form}}
           @customHistoryMessage={{true}}
-          @editFieldsInForm={{false}}
           @canSelectField={{true}}
           @onFieldSelected={{this.setSelectedField}}
           @selectedField={{this.selectedField}}

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -57,6 +57,7 @@
           @instanceId={{this.model.form.id}}
           @form={{this.model.form}}
           @customHistoryMessage={{true}}
+          @isEditFormDefinitionForm={{true}}
           @canSelectField={{true}}
           @onFieldSelected={{this.setSelectedField}}
           @selectedField={{this.selectedField}}

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -89,6 +89,7 @@
         @onFieldUpdated={{this.updateFormContent}}
         @isLoading={{this.isRefreshForm}}
         @selectedField={{this.selectedField}}
+        @canShowInSummaryButton={{this.model.isFormExtension}}
       />
     </div>
   </div>

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -54,7 +54,7 @@
         <AuLoader @hideMessage={{true}} />
       {{else}}
         <EditableForm
-          @instanceId={{this.model.form.id}}
+          @instanceId={{this.model.instanceId}}
           @form={{this.model.form}}
           @customHistoryMessage={{true}}
           @isEditFormDefinitionForm={{true}}

--- a/app/templates/custom-forms/instances/instance.hbs
+++ b/app/templates/custom-forms/instances/instance.hbs
@@ -1,7 +1,6 @@
 {{page-title "Instance"}}
 <div class="au-o-box au-c-body-container au-c-body-container--scroll">
   <EditableForm
-    @toReceiveUserInput={{true}}
     @instanceId={{this.model.instanceId}}
     @form={{this.model.form}}
     @onCancel={{this.onCancel}}

--- a/app/templates/mandatarissen/persoon/index.hbs
+++ b/app/templates/mandatarissen/persoon/index.hbs
@@ -18,12 +18,13 @@
   <div class="au-o-box">
     <Person::Card @persoon={{@model.persoon}} />
   </div>
-  {{!-- <div class="au-o-box">
+
+  <div class="au-o-box">
     <Persoon::ExtraInfoCard
       @persoon={{@model.persoon}}
       @form={{@model.personExtraInfoForm}}
     />
-  </div> --}}
+  </div>
 
   {{#if this.canShowUsage}}
     <div class="au-u-box au-u-padding">

--- a/app/templates/mandatarissen/persoon/index.hbs
+++ b/app/templates/mandatarissen/persoon/index.hbs
@@ -19,12 +19,14 @@
     <Person::Card @persoon={{@model.persoon}} />
   </div>
 
-  <div class="au-o-box">
-    <Persoon::ExtraInfoCard
-      @persoon={{@model.persoon}}
-      @form={{@model.personExtraInfoForm}}
-    />
-  </div>
+  {{#if (is-feature-enabled "person-extra-info")}}
+    <div class="au-o-box">
+      <Persoon::ExtraInfoCard
+        @persoon={{@model.persoon}}
+        @form={{@model.personExtraInfoForm}}
+      />
+    </div>
+  {{/if}}
 
   {{#if this.canShowUsage}}
     <div class="au-u-box au-u-padding">

--- a/app/utils/form-properties.js
+++ b/app/utils/form-properties.js
@@ -12,7 +12,9 @@ export const getFormProperty = (args, property) => {
 
 export const isCustomForm = (forkingStore) => {
   if (!forkingStore) {
-    console.warn('Forkingstore is undefined, returning false.');
+    console.warn(
+      'Forkingstore is undefined, returning false for ext:isCustomForm'
+    );
     return false;
   }
 
@@ -26,5 +28,26 @@ export const isCustomForm = (forkingStore) => {
         new NamedNode('http://www.w3.org/2001/XMLSchema#boolean')
       )
     ) || forkingStore.any(null, EXT('isCustomForm'), true)
+  );
+};
+
+export const isFieldShownInSummmary = (forkingStore, fieldNode) => {
+  if (!forkingStore) {
+    console.warn(
+      'Forkingstore is undefined, returning false for form:showInSummary'
+    );
+    return false;
+  }
+
+  return !!(
+    forkingStore.any(
+      fieldNode,
+      FORM('showInSummary'),
+      new Literal(
+        'true',
+        null,
+        new NamedNode('http://www.w3.org/2001/XMLSchema#boolean')
+      )
+    ) || forkingStore.any(fieldNode, FORM('showInSummary'), true)
   );
 };

--- a/app/utils/form-properties.js
+++ b/app/utils/form-properties.js
@@ -1,4 +1,5 @@
-import { FORM } from 'frontend-lmb/rdf/namespaces';
+import { EXT, FORM } from 'frontend-lmb/rdf/namespaces';
+import { Literal, NamedNode } from 'rdflib';
 
 export const getFormProperty = (args, property) => {
   return args.formStore.match(
@@ -7,4 +8,23 @@ export const getFormProperty = (args, property) => {
     undefined,
     args.graphs.formGraph
   )[0].object.value;
+};
+
+export const isCustomForm = (forkingStore) => {
+  if (!forkingStore) {
+    console.warn('Forkingstore is undefined, returning false.');
+    return false;
+  }
+
+  return !!(
+    forkingStore.any(
+      null,
+      EXT('isCustomForm'),
+      new Literal(
+        'true',
+        null,
+        new NamedNode('http://www.w3.org/2001/XMLSchema#boolean')
+      )
+    ) || forkingStore.any(null, EXT('isCustomForm'), true)
+  );
 };

--- a/app/utils/register-form-fields.js
+++ b/app/utils/register-form-fields.js
@@ -19,6 +19,7 @@ import RdfDateInputComponent from 'frontend-lmb/components/rdf-input-fields/rdf-
 import RDFGeboorteInput from 'frontend-lmb/components/rdf-input-fields/geboorte-input';
 import RDFGenderSelector from 'frontend-lmb/components/rdf-input-fields/gender-selector';
 import RdfInputFieldsCustomStringInputComponent from 'frontend-lmb/components/rdf-input-fields/custom-string-input';
+import RdfInputFieldsStandardStringInputComponent from 'frontend-lmb/components/rdf-input-fields/standard-string-input';
 import RdfInputFieldsCustomAddressInputComponent from 'frontend-lmb/components/rdf-input-fields/custom-address-input';
 import RdfInputFieldsCustomDateInputComponent from 'frontend-lmb/components/rdf-input-fields/custom-date-input';
 import RdfInputFieldsCustomNumberInputComponent from 'frontend-lmb/components/rdf-input-fields/custom-number-input';
@@ -127,6 +128,11 @@ export const registerCustomFormFields = () => {
       displayType:
         'http://lblod.data.gift/display-types/lmb/custom-string-input',
       edit: RdfInputFieldsCustomStringInputComponent,
+    },
+    {
+      displayType:
+        'http://lblod.data.gift/display-types/lmb/standard-string-input',
+      edit: RdfInputFieldsStandardStringInputComponent,
     },
     {
       displayType:

--- a/config/environment.js
+++ b/config/environment.js
@@ -39,6 +39,7 @@ module.exports = function (environment) {
       'enable-mandataris-count-warnings': true,
       politieraad: false,
       'editable-forms': false,
+      'person-extra-info': false,
       'edit-mandataris-rework': false,
       'shacl-report': false,
     },
@@ -72,6 +73,7 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
     ENV.features['editable-forms'] = true;
+    ENV.features['person-extra-info'] = true;
     ENV.features['show-eigen-gegevens-module'] = true;
 
     ENV.features['shacl-report'] = true;


### PR DESCRIPTION
## Description

Eigen gegeven, extra-info-mandataris these should have some UI updates so the UX is better

## How to test

1. show in summary should be disabled when the displaytype is link to form
2. edit field in custom form has padding to the left (all items are aligned the same)
3. By default the first field is selected when editing the definition
4. An warning is shown when there is no field selected to shown in summary
5. Show a pill to the fields that are shown in summary
6. person extra info form should be updated on change instead of on refresh + edit definition is on a different route 
7. When a field does not have a value in the editable form (show mode) it shows "Onbekend" for custom and standard-field-wrapper

![image](https://github.com/user-attachments/assets/02d72a17-f47a-44f3-b4b7-15cddb9b69f3)
![image](https://github.com/user-attachments/assets/d0eb8533-a0c1-4219-9f90-15bff6acc7fc)
![image](https://github.com/user-attachments/assets/4072c3e2-82c4-426c-bd72-457b7ae7d5ce)
![image](https://github.com/user-attachments/assets/bf446519-ed0d-48ef-b844-aa5e8cd7b609)
![image](https://github.com/user-attachments/assets/38863f5d-a9da-4d41-9c49-e1e3cf0a5cb1)
![image](https://github.com/user-attachments/assets/5f9d2f61-632f-4318-801d-b7e4c00b2aff)


## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/437
- https://github.com/lblod/form-content-service/pull/84
