### PR TITLE
LMB-1556 | Breadcrums for eigen-gegevens

### DIFF
--- a/app/components/shared/compact-menu.hbs
+++ b/app/components/shared/compact-menu.hbs
@@ -21,7 +21,7 @@
       </AuLink>
     {{/if}}
     {{#if (is-feature-enabled "editable-forms")}}
-      <AuLink @route="custom-forms.overview" role="menuitem">
+      <AuLink @route="custom-forms" role="menuitem">
         <AuIcon @icon="folder" @alignment="left" />
         Eigen gegevens
       </AuLink>

--- a/app/components/shared/main-menu.hbs
+++ b/app/components/shared/main-menu.hbs
@@ -26,7 +26,7 @@
       {{/if}}
       {{#if (is-feature-enabled "editable-forms")}}
         <li class="au-c-list-navigation__item">
-          <AuNavigationLink @route="custom-forms.overview">
+          <AuNavigationLink @route="custom-forms">
             <AuIcon @icon="folder" @alignment="left" />
             Eigen gegevens
           </AuNavigationLink>

--- a/app/components/shared/modules.hbs
+++ b/app/components/shared/modules.hbs
@@ -36,8 +36,7 @@
       <:description>Hier vind je een overzicht van de eigen formulieren binnen
         Lokaal Mandatenbeheer</:description>
       <:link>
-        <AuLink @route="custom-forms.overview" @skin="button">Ga naar eigen
-          gegevens</AuLink>
+        <AuLink @route="custom-forms" @skin="button">Ga naar eigen gegevens</AuLink>
       </:link>
     </LoketModuleCard>
   </li>

--- a/app/controllers/custom-forms/index.js
+++ b/app/controllers/custom-forms/index.js
@@ -3,7 +3,7 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
-export default class CustomFormsOverviewController extends Controller {
+export default class CustomFormsIndexController extends Controller {
   @service toaster;
 
   @tracked page = 0;

--- a/app/controllers/custom-forms/instances/index.js
+++ b/app/controllers/custom-forms/instances/index.js
@@ -80,7 +80,7 @@ export default class CustomFormsInstancesIndexController extends Controller {
         'Formulier definitie and instances succesvol verwijderd',
         'Formulier'
       );
-      this.router.transitionTo('custom-forms.overview');
+      this.router.transitionTo('custom-forms');
     } catch (error) {
       showErrorToast(
         this.toaster,

--- a/app/controllers/custom-forms/new.js
+++ b/app/controllers/custom-forms/new.js
@@ -55,7 +55,7 @@ export default class CustomFormsNewController extends Controller {
     if (this.isValidName || this.description?.trim() !== '') {
       this.isUnsavedChangesModalOpen = true;
     } else {
-      this.router.transitionTo('custom-forms.overview');
+      this.router.transitionTo('custom-forms');
     }
   }
 
@@ -67,7 +67,7 @@ export default class CustomFormsNewController extends Controller {
     if (this.savedTransition) {
       this.savedTransition?.retry();
     } else {
-      this.router.transitionTo('custom-forms.overview');
+      this.router.transitionTo('custom-forms');
     }
   }
 

--- a/app/router.js
+++ b/app/router.js
@@ -62,14 +62,14 @@ Router.map(function () {
     this.route('detail', { path: '/:id/detail' });
   });
 
-  this.route('custom-forms', { path: 'eigen-gegevens' }, function () {
+  this.route('custom-forms', { path: '/eigen-gegevens' }, function () {
+    this.route('index', { path: '/' });
     this.route('new');
-    this.route('overview', { path: 'overzicht' });
-    this.route('instances', function () {
-      this.route('index', { path: '/:id' });
-      this.route('instance', { path: '/:instance_id/instance' });
-      this.route('new', { path: '/:id/new' });
-      this.route('definition', { path: '/:id/bewerk-formulier-definitie' });
+    this.route('instances', { path: '/:id/instances' }, function () {
+      this.route('index', { path: '/' });
+      this.route('instance', { path: '/:instance_id' });
+      this.route('new');
+      this.route('definition', { path: '/bewerk-formulier-definitie' });
     });
   });
 

--- a/app/routes/custom-forms/index.js
+++ b/app/routes/custom-forms/index.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 
 import { service } from '@ember/service';
 
-export default class CustomFormsOverviewRoute extends Route {
+export default class CustomFormsIndexRoute extends Route {
   @service store;
   @service session;
 

--- a/app/routes/custom-forms/instances.js
+++ b/app/routes/custom-forms/instances.js
@@ -13,7 +13,9 @@ export default class CustomFormsInstancesIndexRoute extends Route {
   }
 
   async model({ id }) {
-    const form = await this.store.findRecord('form', id);
+    const form = await this.store.findRecord('form', id).catch(() => {
+      return { id, name: id };
+    });
     const formDefinition =
       await this.semanticFormRepository.getFormDefinition(id);
     const usage = await this.customForms.getFormDefinitionUsageCount(id);

--- a/app/routes/custom-forms/instances.js
+++ b/app/routes/custom-forms/instances.js
@@ -1,0 +1,28 @@
+import Route from '@ember/routing/route';
+
+import { service } from '@ember/service';
+
+export default class CustomFormsInstancesIndexRoute extends Route {
+  @service store;
+  @service session;
+  @service semanticFormRepository;
+  @service customForms;
+
+  beforeModel(transition) {
+    this.session.requireAuthentication(transition, 'login');
+  }
+
+  async model({ id }) {
+    const form = await this.store.findRecord('form', id);
+    const formDefinition =
+      await this.semanticFormRepository.getFormDefinition(id);
+    const usage = await this.customForms.getFormDefinitionUsageCount(id);
+
+    return {
+      form,
+      formDefinition,
+      headerLabels: await this.semanticFormRepository.getHeaderLabels(form.id),
+      usage,
+    };
+  }
+}

--- a/app/routes/custom-forms/instances/definition.js
+++ b/app/routes/custom-forms/instances/definition.js
@@ -13,7 +13,9 @@ export default class CustomFormsInstancesDefinitionRoute extends Route {
     instanceId: {},
   };
 
-  async model({ id, fullScreenEdit, isFormExtension, instanceId }) {
+  async model({ fullScreenEdit, isFormExtension, instanceId }) {
+    const parent = this.modelFor('custom-forms.instances');
+    const id = parent.form.id;
     let form = null;
     let formInstanceId = null;
     const isFullScreenAsBool = !!(fullScreenEdit && fullScreenEdit === 'true');

--- a/app/routes/custom-forms/instances/index.js
+++ b/app/routes/custom-forms/instances/index.js
@@ -1,35 +1,10 @@
 import Route from '@ember/routing/route';
 
-import { service } from '@ember/service';
-
 export default class CustomFormsInstancesIndexRoute extends Route {
-  @service store;
-  @service session;
-  @service semanticFormRepository;
-  @service customForms;
-
   queryParams = {
     filter: { refreshModel: true },
     page: { refreshModel: false },
     size: { refreshModel: false },
     sort: { refreshModel: true },
   };
-
-  beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-  }
-
-  async model({ id }) {
-    const form = await this.store.findRecord('form', id);
-    const formDefinition =
-      await this.semanticFormRepository.getFormDefinition(id);
-    const usage = await this.customForms.getFormDefinitionUsageCount(id);
-
-    return {
-      form,
-      formDefinition,
-      headerLabels: await this.semanticFormRepository.getHeaderLabels(form.id),
-      usage,
-    };
-  }
 }

--- a/app/routes/custom-forms/instances/instance.js
+++ b/app/routes/custom-forms/instances/instance.js
@@ -20,7 +20,7 @@ export default class CustomFormsInstancesInstanceRoute extends Route {
         this.toaster,
         `Er liep iets mis met het ophalen van de gegevens voor formulier met id: ${model.instanceId}`
       );
-      this.router.transitionTo('custom-forms.overview');
+      this.router.transitionTo('custom-forms');
     }
   }
 }

--- a/app/routes/custom-forms/instances/new.js
+++ b/app/routes/custom-forms/instances/new.js
@@ -1,12 +1,16 @@
 import Route from '@ember/routing/route';
 
 import { service } from '@ember/service';
+
 export default class CustomFormsInstancesNewRoute extends Route {
   @service semanticFormRepository;
 
   async model() {
     const parent = this.modelFor('custom-forms.instances');
+    const formDefinition = await this.semanticFormRepository.getFormDefinition(
+      parent.form.id
+    );
 
-    return { formDefinition: parent.formDefinition };
+    return { formDefinition };
   }
 }

--- a/app/routes/custom-forms/instances/new.js
+++ b/app/routes/custom-forms/instances/new.js
@@ -4,10 +4,9 @@ import { service } from '@ember/service';
 export default class CustomFormsInstancesNewRoute extends Route {
   @service semanticFormRepository;
 
-  async model({ id }) {
-    const formDefinition =
-      await this.semanticFormRepository.getFormDefinition(id);
+  async model() {
+    const parent = this.modelFor('custom-forms.instances');
 
-    return { formDefinition };
+    return { formDefinition: parent.formDefinition };
   }
 }

--- a/app/templates/custom-forms.hbs
+++ b/app/templates/custom-forms.hbs
@@ -1,2 +1,2 @@
-{{page-title "Eigen gegevens"}}
+{{breadcrumb "Eigen gegevens" route="custom-forms"}}
 {{outlet}}

--- a/app/templates/custom-forms/index.hbs
+++ b/app/templates/custom-forms/index.hbs
@@ -1,5 +1,4 @@
 {{page-title "Overzicht"}}
-{{breadcrumb "Overzicht" route="custom-forms.overview"}}
 <AuToolbar
   @size="large"
   class="au-u-padding-bottom-none au-u-margin-bottom"
@@ -50,7 +49,7 @@
     <c.body as |form|>
       <td class="au-u-1-5">
         <LinkTo
-          @route="custom-forms.instances.index"
+          @route="custom-forms.instances"
           @model={{form.id}}
           class="au-c-link au-u-medium"
         >
@@ -58,7 +57,7 @@
         </LinkTo>
       </td>
       <td>
-        {{form.description}}
+        {{form.id}}
       </td>
       <td class="au-u-1-5">{{form.displayCreatedDate}}</td>
       <td class="au-u-1-5">{{form.displayModifiedDate}}</td>

--- a/app/templates/custom-forms/instances.hbs
+++ b/app/templates/custom-forms/instances.hbs
@@ -1,0 +1,6 @@
+{{breadcrumb
+  this.model.form.name
+  route="custom-forms.instances.index"
+  model=this.model.form.id
+}}
+{{outlet}}

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -36,15 +36,6 @@
             Pas aan
           </AuButton></AuHeading>
       </Group>
-      <Group>
-        <AuButtonGroup>
-          <AuLink
-            @route="custom-forms.instances"
-            @model={{this.model.form.id}}
-            @skin="button-secondary"
-          >Terug naar formulieren</AuLink>
-        </AuButtonGroup>
-      </Group>
     </AuToolbar>
     <AuToolbar @size="large" class="au-u-padding-bottom-none" as |Group|>
       <Group>

--- a/app/templates/custom-forms/instances/definition.hbs
+++ b/app/templates/custom-forms/instances/definition.hbs
@@ -1,4 +1,5 @@
-{{page-title "Bewerk formulier definitie"}}
+{{breadcrumb "Definitie" route="custom-forms.instances.definition"}}
+
 <div class="au-c-body-container au-c-body-container--scroll">
   {{#if this.model.fullScreenEdit}}
     <AuToolbar
@@ -38,7 +39,7 @@
       <Group>
         <AuButtonGroup>
           <AuLink
-            @route="custom-forms.instances.index"
+            @route="custom-forms.instances"
             @model={{this.model.form.id}}
             @skin="button-secondary"
           >Terug naar formulieren</AuLink>

--- a/app/templates/custom-forms/instances/index.hbs
+++ b/app/templates/custom-forms/instances/index.hbs
@@ -1,10 +1,3 @@
-{{page-title "Overzicht"}}
-
-{{breadcrumb
-  this.model.form.name
-  route="custom-forms.instances.index"
-  model=this.model.form.id
-}}
 {{outlet}}
 
 <AuMainContainer as |main|>

--- a/app/templates/custom-forms/instances/instance.hbs
+++ b/app/templates/custom-forms/instances/instance.hbs
@@ -1,4 +1,5 @@
-{{page-title "Instance"}}
+{{breadcrumb "Formulier" route="custom-forms.instances.instance"}}
+
 <div class="au-o-box au-c-body-container au-c-body-container--scroll">
   <EditableForm
     @instanceId={{this.model.instanceId}}


### PR DESCRIPTION
## Description

Custom forms route does not have breadcrums. This makes it hard for the user to navigate

## How to test

1. All pages under the `eigen-gegevens` route should have a breadcrum
2. Also test a form extension (edit definition)


