### PR TITLE
LMB-1595 | improve feel of linked instances

### DIFF
--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -115,7 +115,7 @@
       </AuFormRow>
       {{#if this.isDeleteWarningShown}}
         <div
-          class="au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--spaced-tiny warning-panel au-u-margin-top"
+          class="au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--spaced-tiny warning-panel"
         >
           <AuBadge @icon="alert-triangle" @skin="error" @size="small" />
           <span>Dit veld zal verwijderd worden voor

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -92,27 +92,29 @@
           </Shared::Tooltip>
         </AuToggleSwitch>
       </AuFormRow>
-      <AuFormRow>
-        <AuToggleSwitch
-          @disabled={{this.isShowInSummaryToggleDisabled}}
-          @checked={{this.isShownInSummary}}
-          @onChange={{this.toggleShowInSummary}}
-        >Toon in samenvatting
-          <Shared::Tooltip
-            @showTooltip={{true}}
-            @alignment="center"
-            @tooltipText="Dit veld zal getoond worden in de samenvatting van een item, bijvoorbeeld bij het tonen van een lijst van items of bij een verwijzing naar een item."
-          >
-            <AuButton
-              @skin="naked"
-              @icon="circle-question"
-              @hideText={{true}}
-              @disabled={{true}}
-              class="au-u-padding-bottom-small au-u-padding-left-none"
-            />
-          </Shared::Tooltip>
-        </AuToggleSwitch>
-      </AuFormRow>
+      {{#unless @canShowInSummaryButton}}
+        <AuFormRow>
+          <AuToggleSwitch
+            @disabled={{this.isShowInSummaryToggleDisabled}}
+            @checked={{this.isShownInSummary}}
+            @onChange={{this.toggleShowInSummary}}
+          >Toon in samenvatting
+            <Shared::Tooltip
+              @showTooltip={{true}}
+              @alignment="center"
+              @tooltipText="Dit veld zal getoond worden in de samenvatting van een item, bijvoorbeeld bij het tonen van een lijst van items of bij een verwijzing naar een item."
+            >
+              <AuButton
+                @skin="naked"
+                @icon="circle-question"
+                @hideText={{true}}
+                @disabled={{true}}
+                class="au-u-padding-bottom-small au-u-padding-left-none"
+              />
+            </Shared::Tooltip>
+          </AuToggleSwitch>
+        </AuFormRow>
+      {{/unless}}
       {{#if this.isDeleteWarningShown}}
         <div
           class="au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--spaced-tiny warning-panel"

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -94,7 +94,7 @@
       </AuFormRow>
       <AuFormRow>
         <AuToggleSwitch
-          @disabled={{not this.selectedField}}
+          @disabled={{this.isShowInSummaryToggleDisabled}}
           @checked={{this.isShownInSummary}}
           @onChange={{this.toggleShowInSummary}}
         >Toon in samenvatting

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -53,12 +53,26 @@ export default class CustomFormEditCustomField extends Component {
   get isShowInSummaryToggleDisabled() {
     return (
       !this.selectedField ||
-      this.selectedField.displayType === LINK_TO_FORM_CUSTOM_DISPLAY_TYPE
+      this.selectedField.displayType === LINK_TO_FORM_CUSTOM_DISPLAY_TYPE ||
+      this.displayType?.isLinkToForm
     );
   }
 
+  get isLinkFormTypeSelected() {
+    if (!this.displayType?.isLinkToForm) {
+      return true;
+    }
+
+    return this.linkedFormTypeUri;
+  }
+
   get canSaveChanges() {
-    return this.isChanged && this.isValidLabel && this.displayType;
+    return (
+      this.isChanged &&
+      this.isValidLabel &&
+      this.displayType &&
+      this.isLinkFormTypeSelected
+    );
   }
 
   get isChanged() {
@@ -127,6 +141,11 @@ export default class CustomFormEditCustomField extends Component {
   @action
   async saveFieldChanges() {
     this.isSaving = true;
+
+    if (this.displayType?.isLinkToForm) {
+      this.isShownInSummary = false;
+    }
+
     const updatedField = await this.customForms.updateCustomFormField(
       this.args.formDefinitionId,
       this.selectedField.uri,

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -7,6 +7,8 @@ import { tracked, cached } from '@glimmer/tracking';
 import { trackedFunction } from 'reactiveweb/function';
 import { use } from 'ember-resources';
 
+import { LINK_TO_FORM_CUSTOM_DISPLAY_TYPE } from 'frontend-lmb/utils/well-known-uris';
+
 export default class CustomFormEditCustomField extends Component {
   @use(setSelectedField) setSelectedField;
   @use(getDisplayTypes) getDisplayTypes;
@@ -46,6 +48,13 @@ export default class CustomFormEditCustomField extends Component {
 
   get isValidLabel() {
     return this.label?.trim() !== '';
+  }
+
+  get isShowInSummaryToggleDisabled() {
+    return (
+      !this.selectedField ||
+      this.selectedField.displayType === LINK_TO_FORM_CUSTOM_DISPLAY_TYPE
+    );
   }
 
   get canSaveChanges() {

--- a/app/components/custom-form/link-to-form-with-modal.hbs
+++ b/app/components/custom-form/link-to-form-with-modal.hbs
@@ -4,6 +4,7 @@
   @form={{@form}}
   @graphs={{@graphs}}
   @formStore={{@formStore}}
+  @showErrorLineNextToField={{true}}
   as |wrapper|
 >
   <div class="au-u-flex au-u-flex--column">

--- a/app/components/custom-form/link-to-form-with-modal.hbs
+++ b/app/components/custom-form/link-to-form-with-modal.hbs
@@ -16,7 +16,7 @@
           {{/each}}
         </:header>
         <:body>
-          {{#each this.selectedInstances as |instance|}}
+          {{#each this.selectedInstanceOptions as |instance|}}
             <tr>
               {{#each instance.option as |option|}}
                 <td>{{option.value}}</td>

--- a/app/components/custom-form/link-to-form-with-modal.hbs
+++ b/app/components/custom-form/link-to-form-with-modal.hbs
@@ -78,6 +78,11 @@
             </c.body>
           </t.content>
         </AuDataTable>
+        <TablePagination
+          @metadata={{this.instancesMetadata}}
+          @onClickPrevious={{this.fetchPreviousPage}}
+          @onClickNext={{this.fetchNextPage}}
+        />
       </span>
     </:body>
     <:footer>

--- a/app/components/custom-form/link-to-form-with-modal.hbs
+++ b/app/components/custom-form/link-to-form-with-modal.hbs
@@ -30,7 +30,9 @@
     {{/if}}
     <AuButton
       class="au-u-padding-left-none au-u-margin-top-small"
-      @skin="link"
+      @skin="secondary"
+      @icon="pencil"
+      @width="block"
       {{on "click" this.openModal}}
     >Pas aan</AuButton>
   </div>

--- a/app/components/custom-form/link-to-form-with-modal.hbs
+++ b/app/components/custom-form/link-to-form-with-modal.hbs
@@ -5,7 +5,7 @@
   @graphs={{@graphs}}
   @formStore={{@formStore}}
 >
-  <div class="au-u-flex au-u-flex--between au-u-flex--vertical-center">
+  <div class="au-u-flex au-u-flex--column">
     {{#if this.hasSelectedOptions}}
       <AuTable>
         <:header>
@@ -26,7 +26,11 @@
     {{else}}
       <p>Selecteer een formulier</p>
     {{/if}}
-    <AuButton @skin="secondary" {{on "click" this.openModal}}>Voeg toe</AuButton>
+    <AuButton
+      class="au-u-padding-left-none au-u-margin-top-small"
+      @skin="link"
+      {{on "click" this.openModal}}
+    >Pas aan</AuButton>
   </div>
 </RdfInputFields::CustomFieldWrapper>
 

--- a/app/components/custom-form/link-to-form-with-modal.hbs
+++ b/app/components/custom-form/link-to-form-with-modal.hbs
@@ -42,9 +42,8 @@
   >
     <:title>Link naar formulier</:title>
     <:body>
-      <div class="au-u-padding-small">
-        <AuLabel class="au-u-padding-left-small" for="zoek-instantie">Zoek
-          formulier</AuLabel>
+      <div class="au-u-padding-small au-u-padding-left-none">
+        <AuLabel for="zoek-instantie">Zoek formulier</AuLabel>
         <AuInput
           id="zoek-instantie"
           placeholder={{this.searchPlaceholderText}}
@@ -53,11 +52,6 @@
           {{on "keyup" (perform this.filterResults)}}
         />
       </div>
-      <TablePagination
-        @metadata={{this.instancesMetadata}}
-        @onClickPrevious={{this.fetchPreviousPage}}
-        @onClickNext={{this.fetchNextPage}}
-      />
       <span class="no-pagination">
         <AuDataTable
           @content={{this.instancesAsOptions}}
@@ -84,6 +78,11 @@
             </c.body>
           </t.content>
         </AuDataTable>
+        <TablePagination
+          @metadata={{this.instancesMetadata}}
+          @onClickPrevious={{this.fetchPreviousPage}}
+          @onClickNext={{this.fetchNextPage}}
+        />
       </span>
     </:body>
     <:footer>

--- a/app/components/custom-form/link-to-form-with-modal.hbs
+++ b/app/components/custom-form/link-to-form-with-modal.hbs
@@ -42,35 +42,36 @@
   >
     <:title>Link naar formulier</:title>
     <:body>
-      <AuDataTable
-        @content={{this.instancesAsOptions}}
-        @sort={{@sort}}
-        @page={{@page}}
-        @size={{@size}}
-        {{!-- @isLoading={{not this.initialized}} --}}
-        @noDataMessage="Geen formulieren gevonden."
-        as |t|
-      >
-        <t.content as |c|>
-          <c.header>
-            <th> {{! is selected}}</th>
-            {{#each this.instanceDisplayLabels as |label|}}
-              <th>{{label.name}}</th>
-            {{/each}}
-          </c.header>
-          <c.body as |instance|>
-            <td>
-              <AuCheckbox
-                @checked={{instance.isSelected}}
-                @onChange={{fn this.selectInstance instance}}
-              />
-            </td>
-            {{#each instance.option as |option|}}
-              <td>{{option.value}}</td>
-            {{/each}}
-          </c.body>
-        </t.content>
-      </AuDataTable>
+      <span class="no-pagination">
+        <AuDataTable
+          @content={{this.instancesAsOptions}}
+          @sort={{@sort}}
+          @page={{@page}}
+          @size={{@size}}
+          @noDataMessage="Geen formulieren gevonden."
+          as |t|
+        >
+          <t.content as |c|>
+            <c.header>
+              <th> {{! is selected}}</th>
+              {{#each this.instanceDisplayLabels as |label|}}
+                <th>{{label.name}}</th>
+              {{/each}}
+            </c.header>
+            <c.body as |instance|>
+              <td>
+                <AuCheckbox
+                  @checked={{instance.isSelected}}
+                  @onChange={{fn this.selectInstance instance}}
+                />
+              </td>
+              {{#each instance.option as |option|}}
+                <td>{{option.value}}</td>
+              {{/each}}
+            </c.body>
+          </t.content>
+        </AuDataTable>
+      </span>
     </:body>
     <:footer>
       <div class="au-u-flex au-u-flex--center">

--- a/app/components/custom-form/link-to-form-with-modal.hbs
+++ b/app/components/custom-form/link-to-form-with-modal.hbs
@@ -42,6 +42,13 @@
   >
     <:title>Link naar formulier</:title>
     <:body>
+      <AuLabel for="zoek-instantie">Zoek</AuLabel>
+      <AuInput
+        class="au-u-margin-bottom"
+        id="zoek-instantie"
+        @value={{this.searchValue}}
+        {{on "keyup" this.filterResults}}
+      />
       <span class="no-pagination">
         <AuDataTable
           @content={{this.instancesAsOptions}}

--- a/app/components/custom-form/link-to-form-with-modal.hbs
+++ b/app/components/custom-form/link-to-form-with-modal.hbs
@@ -42,19 +42,25 @@
   >
     <:title>Link naar formulier</:title>
     <:body>
-      <AuLabel for="zoek-instantie">Zoek</AuLabel>
-      <AuInput
-        class="au-u-margin-bottom"
-        id="zoek-instantie"
-        @value={{this.searchValue}}
-        {{on "keyup" (perform this.filterResults)}}
+      <div class="au-u-padding-small">
+        <AuLabel class="au-u-padding-left-small" for="zoek-instantie">Zoek
+          formulier</AuLabel>
+        <AuInput
+          id="zoek-instantie"
+          placeholder={{this.searchPlaceholderText}}
+          @width="block"
+          @value={{this.searchValue}}
+          {{on "keyup" (perform this.filterResults)}}
+        />
+      </div>
+      <TablePagination
+        @metadata={{this.instancesMetadata}}
+        @onClickPrevious={{this.fetchPreviousPage}}
+        @onClickNext={{this.fetchNextPage}}
       />
       <span class="no-pagination">
         <AuDataTable
           @content={{this.instancesAsOptions}}
-          @sort={{@sort}}
-          @page={{@page}}
-          @size={{@size}}
           @noDataMessage="Geen formulieren gevonden."
           as |t|
         >
@@ -78,11 +84,6 @@
             </c.body>
           </t.content>
         </AuDataTable>
-        <TablePagination
-          @metadata={{this.instancesMetadata}}
-          @onClickPrevious={{this.fetchPreviousPage}}
-          @onClickNext={{this.fetchNextPage}}
-        />
       </span>
     </:body>
     <:footer>

--- a/app/components/custom-form/link-to-form-with-modal.hbs
+++ b/app/components/custom-form/link-to-form-with-modal.hbs
@@ -47,7 +47,7 @@
         class="au-u-margin-bottom"
         id="zoek-instantie"
         @value={{this.searchValue}}
-        {{on "keyup" this.filterResults}}
+        {{on "keyup" (perform this.filterResults)}}
       />
       <span class="no-pagination">
         <AuDataTable

--- a/app/components/custom-form/link-to-form-with-modal.hbs
+++ b/app/components/custom-form/link-to-form-with-modal.hbs
@@ -1,0 +1,79 @@
+<RdfInputFields::CustomFieldWrapper
+  @inline={{true}}
+  @field={{@field}}
+  @form={{@form}}
+  @graphs={{@graphs}}
+  @formStore={{@formStore}}
+>
+  <div class="au-u-flex au-u-flex--between au-u-flex--vertical-center">
+    {{#if this.hasSelectedOptions}}
+      <AuTable>
+        <:header>
+          {{#each this.instanceDisplayLabels as |label|}}
+            <th>{{label.name}}</th>
+          {{/each}}
+        </:header>
+        <:body>
+          {{#each this.selectedInstances as |instance|}}
+            <tr>
+              {{#each instance.option as |option|}}
+                <td>{{option.value}}</td>
+              {{/each}}
+            </tr>
+          {{/each}}
+        </:body>
+      </AuTable>
+    {{else}}
+      <p>Selecteer een formulier</p>
+    {{/if}}
+    <AuButton @skin="secondary" {{on "click" this.openModal}}>Voeg toe</AuButton>
+  </div>
+</RdfInputFields::CustomFieldWrapper>
+
+<AuModal
+  ...attributes
+  @modalOpen={{this.isModalOpen}}
+  @closable={{true}}
+  @closeModal={{this.onCloseModal}}
+>
+  <:title>Link naar formulier</:title>
+  <:body>
+    <AuDataTable
+      @content={{this.instancesAsOptions}}
+      @sort={{@sort}}
+      @page={{@page}}
+      @size={{@size}}
+      {{!-- @isLoading={{not this.initialized}} --}}
+      @noDataMessage="Geen formulieren gevonden."
+      as |t|
+    >
+      <t.content as |c|>
+        <c.header>
+          <th> {{! is selected}}</th>
+          {{#each this.instanceDisplayLabels as |label|}}
+            <th>{{label.name}}</th>
+          {{/each}}
+        </c.header>
+        <c.body as |instance|>
+          <td>
+            <AuCheckbox
+              @checked={{instance.isSelected}}
+              @onChange={{fn this.selectInstance instance}}
+            />
+          </td>
+          {{#each instance.option as |option|}}
+            <td>{{option.value}}</td>
+          {{/each}}
+        </c.body>
+      </t.content>
+    </AuDataTable>
+  </:body>
+  <:footer>
+    <div class="au-u-flex au-u-flex--center">
+      <AuButton
+        @skin="secondary"
+        {{on "click" this.onCloseModal}}
+      >Sluiten</AuButton>
+    </div>
+  </:footer>
+</AuModal>

--- a/app/components/custom-form/link-to-form-with-modal.hbs
+++ b/app/components/custom-form/link-to-form-with-modal.hbs
@@ -4,6 +4,7 @@
   @form={{@form}}
   @graphs={{@graphs}}
   @formStore={{@formStore}}
+  as |wrapper|
 >
   <div class="au-u-flex au-u-flex--column">
     {{#if this.hasSelectedOptions}}
@@ -32,52 +33,51 @@
       {{on "click" this.openModal}}
     >Pas aan</AuButton>
   </div>
+  <AuModal
+    ...attributes
+    @modalOpen={{this.isModalOpen}}
+    @closable={{true}}
+    @closeModal={{this.onCloseModal}}
+  >
+    <:title>Link naar formulier</:title>
+    <:body>
+      <AuDataTable
+        @content={{this.instancesAsOptions}}
+        @sort={{@sort}}
+        @page={{@page}}
+        @size={{@size}}
+        {{!-- @isLoading={{not this.initialized}} --}}
+        @noDataMessage="Geen formulieren gevonden."
+        as |t|
+      >
+        <t.content as |c|>
+          <c.header>
+            <th> {{! is selected}}</th>
+            {{#each this.instanceDisplayLabels as |label|}}
+              <th>{{label.name}}</th>
+            {{/each}}
+          </c.header>
+          <c.body as |instance|>
+            <td>
+              <AuCheckbox
+                @checked={{instance.isSelected}}
+                @onChange={{fn this.selectInstance instance}}
+              />
+            </td>
+            {{#each instance.option as |option|}}
+              <td>{{option.value}}</td>
+            {{/each}}
+          </c.body>
+        </t.content>
+      </AuDataTable>
+    </:body>
+    <:footer>
+      <div class="au-u-flex au-u-flex--center">
+        <AuButton
+          @skin="secondary"
+          {{on "click" (fn this.onCloseModal wrapper.onInteractedWithField)}}
+        >Sluiten</AuButton>
+      </div>
+    </:footer>
+  </AuModal>
 </RdfInputFields::CustomFieldWrapper>
-
-<AuModal
-  ...attributes
-  @modalOpen={{this.isModalOpen}}
-  @closable={{true}}
-  @closeModal={{this.onCloseModal}}
->
-  <:title>Link naar formulier</:title>
-  <:body>
-    <AuDataTable
-      @content={{this.instancesAsOptions}}
-      @sort={{@sort}}
-      @page={{@page}}
-      @size={{@size}}
-      {{!-- @isLoading={{not this.initialized}} --}}
-      @noDataMessage="Geen formulieren gevonden."
-      as |t|
-    >
-      <t.content as |c|>
-        <c.header>
-          <th> {{! is selected}}</th>
-          {{#each this.instanceDisplayLabels as |label|}}
-            <th>{{label.name}}</th>
-          {{/each}}
-        </c.header>
-        <c.body as |instance|>
-          <td>
-            <AuCheckbox
-              @checked={{instance.isSelected}}
-              @onChange={{fn this.selectInstance instance}}
-            />
-          </td>
-          {{#each instance.option as |option|}}
-            <td>{{option.value}}</td>
-          {{/each}}
-        </c.body>
-      </t.content>
-    </AuDataTable>
-  </:body>
-  <:footer>
-    <div class="au-u-flex au-u-flex--center">
-      <AuButton
-        @skin="secondary"
-        {{on "click" this.onCloseModal}}
-      >Sluiten</AuButton>
-    </div>
-  </:footer>
-</AuModal>

--- a/app/components/custom-form/link-to-form-with-modal.js
+++ b/app/components/custom-form/link-to-form-with-modal.js
@@ -105,7 +105,7 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
 
   get searchPlaceholderText() {
     const labels = this.instanceDisplayLabels.map((d) => d.name);
-    return `Zoek op ${labels.join(', ')}`;
+    return `Zoek op één van de eigenschappen van het formulier. Bv. ${labels.join(', ')}`;
   }
 
   get hasSelectedOptions() {

--- a/app/components/custom-form/link-to-form-with-modal.js
+++ b/app/components/custom-form/link-to-form-with-modal.js
@@ -93,6 +93,8 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
   @action
   filterResults(event) {
     this.searchValue = event.target?.value;
+    this.pageToLoad = 0;
+    this.getInstances.perform();
   }
 
   get hasSelectedOptions() {
@@ -119,10 +121,7 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
     const keysOfLabels = this.instanceDisplayLabels.map((label) => label.name);
     const uniqueInstanceIds = [];
     const instances = [];
-    for (const instance of [
-      ...this.instances,
-      ...this.initialSelectedInstances,
-    ]) {
+    for (const instance of this.instances) {
       if (uniqueInstanceIds.includes(instance.id)) {
         continue;
       } else {

--- a/app/components/custom-form/link-to-form-with-modal.js
+++ b/app/components/custom-form/link-to-form-with-modal.js
@@ -159,14 +159,12 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
   @action
   fetchPreviousPage({ previousPage }) {
     this.pageToLoad = previousPage;
-    console.log('previous:', this.pageToLoad);
     this.getInstances.perform();
   }
 
   @action
   fetchNextPage({ nextPage }) {
     this.pageToLoad = nextPage;
-    console.log('next:', this.pageToLoad);
     this.getInstances.perform();
   }
 
@@ -248,8 +246,6 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
       this.filterInstancesParams
     );
 
-    this.instancesMetadata = enrichedInstances.meta;
-
     return {
       instances: enrichedInstances,
       labels: formInfo.labels,
@@ -260,7 +256,6 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
     const instances = [];
     instances.push(..._instances);
     instances.meta = instances.meta || {};
-    console.log('instnaces', instances.meta);
     instances.meta.count = parseInt(response.headers.get('X-Total-Count'), 10);
     instances.meta.pagination = {
       first: {

--- a/app/components/custom-form/link-to-form-with-modal.js
+++ b/app/components/custom-form/link-to-form-with-modal.js
@@ -1,0 +1,263 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+
+import { A } from '@ember/array';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+import {
+  triplesForPath,
+  updateSimpleFormValue,
+} from '@lblod/submission-form-helpers';
+import { NamedNode } from 'rdflib';
+import { task } from 'ember-concurrency';
+
+import { API, JSON_API_TYPE } from 'frontend-lmb/utils/constants';
+import { EXT } from 'frontend-lmb/rdf/namespaces';
+
+export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
+  @service store;
+  @service semanticFormRepository;
+
+  @tracked isModalOpen;
+
+  @tracked instanceObjectsOfOptions = [];
+  @tracked initialSelectedInstances = A([]);
+  @tracked instances = A([]);
+  @tracked selectedInstances = A([]);
+  @tracked instanceDisplayLabels = [];
+  @tracked pageToLoad = 0;
+  @tracked currentPagination;
+  @tracked lastPageOfInstances;
+  @tracked isLoadingMoreOptions;
+  @tracked areAllInstancesFetched;
+
+  constructor() {
+    super(...arguments);
+    this.isSettingInitialSelectedOptions.perform();
+  }
+
+  @action
+  openModal() {
+    this.isModalOpen = true;
+
+    if (this.isFetchingInstances) {
+      return;
+    }
+
+    this.getInstances.perform();
+  }
+
+  @action
+  onCloseModal() {
+    this.isModalOpen = false;
+  }
+
+  @action
+  async selectInstance(option) {
+    // Retrieve options in store
+    const matches = triplesForPath(this.storeOptions, true).values;
+    if (option.isSelected) {
+      // remove
+    } else {
+      this.selectedInstances.pushObject(option);
+    }
+
+    // Cleanup
+    matches
+      .filter(
+        (m) =>
+          !this.selectedInstances.find((opt) => m.value == opt.instance.uri)
+      )
+      .forEach((m) => updateSimpleFormValue(this.storeOptions, undefined, m));
+
+    // Insert
+    this.selectedInstances
+      .filter(
+        (selected) => !matches.find((m) => selected.instance.uri == m.value)
+      )
+      .forEach((opt) =>
+        updateSimpleFormValue(
+          this.storeOptions,
+          new NamedNode(opt.instance.uri)
+        )
+      );
+    super.updateValidations();
+  }
+
+  get hasSelectedOptions() {
+    return this.selectedInstances?.length >= 1;
+  }
+
+  get formTypeUri() {
+    return this.storeOptions.store.any(
+      this.args.field.uri,
+      EXT('linkedFormType'),
+      undefined,
+      this.storeOptions.formGraph
+    )?.value;
+  }
+
+  get isFetchingInstances() {
+    return (
+      this.isSettingInitialSelectedOptions.isRunning ||
+      this.getInstances.isRunning
+    );
+  }
+
+  get instancesAsOptions() {
+    const keysOfLabels = this.instanceDisplayLabels.map((label) => label.name);
+    const uniqueInstanceIds = [];
+    const instances = [];
+    for (const instance of [
+      ...this.instances,
+      ...this.initialSelectedInstances,
+    ]) {
+      if (uniqueInstanceIds.includes(instance.id)) {
+        continue;
+      } else {
+        uniqueInstanceIds.push(instance.id);
+      }
+      instances.push({
+        option: keysOfLabels.map((key) => {
+          return {
+            key: key,
+            value: instance[key],
+          };
+        }),
+        instance,
+        searchString: [...Object.values(instance), instance.id].join(';'),
+        isSelected: !!this.selectedInstances.find(
+          (o) => o.instance.id === instance.id
+        ),
+      });
+    }
+    return instances;
+  }
+
+  get filterInstancesParams() {
+    return {
+      page: this.pageToLoad,
+      size: 20,
+    };
+  }
+
+  getInstances = task({ enqueue: true }, async () => {
+    if (!this.formTypeUri || isNaN(this.pageToLoad)) {
+      return;
+    }
+    if (
+      this.currentPagination &&
+      this.currentPagination.self.number > this.currentPagination.last.number
+    ) {
+      return;
+    }
+
+    const formInfo = await this.fetchInstancesForUris([]);
+    this.instanceDisplayLabels = formInfo.labels;
+    this.instances.pushObjects(formInfo.instances);
+    this.getInstances.perform();
+  });
+
+  isSettingInitialSelectedOptions = task(async () => {
+    const matches = triplesForPath(this.storeOptions, true);
+    if (matches.values.length > 0) {
+      const initialSelectedInstanceUris = matches.values.map((v) => v.value);
+      const formInfo = await this.fetchInstancesForUris(
+        initialSelectedInstanceUris,
+        false
+      );
+      this.instanceDisplayLabels = formInfo.labels;
+      if (formInfo.instances.length === 0) {
+        return;
+      }
+
+      this.initialSelectedInstances.pushObjects(formInfo.instances);
+      const selectedOptions = this.instancesAsOptions.filter((option) =>
+        formInfo.instances
+          .map((i) => i.id)
+          .filter(
+            (isInstance) => isInstance && isInstance !== this.LOAD_MORE_ID
+          )
+          .includes(option.instance?.id)
+      );
+      this.selectedInstances.pushObjects(selectedOptions);
+    }
+  });
+
+  async fetchInstancesForUris(instanceUris, setPagination = true) {
+    const queryParamsMap = {
+      page: `page[number]=${this.filterInstancesParams.page}`,
+      size: `page[size]=${this.filterInstancesParams.size}`,
+    };
+    const queryParams = Object.keys(this.filterInstancesParams)
+      .map((key) => queryParamsMap[key])
+      .join('&');
+    const response = await fetch(
+      `${API.FORM_CONTENT_SERVICE}/instances/by-form-definition-uri?${queryParams}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': JSON_API_TYPE,
+        },
+        body: JSON.stringify({
+          formDefinitionUri: this.formTypeUri,
+          instanceUris,
+        }),
+      }
+    );
+    if (!response.ok) {
+      console.error(
+        `Er ging iets mis bij het ophalen van instances met uris ${instanceUris.split(', ')}`
+      );
+      return null;
+    }
+    const formInfo = await response.json();
+    if (!setPagination) {
+      return {
+        instances: formInfo.instances,
+        labels: formInfo.labels,
+      };
+    }
+    const enrichedInstances = this.addPaginationToInstances(
+      formInfo.instances,
+      response,
+      this.filterInstancesParams
+    );
+
+    return {
+      instances: enrichedInstances,
+      labels: formInfo.labels,
+    };
+  }
+
+  addPaginationToInstances(_instances, response, options) {
+    const instances = [];
+    instances.push(..._instances);
+    instances.meta = instances.meta || {};
+    instances.meta.count = parseInt(response.headers.get('X-Total-Count'), 10);
+    instances.meta.pagination = {
+      first: {
+        number: 0,
+      },
+      self: {
+        number: options.page,
+        size: options.size,
+      },
+      last: {
+        number: Math.floor(instances.meta.count / options.size),
+      },
+    };
+    if (options.page * options.size < instances.meta.count) {
+      instances.meta.pagination.next = {
+        number: options.page + 1,
+        size: options.size,
+      };
+    }
+
+    this.currentPagination = instances.meta.pagination;
+    this.pageToLoad = this.currentPagination.next?.number;
+
+    return instances;
+  }
+}

--- a/app/components/custom-form/link-to-form-with-modal.js
+++ b/app/components/custom-form/link-to-form-with-modal.js
@@ -103,6 +103,11 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
     this.getInstances.perform();
   });
 
+  get searchPlaceholderText() {
+    const labels = this.instanceDisplayLabels.map((d) => d.name);
+    return `Zoek op ${labels.join(', ')}`;
+  }
+
   get hasSelectedOptions() {
     return this.selectedInstanceOptions?.length >= 1;
   }
@@ -160,7 +165,7 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
   get filterInstancesParams() {
     return {
       page: this.pageToLoad,
-      size: 20,
+      size: 10,
       filter:
         this.searchValue && this.searchValue.trim() !== ''
           ? this.searchValue

--- a/app/components/custom-form/link-to-form-with-modal.js
+++ b/app/components/custom-form/link-to-form-with-modal.js
@@ -31,6 +31,7 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
   @tracked lastPageOfInstances;
   @tracked isLoadingMoreOptions;
   @tracked areAllInstancesFetched;
+  @tracked searchValue;
 
   constructor() {
     super(...arguments);
@@ -88,6 +89,11 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
     super.updateValidations();
   }
 
+  @action
+  filterResults(event) {
+    this.searchValue = event.target?.value;
+  }
+
   get hasSelectedOptions() {
     return this.selectedInstances?.length >= 1;
   }
@@ -129,7 +135,6 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
           };
         }),
         instance,
-        searchString: [...Object.values(instance), instance.id].join(';'),
         isSelected: !!this.selectedInstances.find(
           (o) => o.instance.id === instance.id
         ),
@@ -142,6 +147,10 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
     return {
       page: this.pageToLoad,
       size: 20,
+      filter:
+        this.searchValue && this.searchValue.trim() !== ''
+          ? this.searchValue
+          : null,
     };
   }
 
@@ -192,8 +201,10 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
     const queryParamsMap = {
       page: `page[number]=${this.filterInstancesParams.page}`,
       size: `page[size]=${this.filterInstancesParams.size}`,
+      filter: `filter=${this.filterInstancesParams.filter}`,
     };
     const queryParams = Object.keys(this.filterInstancesParams)
+      .filter((key) => this.filterInstancesParams[key])
       .map((key) => queryParamsMap[key])
       .join('&');
     const response = await fetch(

--- a/app/components/custom-form/link-to-form-with-modal.js
+++ b/app/components/custom-form/link-to-form-with-modal.js
@@ -10,11 +10,14 @@ import {
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
 import { NamedNode } from 'rdflib';
-import { task } from 'ember-concurrency';
+import { task, timeout } from 'ember-concurrency';
 
-import { API, JSON_API_TYPE } from 'frontend-lmb/utils/constants';
+import {
+  API,
+  INPUT_DEBOUNCE,
+  JSON_API_TYPE,
+} from 'frontend-lmb/utils/constants';
 import { EXT } from 'frontend-lmb/rdf/namespaces';
-
 export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
   @service store;
   @service semanticFormRepository;
@@ -93,12 +96,12 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
     super.updateValidations();
   }
 
-  @action
-  filterResults(event) {
+  filterResults = task({ restartable: true }, async (event) => {
+    await timeout(INPUT_DEBOUNCE);
     this.searchValue = event.target?.value;
     this.pageToLoad = 0;
     this.getInstances.perform();
-  }
+  });
 
   get hasSelectedOptions() {
     return this.selectedInstanceOptions?.length >= 1;

--- a/app/components/custom-form/link-to-form-with-modal.js
+++ b/app/components/custom-form/link-to-form-with-modal.js
@@ -49,8 +49,9 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
   }
 
   @action
-  onCloseModal() {
+  onCloseModal(onInteractedWithField) {
     this.isModalOpen = false;
+    onInteractedWithField?.();
   }
 
   @action

--- a/app/components/custom-form/link-to-form-with-modal.js
+++ b/app/components/custom-form/link-to-form-with-modal.js
@@ -55,10 +55,12 @@ export default class CustomFormLinkToFormWithModal extends InputFieldComponent {
 
   @action
   async selectInstance(option) {
-    // Retrieve options in store
     const matches = triplesForPath(this.storeOptions, true).values;
     if (option.isSelected) {
-      // remove
+      const toRemove = this.selectedInstances.find(
+        (o) => o.instance.uri == option.instance.uri
+      );
+      this.selectedInstances.removeObject(toRemove);
     } else {
       this.selectedInstances.pushObject(option);
     }

--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -1,10 +1,14 @@
 {{#unless this.loading}}
-  {{#if this.formState.canEditFormDefinition}}
+  {{#if (and this.editableFormsEnabled this.formState.canEditFormDefinition)}}
     <div class="au-u-flex au-u-flex--end">
       <AuLink
         @model={{@form.id}}
         @route="custom-forms.instances.definition"
-        @query={{hash fullScreenEdit=true isFormExtension=@isFormExtension instanceId=@instanceId}}
+        @query={{hash
+          fullScreenEdit=true
+          isFormExtension=@isFormExtension
+          instanceId=@instanceId
+        }}
         @icon="pencil"
         class=""
       >

--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -13,15 +13,17 @@
   >
     {{#if this.editableFormsEnabled}}
       {{#if this.formState.isAddFieldShownInForm}}
-        <AuButton
-          @skin="secondary"
-          @width="block"
-          @icon="plus"
-          {{on "click" (fn (mut this.showEditModal) true)}}
-          class="au-u-margin-bottom au-u-margin-top"
-        >
-          Voeg een veld toe
-        </AuButton>
+        <div class="add-custom-field">
+          <AuButton
+            @skin="secondary"
+            @width="block"
+            @icon="plus"
+            {{on "click" (fn (mut this.showEditModal) true)}}
+            class="au-u-margin-bottom au-u-margin-top"
+          >
+            Voeg een veld toe
+          </AuButton>
+        </div>
       {{/if}}
 
       {{yield}}

--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -4,7 +4,7 @@
       <AuLink
         @model={{@form.id}}
         @route="custom-forms.instances.definition"
-        @query={{hash fullScreenEdit=true}}
+        @query={{hash fullScreenEdit=true isFormExtension=@isFormExtension instanceId=@instanceId}}
         @icon="pencil"
         class=""
       >

--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -34,7 +34,6 @@
         @onCloseModal={{this.formContext.onFormUpdate}}
         @form={{this.formContext.formDefinition}}
         @field={{@field}}
-        @isForFormExtension={{this.formContext.isForFormExtension}}
       />
     {{/if}}
     {{yield}}

--- a/app/components/editable-form.hbs
+++ b/app/components/editable-form.hbs
@@ -1,4 +1,17 @@
 {{#unless this.loading}}
+  {{#if this.formState.canEditFormDefinition}}
+    <div class="au-u-flex au-u-flex--end">
+      <AuLink
+        @model={{@form.id}}
+        @route="custom-forms.instances.definition"
+        @query={{hash fullScreenEdit=true}}
+        @icon="pencil"
+        class=""
+      >
+        Bewerk formulier definitie
+      </AuLink>
+    </div>
+  {{/if}}
   <SemanticForms::Instance
     @show={{@isReadOnly}}
     @instanceId={{@instanceId}}
@@ -12,7 +25,8 @@
     @saveTitle={{@saveTitle}}
   >
     {{#if this.editableFormsEnabled}}
-      {{#if this.formState.isAddFieldShownInForm}}
+      {{#if this.formState.isEditFormDefinitionForm}}
+        {{! TODO this would be handy if it was in the <CustomForm::EditCustomField> component }}
         <div class="add-custom-field">
           <AuButton
             @skin="secondary"

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -8,12 +8,11 @@ import { provide } from 'ember-provide-consume-context';
 import { trackedFunction } from 'reactiveweb/function';
 import { use } from 'ember-resources';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
-import { NamedNode, Literal } from 'rdflib';
 
 import { API } from 'frontend-lmb/utils/constants';
 import { showErrorToast } from 'frontend-lmb/utils/toasts';
-import { EXT } from 'frontend-lmb/rdf/namespaces';
 import { SOURCE_GRAPH } from 'frontend-lmb/utils/constants';
+import { isCustomForm } from 'frontend-lmb/utils/form-properties';
 
 export default class EditableFormComponent extends Component {
   @use(getFieldsForForm) getFieldsForForm;
@@ -98,16 +97,7 @@ function getFieldsForForm() {
 
       const forkingStore = new ForkingStore();
       forkingStore.parse(this.currentForm.formTtl, SOURCE_GRAPH, 'text/turtle');
-      const isCustomForm = forkingStore.any(
-        null,
-        EXT('isCustomForm'),
-        new Literal(
-          'true',
-          null,
-          new NamedNode('http://www.w3.org/2001/XMLSchema#boolean')
-        )
-      );
-      if (!isCustomForm) {
+      if (!isCustomForm(forkingStore)) {
         return [];
       }
 

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -24,14 +24,10 @@ export default class EditableFormComponent extends Component {
   @service features;
 
   @tracked showEditModal;
-  @tracked clickedField;
 
   constructor() {
     super(...arguments);
     this.updateForm();
-    if (this.args.selectedField) {
-      this.clickedField = this.args.selectedField;
-    }
   }
 
   async updateForm() {
@@ -52,17 +48,18 @@ export default class EditableFormComponent extends Component {
     return this.getFieldsForForm?.value || [];
   }
 
+  get clickedField() {
+    return this.args.selectedField;
+  }
+
   @action
   async setClickedField(fieldModel) {
-    this.clickedField = fieldModel;
+    let field = fieldModel;
     if (this.args.onFieldSelected && fieldModel) {
       await this.getFieldsForForm.retry();
-      const field = this.fields.filter(
-        (f) => f.uri === fieldModel.uri?.value
-      )[0];
-      this.clickedField = field;
+      field = this.fields.filter((f) => f.uri === fieldModel.uri?.value)[0];
     }
-    this.args.onFieldSelected(this.clickedField);
+    this.args.onFieldSelected(field);
   }
 
   get editableFormsEnabled() {

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -95,12 +95,12 @@ function getFieldsForForm() {
         return [];
       }
 
-      const forkingStore = new ForkingStore();
-      forkingStore.parse(this.currentForm.formTtl, SOURCE_GRAPH, 'text/turtle');
-      const isCustomForm = forkingStore.any(null, EXT('isCustomForm'), true);
-      if (!isCustomForm) {
-        return [];
-      }
+      // const forkingStore = new ForkingStore();
+      // forkingStore.parse(this.currentForm.formTtl, SOURCE_GRAPH, 'text/turtle');
+      // const isCustomForm = forkingStore.any(null, EXT('isCustomForm'), true);
+      // if (!isCustomForm) {
+      //   return [];
+      // }
 
       const response = await fetch(
         `${API.FORM_CONTENT_SERVICE}/custom-form/${this.currentForm.id}/fields`

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -69,6 +69,8 @@ export default class EditableFormComponent extends Component {
   @provide('form-state')
   get formState() {
     return {
+      isEditFormDefinitionForm: !!this.args.isEditFormDefinitionForm,
+      canEditFormDefinition: !!this.args.canEditFormDefinition,
       canSelectField: !!this.args.canSelectField,
       clickedField: this.clickedField,
       isReadOnly: this.args.isReadOnly,

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -7,12 +7,13 @@ import { service } from '@ember/service';
 import { provide } from 'ember-provide-consume-context';
 import { trackedFunction } from 'reactiveweb/function';
 import { use } from 'ember-resources';
+import { ForkingStore } from '@lblod/ember-submission-form-fields';
+import { NamedNode, Literal } from 'rdflib';
 
 import { API } from 'frontend-lmb/utils/constants';
 import { showErrorToast } from 'frontend-lmb/utils/toasts';
 import { EXT } from 'frontend-lmb/rdf/namespaces';
 import { SOURCE_GRAPH } from 'frontend-lmb/utils/constants';
-import { ForkingStore } from '@lblod/ember-submission-form-fields';
 
 export default class EditableFormComponent extends Component {
   @use(getFieldsForForm) getFieldsForForm;
@@ -95,12 +96,20 @@ function getFieldsForForm() {
         return [];
       }
 
-      // const forkingStore = new ForkingStore();
-      // forkingStore.parse(this.currentForm.formTtl, SOURCE_GRAPH, 'text/turtle');
-      // const isCustomForm = forkingStore.any(null, EXT('isCustomForm'), true);
-      // if (!isCustomForm) {
-      //   return [];
-      // }
+      const forkingStore = new ForkingStore();
+      forkingStore.parse(this.currentForm.formTtl, SOURCE_GRAPH, 'text/turtle');
+      const isCustomForm = forkingStore.any(
+        null,
+        EXT('isCustomForm'),
+        new Literal(
+          'true',
+          null,
+          new NamedNode('http://www.w3.org/2001/XMLSchema#boolean')
+        )
+      );
+      if (!isCustomForm) {
+        return [];
+      }
 
       const response = await fetch(
         `${API.FORM_CONTENT_SERVICE}/custom-form/${this.currentForm.id}/fields`

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -68,21 +68,10 @@ export default class EditableFormComponent extends Component {
 
   @provide('form-state')
   get formState() {
-    const canEditFieldsInlineInForm =
-      this.args.editFieldsInForm == undefined
-        ? true
-        : !!this.args.editFieldsInForm;
     return {
-      editFieldsInForm: canEditFieldsInlineInForm,
       canSelectField: !!this.args.canSelectField,
       clickedField: this.clickedField,
       isReadOnly: this.args.isReadOnly,
-      isFieldEditPencilShown:
-        canEditFieldsInlineInForm && !this.args.toReceiveUserInput,
-      isAddFieldShownInForm:
-        !this.args.toReceiveUserInput && !this.args.isReadOnly,
-      canMoveFieldsInForm:
-        !this.args.toReceiveUserInput && !this.args.isReadOnly,
     };
   }
 
@@ -93,7 +82,6 @@ export default class EditableFormComponent extends Component {
       onFieldClicked: (fieldModel) => this.setClickedField(fieldModel),
       formDefinition: this.currentForm,
       fieldsInForm: this.fields,
-      isForFormExtension: !!this.args.isForFormExtension,
     };
   }
 }

--- a/app/components/mandatarissen/mandataris-extra-info-card.hbs
+++ b/app/components/mandatarissen/mandataris-extra-info-card.hbs
@@ -57,6 +57,7 @@
       @formInitialized={{fn (mut this.formInitialized) true}}
       @customHistoryMessage={{true}}
       @canEditFormDefinition={{true}}
+      @isFormExtension={{true}}
     />
     {{#unless this.formInitialized}}
       <Skeleton::Forms::MandatarisExtraInfo />

--- a/app/components/mandatarissen/mandataris-extra-info-card.hbs
+++ b/app/components/mandatarissen/mandataris-extra-info-card.hbs
@@ -56,6 +56,7 @@
       @onSave={{this.onSave}}
       @formInitialized={{fn (mut this.formInitialized) true}}
       @customHistoryMessage={{true}}
+      @canEditFormDefinition={{true}}
     />
     {{#unless this.formInitialized}}
       <Skeleton::Forms::MandatarisExtraInfo />

--- a/app/components/mandatarissen/mandataris-extra-info-card.hbs
+++ b/app/components/mandatarissen/mandataris-extra-info-card.hbs
@@ -56,7 +56,6 @@
       @onSave={{this.onSave}}
       @formInitialized={{fn (mut this.formInitialized) true}}
       @customHistoryMessage={{true}}
-      @isForFormExtension={{true}}
     />
     {{#unless this.formInitialized}}
       <Skeleton::Forms::MandatarisExtraInfo />

--- a/app/components/persoon/extra-info-card.hbs
+++ b/app/components/persoon/extra-info-card.hbs
@@ -54,6 +54,8 @@
       @onSave={{this.onSave}}
       @formInitialized={{fn (mut this.formInitialized) true}}
       @customHistoryMessage={{true}}
+      @canEditFormDefinition={{true}}
+      @isFormExtension={{true}}
     />
     {{#unless this.formInitialized}}
       <Skeleton::Forms::MandatarisExtraInfo />

--- a/app/components/persoon/extra-info-card.hbs
+++ b/app/components/persoon/extra-info-card.hbs
@@ -30,7 +30,6 @@
         @onSave={{this.noop}}
         @formInitialized={{fn (mut this.formInitialized) true}}
         @customHistoryMessage={{true}}
-        @isForFormExtension={{true}}
       />
       {{#unless this.formInitialized}}
         <Skeleton::Forms::MandatarisExtraInfo />
@@ -55,7 +54,6 @@
       @onSave={{this.onSave}}
       @formInitialized={{fn (mut this.formInitialized) true}}
       @customHistoryMessage={{true}}
-      @isForFormExtension={{true}}
     />
     {{#unless this.formInitialized}}
       <Skeleton::Forms::MandatarisExtraInfo />

--- a/app/components/rdf-input-fields/beleidsdomein-code-selector.hbs
+++ b/app/components/rdf-input-fields/beleidsdomein-code-selector.hbs
@@ -1,52 +1,65 @@
-{{#if @show}}
-  <AuLabel class="au-c-description-label">
-    {{@field.label}}
-  </AuLabel>
-  <p class="au-c-description-value">
-    {{#each this.selected as |beleidsdomein index|}}
-      {{beleidsdomein.label}}
-      {{#if (not-eq index (dec this.selected.length))}}
-        ,
-      {{/if}}
-    {{/each}}
-  </p>
-{{else}}
-  {{#if this.shouldRender}}
-    {{#unless @inTable}}
-      <AuLabel
-        @error={{this.hasErrors}}
-        @required={{this.isRequired}}
-        @warning={{this.hasWarnings}}
-        for={{this.inputId}}
-      >
-        {{@field.label}}
-      </AuLabel>
-    {{/unless}}
-    <div class={{if this.hasErrors "ember-power-select--error"}}>
-      <Mandatarissen::ConceptSelectorWithCreate
-        @multiple={{true}}
-        @type={{@field.options.type}}
-        @conceptScheme={{this.conceptScheme}}
-        @search={{this.search}}
-        @searchEnabled={{this.searchEnabled}}
-        @selected={{this.selected}}
-        @options={{this.options}}
-        @onClose={{fn (mut this.hasBeenFocused) true}}
-        @onChange={{this.updateSelection}}
-        @onCreate={{this.add}}
-        @disabled={{@show}}
-        as |concept|
-      >
-        {{concept.label}}
-      </Mandatarissen::ConceptSelectorWithCreate>
-    </div>
+<RdfInputFields::StandardFieldWrapper
+  @inline={{true}}
+  @field={{@field}}
+  @form={{@form}}
+  @graphs={{@graphs}}
+  @formStore={{@formStore}}
+  as |wrapper|
+>
+  {{#if @show}}
+    <AuLabel class="au-c-description-label">
+      {{@field.label}}
+    </AuLabel>
+    <p class="au-c-description-value">
+      {{#each this.selected as |beleidsdomein index|}}
+        {{beleidsdomein.label}}
+        {{#if (not-eq index (dec this.selected.length))}}
+          ,
+        {{/if}}
+      {{/each}}
+    </p>
+  {{else}}
+    {{#if this.shouldRender}}
+      <div class={{if this.hasErrors "ember-power-select--error"}}>
+        <Mandatarissen::ConceptSelectorWithCreate
+          @multiple={{true}}
+          @type={{@field.options.type}}
+          @conceptScheme={{this.conceptScheme}}
+          @search={{this.search}}
+          @searchEnabled={{this.searchEnabled}}
+          @selected={{this.selected}}
+          @options={{this.options}}
+          @onClose={{fn (mut this.hasBeenFocused) true}}
+          @onChange={{this.updateSelection}}
+          @onCreate={{this.add}}
+          @disabled={{@show}}
+          as |concept|
+        >
+          {{concept.label}}
+        </Mandatarissen::ConceptSelectorWithCreate>
+      </div>
 
-    {{#each this.errors as |error|}}
-      <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
-    {{/each}}
+      {{#each this.errors as |error|}}
+        <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
+      {{/each}}
 
-    {{#each this.warnings as |warning|}}
-      <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
-    {{/each}}
+      {{#each this.warnings as |warning|}}
+        <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
+      {{/each}}
+    {{else}}
+      <RdfInputFields::ConceptSchemeMultiSelector
+        @showLabel={{false}}
+        @showFieldLabel={{false}}
+        @field={{@field}}
+        @form={{@form}}
+        @formStore={{@formStore}}
+        @graphs={{@graphs}}
+        @sourceNode={{@sourceNode}}
+        @forceShowErrors={{@forceShowErrors}}
+        @cacheConditionals={{@cacheConditionals}}
+        @show={{@show}}
+        @onInteractedWithField={{wrapper.onInteractedWithField}}
+      />
+    {{/if}}
   {{/if}}
-{{/if}}
+</RdfInputFields::StandardFieldWrapper>

--- a/app/components/rdf-input-fields/beleidsdomein-code-selector.hbs
+++ b/app/components/rdf-input-fields/beleidsdomein-code-selector.hbs
@@ -4,7 +4,6 @@
   @form={{@form}}
   @graphs={{@graphs}}
   @formStore={{@formStore}}
-  as |wrapper|
 >
   {{#if @show}}
     <AuLabel class="au-c-description-label">
@@ -46,20 +45,6 @@
       {{#each this.warnings as |warning|}}
         <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
       {{/each}}
-    {{else}}
-      <RdfInputFields::ConceptSchemeMultiSelector
-        @showLabel={{false}}
-        @showFieldLabel={{false}}
-        @field={{@field}}
-        @form={{@form}}
-        @formStore={{@formStore}}
-        @graphs={{@graphs}}
-        @sourceNode={{@sourceNode}}
-        @forceShowErrors={{@forceShowErrors}}
-        @cacheConditionals={{@cacheConditionals}}
-        @show={{@show}}
-        @onInteractedWithField={{wrapper.onInteractedWithField}}
-      />
     {{/if}}
   {{/if}}
 </RdfInputFields::StandardFieldWrapper>

--- a/app/components/rdf-input-fields/crud-custom-field-modal.hbs
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.hbs
@@ -128,7 +128,7 @@
         {{#if this.isCustomForm}}
           <AuFormRow>
             <AuToggleSwitch
-              @disabled={{@show}}
+              @disabled={{this.isShowInSummaryToggleDisabled}}
               @checked={{this.isShownInSummary}}
               @onChange={{this.toggleShowInSummary}}
             >Toon in samenvatting

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -20,6 +20,7 @@ import { isCustomForm } from 'frontend-lmb/utils/form-properties';
 import { NamedNode } from 'rdflib';
 import { trackedFunction } from 'reactiveweb/function';
 import { use } from 'ember-resources';
+import LibraryEntryModel from 'frontend-lmb/models/library-entry';
 
 export default class RdfInputFieldCrudCustomFieldModalComponent extends Component {
   @consume('form-context') formContext;
@@ -35,14 +36,10 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
   @tracked isShownInSummary;
   @tracked wantsToRemove;
 
-  customFieldEntry = this.store.createRecord('library-entry', {
-    name: 'Eigen veld',
-  });
-
   @tracked displayTypes = [];
 
   @tracked fieldName;
-  @tracked libraryFieldType = this.customFieldEntry;
+  @tracked libraryFieldType;
   @tracked displayType;
   @tracked conceptScheme;
   @tracked conceptSchemeOnLoad;
@@ -50,6 +47,8 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
 
   constructor() {
     super(...arguments);
+
+    this.libraryFieldType = LibraryEntryModel.ensureFakeEntry(this.store);
 
     let withValue = TEXT_CUSTOM_DISPLAY_TYPE;
     if (!this.args.isCreating) {
@@ -342,7 +341,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
 
   get canSelectTypeForEntry() {
     if (this.args.isCreating) {
-      return this.libraryFieldType === this.customFieldEntry;
+      return this.libraryFieldType.isNew; // so the fake one we created
     }
 
     return !LIBRARY_ENTREES.includes(this.libraryEntryUri);
@@ -367,6 +366,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
 
 function getLibraryFieldOptions() {
   return trackedFunction(async () => {
+    const customFieldEntry = LibraryEntryModel.ensureFakeEntry(this.store);
     const allOptions = await this.store.query('library-entry', {
       sort: 'name',
       include: 'display-type',
@@ -377,6 +377,6 @@ function getLibraryFieldOptions() {
     const unused = allOptions.filter((entry) => {
       return entry.uri && usedOptions.indexOf(entry.uri) < 0;
     });
-    return [this.customFieldEntry, ...unused];
+    return [customFieldEntry, ...unused];
   });
 }

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -13,7 +13,6 @@ import { FIELD_OPTION, FORM, EXT, PROV } from 'frontend-lmb/rdf/namespaces';
 import { showErrorToast } from 'frontend-lmb/utils/toasts';
 import {
   LIBRARY_ENTREES,
-  LINK_TO_FORM_CUSTOM_DISPLAY_TYPE,
   TEXT_CUSTOM_DISPLAY_TYPE,
 } from 'frontend-lmb/utils/well-known-uris';
 import { Literal, NamedNode } from 'rdflib';
@@ -68,14 +67,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
         sort: 'label',
       })
       .then((displayTypes) => {
-        if (this.args.isForFormExtension) {
-          const allowedTypes = displayTypes.filter(
-            (type) => type.uri !== LINK_TO_FORM_CUSTOM_DISPLAY_TYPE
-          );
-          this.displayTypes = allowedTypes;
-        } else {
-          this.displayTypes = displayTypes;
-        }
+        this.displayTypes = displayTypes;
         this.displayType = this.displayTypes.find((t) => t.uri === withValue);
       });
   }

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -15,7 +15,9 @@ import {
   LIBRARY_ENTREES,
   TEXT_CUSTOM_DISPLAY_TYPE,
 } from 'frontend-lmb/utils/well-known-uris';
-import { Literal, NamedNode } from 'rdflib';
+import { isCustomForm } from 'frontend-lmb/utils/form-properties';
+
+import { NamedNode } from 'rdflib';
 import { trackedFunction } from 'reactiveweb/function';
 import { use } from 'ember-resources';
 
@@ -273,15 +275,8 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
   get isCustomForm() {
     const forkingStore = this.forkingStore;
     return (
-      forkingStore.any(
-        null,
-        EXT('isCustomForm'),
-        new Literal(
-          'true',
-          null,
-          new NamedNode('http://www.w3.org/2001/XMLSchema#boolean')
-        )
-      ) && !forkingStore.any(null, EXT('extendsForm'), null, SOURCE_GRAPH)
+      isCustomForm(forkingStore) &&
+      !forkingStore.any(null, EXT('extendsForm'), null, SOURCE_GRAPH)
     );
   }
 

--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -107,6 +107,10 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
     return models.at(0) ?? null;
   }
 
+  get isShowInSummaryToggleDisabled() {
+    return this.args.show || this.displayType?.isLinkToForm;
+  }
+
   get deleteWillLoseData() {
     return this.libraryFieldType?.uri !== null;
   }

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -12,16 +12,14 @@
               @required={{this.isRequired}}
               @error={{this.hasErrors}}
             >{{this.title}}</AuLabel>
-            {{#if this.formState.isFieldEditPencilShown}}
-              <AuButton
-                @skin="link-secondary"
-                @icon="pencil"
-                @hideText={{true}}
-                {{on "click" (fn (mut this.showModal) true)}}
-              >
-                Pas aan
-              </AuButton>
-            {{/if}}
+            <AuButton
+              @skin="link-secondary"
+              @icon="pencil"
+              @hideText={{true}}
+              {{on "click" (fn (mut this.showModal) true)}}
+            >
+              Pas aan
+            </AuButton>
           {{/unless}}
         </div>
         <div
@@ -39,26 +37,24 @@
           </div>
         </div>
       </div>
-      {{#if this.formState.canMoveFieldsInForm}}
-        <div class="au-u-flex au-u-flex--column au-u-flex--vertical-center">
-          <AuButton
-            @skin="naked"
-            @icon="nav-up"
-            @hideText={{true}}
-            {{on "click" (perform this.moveField "up")}}
-          >
-            Naar boven
-          </AuButton>
-          <AuButton
-            @skin="naked"
-            @icon="nav-down"
-            @hideText={{true}}
-            {{on "click" (perform this.moveField "down")}}
-          >
-            Naar onder
-          </AuButton>
-        </div>
-      {{/if}}
+      <div class="au-u-flex au-u-flex--column au-u-flex--vertical-center">
+        <AuButton
+          @skin="naked"
+          @icon="nav-up"
+          @hideText={{true}}
+          {{on "click" (perform this.moveField "up")}}
+        >
+          Naar boven
+        </AuButton>
+        <AuButton
+          @skin="naked"
+          @icon="nav-down"
+          @hideText={{true}}
+          {{on "click" (perform this.moveField "down")}}
+        >
+          Naar onder
+        </AuButton>
+      </div>
     </div>
   </div>
 {{/unless}}
@@ -71,5 +67,4 @@
   @field={{@field}}
   @isRequiredField={{this.isRequired}}
   @isShownInSummary={{this.isShownInSummary}}
-  @isForFormExtension={{this.formContext.isForFormExtension}}
 />

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -24,9 +24,7 @@
             >In samenvatting</AuPill>
           {{/if}}
         </div>
-        <div
-          class="au-u-flex au-u-flex--between au-u-flex--vertical-start au-u-flex--spaced-tiny"
-        >
+        <div class={{this.styleClassForContainerAroundField}}>
           <div class="flex-grow">
             {{#if this.isFieldReadOnly}}
               <ReadOnlyFieldForDisplayType

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -13,6 +13,16 @@
               @error={{this.hasErrors}}
             >{{this.title}}</AuLabel>
           {{/unless}}
+          {{#if
+            (and
+              this.formState.isEditFormDefinitionForm this.isFieldShownInSummary
+            )
+          }}
+            <AuPill
+              class="au-u-margin-left-tiny au-u-margin-bottom-tiny"
+              @skin="link"
+            >In samenvatting</AuPill>
+          {{/if}}
         </div>
         <div
           class="au-u-flex au-u-flex--between au-u-flex--vertical-start au-u-flex--spaced-tiny"

--- a/app/components/rdf-input-fields/custom-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/custom-field-wrapper.hbs
@@ -12,14 +12,6 @@
               @required={{this.isRequired}}
               @error={{this.hasErrors}}
             >{{this.title}}</AuLabel>
-            <AuButton
-              @skin="link-secondary"
-              @icon="pencil"
-              @hideText={{true}}
-              {{on "click" (fn (mut this.showModal) true)}}
-            >
-              Pas aan
-            </AuButton>
           {{/unless}}
         </div>
         <div
@@ -37,34 +29,26 @@
           </div>
         </div>
       </div>
-      <div class="au-u-flex au-u-flex--column au-u-flex--vertical-center">
-        <AuButton
-          @skin="naked"
-          @icon="nav-up"
-          @hideText={{true}}
-          {{on "click" (perform this.moveField "up")}}
-        >
-          Naar boven
-        </AuButton>
-        <AuButton
-          @skin="naked"
-          @icon="nav-down"
-          @hideText={{true}}
-          {{on "click" (perform this.moveField "down")}}
-        >
-          Naar onder
-        </AuButton>
-      </div>
+      {{#if (and this.formState.isEditFormDefinitionForm this.isFieldSelected)}}
+        <div class="au-u-flex au-u-flex--column au-u-flex--vertical-center">
+          <AuButton
+            @skin="naked"
+            @icon="nav-up"
+            @hideText={{true}}
+            {{on "click" (perform this.moveField "up")}}
+          >
+            Naar boven
+          </AuButton>
+          <AuButton
+            @skin="naked"
+            @icon="nav-down"
+            @hideText={{true}}
+            {{on "click" (perform this.moveField "down")}}
+          >
+            Naar onder
+          </AuButton>
+        </div>
+      {{/if}}
     </div>
   </div>
 {{/unless}}
-
-<RdfInputFields::CrudCustomFieldModal
-  @isCreating={{false}}
-  @showModal={{this.showModal}}
-  @onCloseModal={{fn (mut this.showModal) false}}
-  @form={{@form}}
-  @field={{@field}}
-  @isRequiredField={{this.isRequired}}
-  @isShownInSummary={{this.isShownInSummary}}
-/>

--- a/app/components/rdf-input-fields/custom-field-wrapper.js
+++ b/app/components/rdf-input-fields/custom-field-wrapper.js
@@ -16,6 +16,7 @@ import {
   PERSON_CUSTOM_DISPLAY_TYPE,
   PERSON_MULTI_CUSTOM_DISPLAY_TYPE,
 } from 'frontend-lmb/utils/well-known-uris';
+import { isFieldShownInSummmary } from 'frontend-lmb/utils/form-properties';
 
 export default class RdfInputFieldsCustomFieldWrapperComponent extends Component {
   @consume('form-context') formContext;
@@ -102,6 +103,13 @@ export default class RdfInputFieldsCustomFieldWrapperComponent extends Component
       this.formContext.onFieldClicked(null);
     }
   });
+
+  get isFieldShownInSummary() {
+    return isFieldShownInSummmary(
+      this.storeOptions.store,
+      this.args.field?.uri
+    );
+  }
 
   // From ember-submission-form-fields component: input-field.js
   // We cannot access these properties as they are in the component itself and this is just a wrapper

--- a/app/components/rdf-input-fields/custom-field-wrapper.js
+++ b/app/components/rdf-input-fields/custom-field-wrapper.js
@@ -57,6 +57,17 @@ export default class RdfInputFieldsCustomFieldWrapperComponent extends Component
     return classes.join(' ');
   }
 
+  get styleClassForContainerAroundField() {
+    const base =
+      'au-u-flex au-u-flex--between au-u-flex--vertical-start au-u-flex--spaced-tiny';
+
+    if (this.hasErrors && this.args.showErrorLineNextToField) {
+      return base + ' wrapped-field--error';
+    }
+
+    return base;
+  }
+
   @action
   interactedWithField() {
     this.hasErrors = this.errors.length;

--- a/app/components/rdf-input-fields/custom-field-wrapper.js
+++ b/app/components/rdf-input-fields/custom-field-wrapper.js
@@ -21,7 +21,6 @@ export default class RdfInputFieldsCustomFieldWrapperComponent extends Component
   @consume('form-context') formContext;
   @consume('form-state') formState;
 
-  @tracked showModal;
   @tracked hasErrors;
 
   get title() {

--- a/app/components/rdf-input-fields/standard-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/standard-field-wrapper.hbs
@@ -6,7 +6,7 @@
       {{/unless}}
     </div>
     <div
-      class="au-u-flex au-u-flex--between au-u-flex--vertical-start au-u-flex--spaced-tiny au-u-margin-right"
+      class="au-u-flex au-u-flex--between au-u-flex--vertical-start au-u-flex--spaced-tiny au-u-margin-right-small"
     >
       <div class="flex-grow">
         {{yield}}

--- a/app/components/rdf-input-fields/standard-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/standard-field-wrapper.hbs
@@ -9,7 +9,14 @@
       class="au-u-flex au-u-flex--between au-u-flex--vertical-start au-u-flex--spaced-tiny au-u-margin-right-small"
     >
       <div class="flex-grow">
-        {{yield}}
+        {{#if this.isFieldReadOnly}}
+          <ReadOnlyFieldForDisplayType
+            @field={{@field}}
+            @storeOptions={{this.storeOptions}}
+          />
+        {{else}}
+          {{yield}}
+        {{/if}}
       </div>
     </div>
   </div>

--- a/app/components/rdf-input-fields/standard-field-wrapper.hbs
+++ b/app/components/rdf-input-fields/standard-field-wrapper.hbs
@@ -1,0 +1,16 @@
+{{#unless this.removed}}
+  <div class="standard-form-field">
+    <div class="au-u-flex au-u-flex--row">
+      {{#unless this.formState.isReadOnly}}
+        <AuLabel @required={{this.isRequired}}>{{this.title}}</AuLabel>
+      {{/unless}}
+    </div>
+    <div
+      class="au-u-flex au-u-flex--between au-u-flex--vertical-start au-u-flex--spaced-tiny au-u-margin-right"
+    >
+      <div class="flex-grow">
+        {{yield}}
+      </div>
+    </div>
+  </div>
+{{/unless}}

--- a/app/components/rdf-input-fields/standard-field-wrapper.js
+++ b/app/components/rdf-input-fields/standard-field-wrapper.js
@@ -1,0 +1,87 @@
+import Component from '@glimmer/component';
+
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+import { consume } from 'ember-provide-consume-context';
+import { validationsForFieldWithType } from '@lblod/submission-form-helpers';
+
+import {
+  ADRES_CUSTOM_DISPLAY_TYPE,
+  PERSON_CUSTOM_DISPLAY_TYPE,
+  PERSON_MULTI_CUSTOM_DISPLAY_TYPE,
+} from 'frontend-lmb/utils/well-known-uris';
+
+export default class RdfInputFieldsStandardFieldWrapperComponent extends Component {
+  @consume('form-context') formContext;
+  @consume('form-state') formState;
+
+  @tracked showModal;
+  @tracked hasErrors;
+
+  get title() {
+    return this.args.field?.label;
+  }
+
+  get isFieldReadOnly() {
+    return (
+      this.formState?.isReadOnly &&
+      ![
+        ADRES_CUSTOM_DISPLAY_TYPE,
+        PERSON_CUSTOM_DISPLAY_TYPE,
+        PERSON_MULTI_CUSTOM_DISPLAY_TYPE,
+      ].includes(this.args.field.displayType)
+    );
+  }
+
+  get isFieldSelected() {
+    return this.formState?.clickedField?.uri === this.args.field.uri.value;
+  }
+
+  @action
+  interactedWithField() {
+    this.hasErrors = this.errors.length;
+  }
+
+  @action
+  passOnClickedField() {
+    if (!this.formState?.canSelectField) {
+      return;
+    }
+
+    let clickedField = null;
+    if (this.formState.clickedField?.uri !== this.args.field.uri.value) {
+      clickedField = this.args.field;
+    }
+    this.formContext.onFieldClicked(clickedField);
+  }
+
+  // From ember-submission-form-fields component: input-field.js
+  // We cannot access these properties as they are in the component itself and this is just a wrapper
+  get isRequired() {
+    return (
+      !this.args.show &&
+      this.constraints.some(
+        (constraint) =>
+          constraint.type.value ===
+          'http://lblod.data.gift/vocabularies/forms/RequiredConstraint'
+      )
+    );
+  }
+
+  get constraints() {
+    return validationsForFieldWithType(this.args.field.uri, this.storeOptions);
+  }
+
+  get storeOptions() {
+    return {
+      formGraph: this.args.graphs.formGraph,
+      sourceGraph: this.args.graphs.sourceGraph,
+      metaGraph: this.args.graphs.metaGraph,
+      sourceNode: this.args.sourceNode,
+      store: this.args.formStore,
+      path: this.args.field.rdflibPath,
+      scope: this.args.field.rdflibScope,
+    };
+  }
+}

--- a/app/components/rdf-input-fields/standard-string-input.hbs
+++ b/app/components/rdf-input-fields/standard-string-input.hbs
@@ -1,0 +1,24 @@
+<RdfInputFields::StandardFieldWrapper
+  @inline={{true}}
+  @field={{@field}}
+  @form={{@form}}
+  @graphs={{@graphs}}
+  @formStore={{@formStore}}
+>
+  {{#if @show}}
+    <AuLabel class="au-c-description-label">
+      {{@field.label}}
+    </AuLabel>
+  {{/if}}
+  <RdfInputFields::Input
+    @inTable={{true}}
+    @field={{@field}}
+    @form={{@form}}
+    @formStore={{@formStore}}
+    @graphs={{@graphs}}
+    @sourceNode={{@sourceNode}}
+    @forceShowErrors={{@forceShowErrors}}
+    @cacheConditionals={{@cacheConditionals}}
+    @show={{@show}}
+  />
+</RdfInputFields::StandardFieldWrapper>

--- a/app/components/read-only-field-for-display-type.hbs
+++ b/app/components/read-only-field-for-display-type.hbs
@@ -1,10 +1,8 @@
 <span ...attributes>
-  {{#if this.value}}
-    <div class="au-u-flex au-u-flex--column">
-      <AuLabel class="au-c-description-label">
-        {{@field.label}}
-      </AuLabel>
-      <p class="au-c-description-value">{{this.value}}</p>
-    </div>
-  {{/if}}
+  <div class="au-u-flex au-u-flex--column">
+    <AuLabel class="au-c-description-label">
+      {{@field.label}}
+    </AuLabel>
+    <p class="au-c-description-value">{{or this.value "Onbekend"}}</p>
+  </div>
 </span>

--- a/app/components/read-only-field-for-display-type.js
+++ b/app/components/read-only-field-for-display-type.js
@@ -4,11 +4,19 @@ import { triplesForPath } from '@lblod/submission-form-helpers';
 import { isNamedNode, Literal } from 'rdflib';
 import moment from 'moment';
 
-import { DATE_CUSTOM_DISPLAY_TYPE } from 'frontend-lmb/utils/well-known-uris';
+import {
+  DATE_CUSTOM_DISPLAY_TYPE,
+  LINK_TO_FORM_CUSTOM_DISPLAY_TYPE,
+} from 'frontend-lmb/utils/well-known-uris';
 
 export default class ReadOnlyFieldForDisplayType extends Component {
   get value() {
     const matches = triplesForPath(this.args.storeOptions);
+
+    if (this.args.field.displayType === LINK_TO_FORM_CUSTOM_DISPLAY_TYPE) {
+      return `${matches.values.length ?? 0} link(s)`;
+    }
+
     const firstMatch = matches.values?.at(0);
     if (!firstMatch || isNamedNode(firstMatch)) {
       return null;

--- a/app/components/table-pagination.hbs
+++ b/app/components/table-pagination.hbs
@@ -1,0 +1,28 @@
+<div class="au-u-flex au-u-flex--between au-u-flex--no-wrap au-u-padding-small">
+  <p class="au-u-muted">
+    <span class="au-u-medium">{{this.page}}</span>
+    van
+    {{this.totalItems}}
+  </p>
+  <AuList @direction="horizontal" @divider={{true}} as |Item|>
+    <Item>
+      <AuButton
+        @skin="link"
+        @icon="chevron-left"
+        {{on "click" this.onClickPrevious}}
+      >
+        vorige
+      </AuButton>
+    </Item>
+    <Item>
+      <AuButton
+        @skin="link"
+        @icon="chevron-right"
+        @iconAlignment="right"
+        {{on "click" this.onClickNext}}
+      >
+        volgende
+      </AuButton>
+    </Item>
+  </AuList>
+</div>

--- a/app/components/table-pagination.hbs
+++ b/app/components/table-pagination.hbs
@@ -5,24 +5,28 @@
     {{this.totalItems}}
   </p>
   <AuList @direction="horizontal" @divider={{true}} as |Item|>
-    <Item>
-      <AuButton
-        @skin="link"
-        @icon="chevron-left"
-        {{on "click" this.onClickPrevious}}
-      >
-        vorige
-      </AuButton>
-    </Item>
-    <Item>
-      <AuButton
-        @skin="link"
-        @icon="chevron-right"
-        @iconAlignment="right"
-        {{on "click" this.onClickNext}}
-      >
-        volgende
-      </AuButton>
-    </Item>
+    {{#unless this.isPreviousButtonHidden}}
+      <Item>
+        <AuButton
+          @skin="link"
+          @icon="chevron-left"
+          {{on "click" this.onClickPrevious}}
+        >
+          vorige
+        </AuButton>
+      </Item>
+    {{/unless}}
+    {{#unless this.isNextButtonHidden}}
+      <Item>
+        <AuButton
+          @skin="link"
+          @icon="chevron-right"
+          @iconAlignment="right"
+          {{on "click" this.onClickNext}}
+        >
+          volgende
+        </AuButton>
+      </Item>
+    {{/unless}}
   </AuList>
 </div>

--- a/app/components/table-pagination.js
+++ b/app/components/table-pagination.js
@@ -4,12 +4,15 @@ import { action } from '@ember/object';
 
 export default class TablePagination extends Component {
   get page() {
-    let items = this.currentPage * this.itemsPerPage;
-    if (items === 0) {
-      items = this.itemsPerPage;
+    const multiplierItems = this.currentPage + 1;
+    let topItems = multiplierItems * this.itemsPerPage;
+    const bottomItems = topItems - this.itemsPerPage;
+
+    if (topItems > this.totalItems) {
+      topItems = this.totalItems;
     }
 
-    return `${this.currentPage} - ${items}`;
+    return `${bottomItems} - ${topItems}`;
   }
 
   get totalItems() {
@@ -45,7 +48,15 @@ export default class TablePagination extends Component {
       return this.currentPage + 1;
     }
 
-    return this.lastPage;
+    return this.args.metadata?.pagination?.next?.number ?? this.lastPage;
+  }
+
+  get isPreviousButtonHidden() {
+    return this.currentPage === this.firstPage;
+  }
+
+  get isNextButtonHidden() {
+    return this.currentPage === this.lastPage;
   }
 
   @action

--- a/app/components/table-pagination.js
+++ b/app/components/table-pagination.js
@@ -1,0 +1,60 @@
+import Component from '@glimmer/component';
+
+import { action } from '@ember/object';
+
+export default class TablePagination extends Component {
+  get page() {
+    let items = this.currentPage * this.itemsPerPage;
+    if (items === 0) {
+      items = this.itemsPerPage;
+    }
+
+    return `${this.currentPage} - ${items}`;
+  }
+
+  get totalItems() {
+    return this.args.metadata?.count || null;
+  }
+
+  get currentPage() {
+    return this.args.metadata?.pagination?.self?.number || this.firstPage;
+  }
+
+  get itemsPerPage() {
+    return this.args.metadata?.pagination?.self?.size || 20;
+  }
+
+  get firstPage() {
+    return this.args.metadata?.pagination?.first?.number || 0;
+  }
+
+  get lastPage() {
+    return this.args.metadata?.pagination?.last?.number || this.firstPage;
+  }
+
+  get previousPage() {
+    if (this.currentPage - 1 >= this.firstPage) {
+      return this.currentPage - 1;
+    }
+
+    return this.firstPage;
+  }
+
+  get nextPage() {
+    if (this.currentPage + 1 <= this.lastPage) {
+      return this.currentPage + 1;
+    }
+
+    return this.lastPage;
+  }
+
+  @action
+  onClickPrevious() {
+    this.args.onClickPrevious?.({ previousPage: this.previousPage });
+  }
+
+  @action
+  onClickNext() {
+    this.args.onClickNext?.({ nextPage: this.nextPage });
+  }
+}

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -46,6 +46,10 @@ export default class CustomFormsInstancesDefinitionController extends Controller
 
   @action
   setSelectedField(field) {
+    if (!field) {
+      return;
+    }
+
     this.selectedField = field;
   }
 
@@ -65,7 +69,10 @@ export default class CustomFormsInstancesDefinitionController extends Controller
 
   @action
   updateSelectedFieldData(fields) {
-    if (this.selectedField) {
+    if (
+      this.selectedField &&
+      fields.map((f) => f.uri).includes(this.selectedField.uri)
+    ) {
       this.selectedField = fields.filter(
         (f) => f.uri === this.selectedField.uri
       )[0];

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { consume } from 'ember-provide-consume-context';
 import { timeout } from 'ember-concurrency';
+import { isCustomDisplayType } from 'frontend-lmb/models/display-type';
 
 export default class CustomFormsInstancesDefinitionController extends Controller {
   @consume('form-context') formContext;
@@ -69,7 +70,9 @@ export default class CustomFormsInstancesDefinitionController extends Controller
         (f) => f.uri === this.selectedField.uri
       )[0];
     } else {
-      this.selectedField = fields[0] || null;
+      this.selectedField = fields.filter((f) =>
+        isCustomDisplayType(f.displayType)
+      )?.[0];
     }
     this.isShownInSummaryAddedToFields = fields.every(
       (f) => !f.isShownInSummary

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -67,6 +67,8 @@ export default class CustomFormsInstancesDefinitionController extends Controller
       this.selectedField = fields.filter(
         (f) => f.uri === this.selectedField.uri
       )[0];
+    } else {
+      this.selectedField = fields[0] || null;
     }
   }
 

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -12,6 +12,7 @@ export default class CustomFormsInstancesDefinitionController extends Controller
   @tracked isEditFormModalOpen;
   @tracked isRefreshForm;
   @tracked selectedField;
+  @tracked isShownInSummaryAddedToFields;
 
   @action
   updateFormName(event) {
@@ -70,6 +71,9 @@ export default class CustomFormsInstancesDefinitionController extends Controller
     } else {
       this.selectedField = fields[0] || null;
     }
+    this.isShownInSummaryAddedToFields = fields.every(
+      (f) => !f.isShownInSummary
+    );
   }
 
   @action

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { consume } from 'ember-provide-consume-context';
@@ -9,6 +10,8 @@ import { isCustomDisplayType } from 'frontend-lmb/models/display-type';
 
 export default class CustomFormsInstancesDefinitionController extends Controller {
   @consume('form-context') formContext;
+
+  @service router;
 
   @tracked isEditFormModalOpen;
   @tracked isRefreshForm;
@@ -90,5 +93,10 @@ export default class CustomFormsInstancesDefinitionController extends Controller
   cancelUpdateFormDetails() {
     this.model.form.rollbackAttributes();
     this.isEditFormModalOpen = false;
+  }
+
+  @action
+  goBackToLastRoute() {
+    this.router.location.history.back();
   }
 }

--- a/app/models/display-type.js
+++ b/app/models/display-type.js
@@ -1,9 +1,14 @@
 import Model, { attr } from '@ember-data/model';
 
 import {
+  ADRES_CUSTOM_DISPLAY_TYPE,
   CONCEPT_SCHEME_MULTI_SELECTOR_CUSTOM_DISPLAY_TYPE,
   CONCEPT_SCHEME_SELECTOR_CUSTOM_DISPLAY_TYPE,
+  DATE_CUSTOM_DISPLAY_TYPE,
   LINK_TO_FORM_CUSTOM_DISPLAY_TYPE,
+  PERSON_CUSTOM_DISPLAY_TYPE,
+  PERSON_MULTI_CUSTOM_DISPLAY_TYPE,
+  TEXT_CUSTOM_DISPLAY_TYPE,
 } from 'frontend-lmb/utils/well-known-uris';
 
 export default class DisplayTypeModel extends Model {
@@ -22,4 +27,17 @@ export default class DisplayTypeModel extends Model {
   get isLinkToForm() {
     return this.uri === LINK_TO_FORM_CUSTOM_DISPLAY_TYPE;
   }
+}
+
+export function isCustomDisplayType(uri) {
+  return [
+    TEXT_CUSTOM_DISPLAY_TYPE,
+    DATE_CUSTOM_DISPLAY_TYPE,
+    ADRES_CUSTOM_DISPLAY_TYPE,
+    PERSON_CUSTOM_DISPLAY_TYPE,
+    PERSON_MULTI_CUSTOM_DISPLAY_TYPE,
+    CONCEPT_SCHEME_SELECTOR_CUSTOM_DISPLAY_TYPE,
+    CONCEPT_SCHEME_MULTI_SELECTOR_CUSTOM_DISPLAY_TYPE,
+    LINK_TO_FORM_CUSTOM_DISPLAY_TYPE,
+  ].includes(uri);
 }

--- a/app/models/library-entry.js
+++ b/app/models/library-entry.js
@@ -12,3 +12,13 @@ export default class LibraryEntryModel extends Model {
   })
   displayType;
 }
+
+LibraryEntryModel.ensureFakeEntry = (store) => {
+  if (LibraryEntryModel.fakeEntry) {
+    return LibraryEntryModel.fakeEntry;
+  }
+  LibraryEntryModel.fakeEntry = store.createRecord('library-entry', {
+    name: 'Eigen veld',
+  });
+  return LibraryEntryModel.fakeEntry;
+};

--- a/app/routes/custom-forms/instances/definition.js
+++ b/app/routes/custom-forms/instances/definition.js
@@ -18,7 +18,6 @@ export default class CustomFormsInstancesDefinitionRoute extends Route {
     let formInstanceId = form.id;
 
     if (isFormExtension && fullScreenEdit === 'true') {
-      console.log({ instanceId });
       formInstanceId = instanceId;
       const currentFormId = this.formReplacements.getReplacement(id);
       form = await this.semanticFormRepository.getFormDefinition(

--- a/app/routes/custom-forms/instances/definition.js
+++ b/app/routes/custom-forms/instances/definition.js
@@ -5,11 +5,16 @@ import { service } from '@ember/service';
 export default class CustomFormsInstancesDefinitionRoute extends Route {
   @service store;
 
-  async model({ id }) {
+  queryParams = {
+    fullScreenEdit: {},
+  };
+
+  async model({ id, fullScreenEdit }) {
     const form = await this.store.findRecord('form', id);
 
     return {
       form,
+      fullScreenEdit: fullScreenEdit && fullScreenEdit === 'true',
     };
   }
 }

--- a/app/routes/custom-forms/instances/definition.js
+++ b/app/routes/custom-forms/instances/definition.js
@@ -34,7 +34,7 @@ export default class CustomFormsInstancesDefinitionRoute extends Route {
         true
       );
     }
-    console.log(`ext?`, isFormExtensionAsBool);
+
     return {
       form,
       instanceId: formInstanceId,

--- a/app/routes/custom-forms/instances/definition.js
+++ b/app/routes/custom-forms/instances/definition.js
@@ -4,16 +4,32 @@ import { service } from '@ember/service';
 
 export default class CustomFormsInstancesDefinitionRoute extends Route {
   @service store;
+  @service formReplacements;
+  @service semanticFormRepository;
 
   queryParams = {
     fullScreenEdit: {},
+    isFormExtension: {},
+    instanceId: {},
   };
 
-  async model({ id, fullScreenEdit }) {
-    const form = await this.store.findRecord('form', id);
+  async model({ id, fullScreenEdit, isFormExtension, instanceId }) {
+    let form = await this.store.findRecord('form', id);
+    let formInstanceId = form.id;
+
+    if (isFormExtension && fullScreenEdit === 'true') {
+      console.log({ instanceId });
+      formInstanceId = instanceId;
+      const currentFormId = this.formReplacements.getReplacement(id);
+      form = await this.semanticFormRepository.getFormDefinition(
+        currentFormId,
+        true
+      );
+    }
 
     return {
       form,
+      instanceId: formInstanceId,
       fullScreenEdit: fullScreenEdit && fullScreenEdit === 'true',
     };
   }

--- a/app/routes/custom-forms/instances/definition.js
+++ b/app/routes/custom-forms/instances/definition.js
@@ -14,8 +14,13 @@ export default class CustomFormsInstancesDefinitionRoute extends Route {
   };
 
   async model({ id, fullScreenEdit, isFormExtension, instanceId }) {
-    let form = await this.store.findRecord('form', id);
-    let formInstanceId = form.id;
+    let form = null;
+    let formInstanceId = null;
+
+    if (!isFormExtension) {
+      form = await this.store.findRecord('form', id);
+      formInstanceId = form.id;
+    }
 
     if (isFormExtension && fullScreenEdit === 'true') {
       formInstanceId = instanceId;

--- a/app/routes/custom-forms/instances/definition.js
+++ b/app/routes/custom-forms/instances/definition.js
@@ -16,13 +16,17 @@ export default class CustomFormsInstancesDefinitionRoute extends Route {
   async model({ id, fullScreenEdit, isFormExtension, instanceId }) {
     let form = null;
     let formInstanceId = null;
+    const isFullScreenAsBool = !!(fullScreenEdit && fullScreenEdit === 'true');
+    const isFormExtensionAsBool = !!(
+      isFormExtension && isFormExtension === 'true'
+    );
 
-    if (!isFormExtension) {
+    if (!isFormExtensionAsBool) {
       form = await this.store.findRecord('form', id);
       formInstanceId = form.id;
     }
 
-    if (isFormExtension && fullScreenEdit === 'true') {
+    if (isFormExtensionAsBool && isFullScreenAsBool) {
       formInstanceId = instanceId;
       const currentFormId = this.formReplacements.getReplacement(id);
       form = await this.semanticFormRepository.getFormDefinition(
@@ -30,11 +34,12 @@ export default class CustomFormsInstancesDefinitionRoute extends Route {
         true
       );
     }
-
+    console.log(`ext?`, isFormExtensionAsBool);
     return {
       form,
       instanceId: formInstanceId,
-      fullScreenEdit: fullScreenEdit && fullScreenEdit === 'true',
+      fullScreenEdit: isFullScreenAsBool,
+      isFormExtension: isFormExtensionAsBool,
     };
   }
 }

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -18,6 +18,13 @@
   border: 2px solid var(--au-gray-200);
   border-radius: 5px;
   background-color: var(--au-white);
+
+  .custom-form-field {
+    padding-left: $au-unit;
+  }
+  .add-custom-field {
+    margin: 0 $au-unit;
+  }
 }
 
 .edit-form-defintion--edit-panel {

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -25,6 +25,10 @@
   .add-custom-field {
     margin: 0 $au-unit;
   }
+
+  .standard-form-field {
+    padding-left: $au-unit;
+  }
 }
 
 .edit-form-defintion--edit-panel {

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -4,6 +4,7 @@
   flex-direction: row;
   gap: 1rem;
   padding: 2rem;
+  height: 100%;
 }
 
 @media (max-width: 750px) {

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -52,3 +52,8 @@
   background-color: var(--au-blue-200);
   outline: 2px solid var(--au-blue-300);
 }
+
+.wrapped-field--error {
+  border-left: 2px solid var(--au-red-600);
+  padding-left: 1rem !important;
+}

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -26,15 +26,25 @@
       </AuButtonGroup>
     </Group>
   </AuToolbar>
-  <AuToolbar
-    @size="large"
-    class="au-u-padding-bottom-none au-u-margin-bottom"
-    as |Group|
-  >
+  <AuToolbar @size="large" class="au-u-padding-bottom-none" as |Group|>
     <Group>
       <p>{{this.model.form.description}}</p>
     </Group>
   </AuToolbar>
+  {{#if this.isShownInSummaryAddedToFields}}
+    <div class="au-o-box">
+      <AuAlert
+        @title="Toon in samenvatting"
+        @skin="warning"
+        @icon="alert-triangle"
+      >
+        Er werd geen veld aangeduid dat getoont zal worden in het overzicht.
+        Hierdoor vind je mogelijk instanties van dit formulier niet meer terug.
+        <br />
+        Zorg ervoor dat voor een van de velden in het formulier "Toon in
+        samenvatting" aan staat.</AuAlert>
+    </div>
+  {{/if}}
   <div class="edit-form-defintion">
     <div class="au-o-box edit-form-defintion--form">
       {{#if this.isRefreshForm}}

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -1,50 +1,53 @@
 {{page-title "Bewerk formulier definitie"}}
 <div class="au-c-body-container au-c-body-container--scroll">
-  <AuToolbar
-    @size="large"
-    class="au-u-padding-bottom-none au-u-margin-bottom"
-    as |Group|
-  >
-    <Group>
-      <AuHeading @skin="2">{{this.model.form.name}}
-        <AuButton
-          @skin="link-secondary"
-          @icon="pencil"
-          @hideText={{true}}
-          {{on "click" (fn (mut this.isEditFormModalOpen) true)}}
+  {{#unless this.model.fullScreenEdit}}
+    <AuToolbar
+      @size="large"
+      class="au-u-padding-bottom-none au-u-margin-bottom"
+      as |Group|
+    >
+      <Group>
+        <AuHeading @skin="2">{{this.model.form.name}}
+          <AuButton
+            @skin="link-secondary"
+            @icon="pencil"
+            @hideText={{true}}
+            {{on "click" (fn (mut this.isEditFormModalOpen) true)}}
+          >
+            Pas aan
+          </AuButton></AuHeading>
+      </Group>
+      <Group>
+        <AuButtonGroup>
+          <AuLink
+            @route="custom-forms.instances.index"
+            @model={{this.model.form.id}}
+            @skin="button-secondary"
+          >Terug naar formulieren</AuLink>
+        </AuButtonGroup>
+      </Group>
+    </AuToolbar>
+    <AuToolbar @size="large" class="au-u-padding-bottom-none" as |Group|>
+      <Group>
+        <p>{{this.model.form.description}}</p>
+      </Group>
+    </AuToolbar>
+    {{#if this.isShownInSummaryAddedToFields}}
+      <div class="au-o-box">
+        <AuAlert
+          @title="Toon in samenvatting"
+          @skin="warning"
+          @icon="alert-triangle"
         >
-          Pas aan
-        </AuButton></AuHeading>
-    </Group>
-    <Group>
-      <AuButtonGroup>
-        <AuLink
-          @route="custom-forms.instances.index"
-          @model={{this.model.form.id}}
-          @skin="button-secondary"
-        >Terug naar formulieren</AuLink>
-      </AuButtonGroup>
-    </Group>
-  </AuToolbar>
-  <AuToolbar @size="large" class="au-u-padding-bottom-none" as |Group|>
-    <Group>
-      <p>{{this.model.form.description}}</p>
-    </Group>
-  </AuToolbar>
-  {{#if this.isShownInSummaryAddedToFields}}
-    <div class="au-o-box">
-      <AuAlert
-        @title="Toon in samenvatting"
-        @skin="warning"
-        @icon="alert-triangle"
-      >
-        Er werd geen veld aangeduid dat getoont zal worden in het overzicht.
-        Hierdoor vind je mogelijk instanties van dit formulier niet meer terug.
-        <br />
-        Zorg ervoor dat voor een van de velden in het formulier "Toon in
-        samenvatting" aan staat.</AuAlert>
-    </div>
-  {{/if}}
+          Er werd geen veld aangeduid dat getoont zal worden in het overzicht.
+          Hierdoor vind je mogelijk instanties van dit formulier niet meer
+          terug.
+          <br />
+          Zorg ervoor dat voor een van de velden in het formulier "Toon in
+          samenvatting" aan staat.</AuAlert>
+      </div>
+    {{/if}}
+  {{/unless}}
   <div class="edit-form-defintion">
     <div class="au-o-box edit-form-defintion--form">
       {{#if this.isRefreshForm}}

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -1,6 +1,24 @@
 {{page-title "Bewerk formulier definitie"}}
 <div class="au-c-body-container au-c-body-container--scroll">
-  {{#unless this.model.fullScreenEdit}}
+  {{#if this.model.fullScreenEdit}}
+    <AuToolbar
+      @size="large"
+      class="au-u-padding-bottom-none au-u-margin-bottom"
+      as |Group|
+    >
+      <Group>
+        {{! for styling }}
+      </Group>
+      <Group>
+        <AuButtonGroup>
+          <AuButton
+            @skin="secondary"
+            {{on "click" this.goBackToLastRoute}}
+          >Terug naar vorige pagina</AuButton>
+        </AuButtonGroup>
+      </Group>
+    </AuToolbar>
+  {{else}}
     <AuToolbar
       @size="large"
       class="au-u-padding-bottom-none au-u-margin-bottom"
@@ -47,7 +65,7 @@
           samenvatting" aan staat.</AuAlert>
       </div>
     {{/if}}
-  {{/unless}}
+  {{/if}}
   <div class="edit-form-defintion">
     <div class="au-o-box edit-form-defintion--form">
       {{#if this.isRefreshForm}}

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -57,7 +57,6 @@
           @instanceId={{this.model.form.id}}
           @form={{this.model.form}}
           @customHistoryMessage={{true}}
-          @editFieldsInForm={{false}}
           @canSelectField={{true}}
           @onFieldSelected={{this.setSelectedField}}
           @selectedField={{this.selectedField}}

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -57,6 +57,7 @@
           @instanceId={{this.model.form.id}}
           @form={{this.model.form}}
           @customHistoryMessage={{true}}
+          @isEditFormDefinitionForm={{true}}
           @canSelectField={{true}}
           @onFieldSelected={{this.setSelectedField}}
           @selectedField={{this.selectedField}}

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -89,6 +89,7 @@
         @onFieldUpdated={{this.updateFormContent}}
         @isLoading={{this.isRefreshForm}}
         @selectedField={{this.selectedField}}
+        @canShowInSummaryButton={{this.model.isFormExtension}}
       />
     </div>
   </div>

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -54,7 +54,7 @@
         <AuLoader @hideMessage={{true}} />
       {{else}}
         <EditableForm
-          @instanceId={{this.model.form.id}}
+          @instanceId={{this.model.instanceId}}
           @form={{this.model.form}}
           @customHistoryMessage={{true}}
           @isEditFormDefinitionForm={{true}}

--- a/app/templates/custom-forms/instances/instance.hbs
+++ b/app/templates/custom-forms/instances/instance.hbs
@@ -1,7 +1,6 @@
 {{page-title "Instance"}}
 <div class="au-o-box au-c-body-container au-c-body-container--scroll">
   <EditableForm
-    @toReceiveUserInput={{true}}
     @instanceId={{this.model.instanceId}}
     @form={{this.model.form}}
     @onCancel={{this.onCancel}}

--- a/app/templates/mandatarissen/persoon/index.hbs
+++ b/app/templates/mandatarissen/persoon/index.hbs
@@ -18,12 +18,13 @@
   <div class="au-o-box">
     <Person::Card @persoon={{@model.persoon}} />
   </div>
-  {{!-- <div class="au-o-box">
+
+  <div class="au-o-box">
     <Persoon::ExtraInfoCard
       @persoon={{@model.persoon}}
       @form={{@model.personExtraInfoForm}}
     />
-  </div> --}}
+  </div>
 
   {{#if this.canShowUsage}}
     <div class="au-u-box au-u-padding">

--- a/app/templates/mandatarissen/persoon/index.hbs
+++ b/app/templates/mandatarissen/persoon/index.hbs
@@ -19,12 +19,14 @@
     <Person::Card @persoon={{@model.persoon}} />
   </div>
 
-  <div class="au-o-box">
-    <Persoon::ExtraInfoCard
-      @persoon={{@model.persoon}}
-      @form={{@model.personExtraInfoForm}}
-    />
-  </div>
+  {{#if (is-feature-enabled "person-extra-info")}}
+    <div class="au-o-box">
+      <Persoon::ExtraInfoCard
+        @persoon={{@model.persoon}}
+        @form={{@model.personExtraInfoForm}}
+      />
+    </div>
+  {{/if}}
 
   {{#if this.canShowUsage}}
     <div class="au-u-box au-u-padding">

--- a/app/utils/form-properties.js
+++ b/app/utils/form-properties.js
@@ -12,7 +12,9 @@ export const getFormProperty = (args, property) => {
 
 export const isCustomForm = (forkingStore) => {
   if (!forkingStore) {
-    console.warn('Forkingstore is undefined, returning false.');
+    console.warn(
+      'Forkingstore is undefined, returning false for ext:isCustomForm'
+    );
     return false;
   }
 
@@ -26,5 +28,26 @@ export const isCustomForm = (forkingStore) => {
         new NamedNode('http://www.w3.org/2001/XMLSchema#boolean')
       )
     ) || forkingStore.any(null, EXT('isCustomForm'), true)
+  );
+};
+
+export const isFieldShownInSummmary = (forkingStore, fieldNode) => {
+  if (!forkingStore) {
+    console.warn(
+      'Forkingstore is undefined, returning false for form:showInSummary'
+    );
+    return false;
+  }
+
+  return !!(
+    forkingStore.any(
+      fieldNode,
+      FORM('showInSummary'),
+      new Literal(
+        'true',
+        null,
+        new NamedNode('http://www.w3.org/2001/XMLSchema#boolean')
+      )
+    ) || forkingStore.any(fieldNode, FORM('showInSummary'), true)
   );
 };

--- a/app/utils/form-properties.js
+++ b/app/utils/form-properties.js
@@ -1,4 +1,5 @@
-import { FORM } from 'frontend-lmb/rdf/namespaces';
+import { EXT, FORM } from 'frontend-lmb/rdf/namespaces';
+import { Literal, NamedNode } from 'rdflib';
 
 export const getFormProperty = (args, property) => {
   return args.formStore.match(
@@ -7,4 +8,23 @@ export const getFormProperty = (args, property) => {
     undefined,
     args.graphs.formGraph
   )[0].object.value;
+};
+
+export const isCustomForm = (forkingStore) => {
+  if (!forkingStore) {
+    console.warn('Forkingstore is undefined, returning false.');
+    return false;
+  }
+
+  return !!(
+    forkingStore.any(
+      null,
+      EXT('isCustomForm'),
+      new Literal(
+        'true',
+        null,
+        new NamedNode('http://www.w3.org/2001/XMLSchema#boolean')
+      )
+    ) || forkingStore.any(null, EXT('isCustomForm'), true)
+  );
 };

--- a/app/utils/register-form-fields.js
+++ b/app/utils/register-form-fields.js
@@ -26,7 +26,6 @@ import RdfInputFieldsCustomNumberInputComponent from 'frontend-lmb/components/rd
 import RdfInputFieldsCustomTextInputComponent from 'frontend-lmb/components/rdf-input-fields/custom-text-input';
 import RdfInputFieldCustomConceptSchemeSelectorInput from 'frontend-lmb/components/rdf-input-fields/custom-concept-scheme-selector-input';
 import RdfInputFieldCustomConceptSchemeMultiSelectorInput from 'frontend-lmb/components/rdf-input-fields/custom-concept-scheme-multi-selector-input';
-import CustomFormLinkToFormInstance from 'frontend-lmb/components/custom-form/link-to-form-instance';
 import RdfInputFieldCustomPersonSelector from 'frontend-lmb/components/rdf-input-fields/custom-person-input';
 import RdfInputFieldCustomPersonMultiSelector from 'frontend-lmb/components/rdf-input-fields/custom-person-multi-input';
 import {
@@ -167,7 +166,6 @@ export const registerCustomFormFields = () => {
       displayType:
         'http://lblod.data.gift/display-types/lmb/custom-link-to-form-selector-input',
       edit: CustomFormLinkToFormWithModal,
-      // edit: CustomFormLinkToFormInstance,
     },
     {
       displayType: PERSON_CUSTOM_DISPLAY_TYPE,

--- a/app/utils/register-form-fields.js
+++ b/app/utils/register-form-fields.js
@@ -33,6 +33,7 @@ import {
   PERSON_CUSTOM_DISPLAY_TYPE,
   PERSON_MULTI_CUSTOM_DISPLAY_TYPE,
 } from './well-known-uris';
+import CustomFormLinkToFormWithModal from 'frontend-lmb/components/custom-form/link-to-form-with-modal';
 
 export const registerCustomFormFields = () => {
   registerFormFields([
@@ -165,7 +166,8 @@ export const registerCustomFormFields = () => {
     {
       displayType:
         'http://lblod.data.gift/display-types/lmb/custom-link-to-form-selector-input',
-      edit: CustomFormLinkToFormInstance,
+      edit: CustomFormLinkToFormWithModal,
+      // edit: CustomFormLinkToFormInstance,
     },
     {
       displayType: PERSON_CUSTOM_DISPLAY_TYPE,

--- a/app/utils/register-form-fields.js
+++ b/app/utils/register-form-fields.js
@@ -19,6 +19,7 @@ import RdfDateInputComponent from 'frontend-lmb/components/rdf-input-fields/rdf-
 import RDFGeboorteInput from 'frontend-lmb/components/rdf-input-fields/geboorte-input';
 import RDFGenderSelector from 'frontend-lmb/components/rdf-input-fields/gender-selector';
 import RdfInputFieldsCustomStringInputComponent from 'frontend-lmb/components/rdf-input-fields/custom-string-input';
+import RdfInputFieldsStandardStringInputComponent from 'frontend-lmb/components/rdf-input-fields/standard-string-input';
 import RdfInputFieldsCustomAddressInputComponent from 'frontend-lmb/components/rdf-input-fields/custom-address-input';
 import RdfInputFieldsCustomDateInputComponent from 'frontend-lmb/components/rdf-input-fields/custom-date-input';
 import RdfInputFieldsCustomNumberInputComponent from 'frontend-lmb/components/rdf-input-fields/custom-number-input';
@@ -127,6 +128,11 @@ export const registerCustomFormFields = () => {
       displayType:
         'http://lblod.data.gift/display-types/lmb/custom-string-input',
       edit: RdfInputFieldsCustomStringInputComponent,
+    },
+    {
+      displayType:
+        'http://lblod.data.gift/display-types/lmb/standard-string-input',
+      edit: RdfInputFieldsStandardStringInputComponent,
     },
     {
       displayType:

--- a/config/environment.js
+++ b/config/environment.js
@@ -39,6 +39,7 @@ module.exports = function (environment) {
       'enable-mandataris-count-warnings': true,
       politieraad: false,
       'editable-forms': false,
+      'person-extra-info': false,
       'edit-mandataris-rework': false,
       'shacl-report': false,
     },
@@ -72,6 +73,7 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
     ENV.features['editable-forms'] = true;
+    ENV.features['person-extra-info'] = true;
     ENV.features['show-eigen-gegevens-module'] = true;
 
     ENV.features['shacl-report'] = true;

--- a/tests/integration/components/custom-form/link-to-form-with-modal-test.js
+++ b/tests/integration/components/custom-form/link-to-form-with-modal-test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | custom-form/link-to-form-with-modal',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.set('myAction', function(val) { ... });
+
+      await render(hbs`<CustomForm::LinkToFormWithModal />`);
+
+      assert.dom().hasText('');
+
+      // Template block usage:
+      await render(hbs`<CustomForm::LinkToFormWithModal>
+  template block text
+</CustomForm::LinkToFormWithModal>`);
+
+      assert.dom().hasText('template block text');
+    });
+  }
+);

--- a/tests/integration/components/table-pagination-test.js
+++ b/tests/integration/components/table-pagination-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-lmb/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | table-pagination', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<TablePagination />`);
+
+    assert.dom().hasText('');
+
+    // Template block usage:
+    await render(hbs`<TablePagination>
+  template block text
+</TablePagination>`);
+
+    assert.dom().hasText('template block text');
+  });
+});


### PR DESCRIPTION
## Description

Showing the linked forms in a dropdown with flex does not give the user a clear overview. We wan tot show it as a table.

## How to test

1. eigen-gegevens:  add form field with type link to form e.g. fractie/mandataris
2. Create an instance for for the defintion and use the link to form field, CRUD
3. Go to a person detail and add such field to the extra info form, it shoul work the same but the read only should show the count of links ( could change but not sure how we would want to visualize it here)

## Attachments

** OLD**
![image](https://github.com/user-attachments/assets/344388c5-3a91-45fe-a53e-c94f1641caca)


**NEW**
![image](https://github.com/user-attachments/assets/9ed8da70-6e42-4a35-bced-e1f0cd95633b)
![image](https://github.com/user-attachments/assets/d1378818-e03d-4ff1-817f-cd43cc48ba73)

