### PR TITLE
allow selecting vervanger when a verhinder mandataris is being creatd

### DIFF
--- a/app/components/mandataris/edit/form.hbs
+++ b/app/components/mandataris/edit/form.hbs
@@ -34,7 +34,7 @@
       </AuLabel>
       <Mandatarissen::ReplacementSelect
         @mandataris={{@formValues}}
-        @selected={{this.replacementPerson}}
+        @selected={{@replacementPerson}}
         @onSelect={{this.updateReplacement}}
         @bestuursorgaanIT={{@bestuursorgaanIT}}
         @inline={{true}}

--- a/app/components/mandataris/edit/form.js
+++ b/app/components/mandataris/edit/form.js
@@ -28,9 +28,9 @@ export default class MandatarisEditFormComponent extends Component {
   @tracked endDate;
   @tracked fractie;
   @tracked rangorde;
-  @tracked person;
   @tracked replacementMandataris;
   @tracked replacementPerson;
+  @tracked originalReplacementPerson;
 
   @tracked errorMap = new Map();
 
@@ -49,7 +49,6 @@ export default class MandatarisEditFormComponent extends Component {
     this.mandaat = await this.args.formValues.bekleedt;
     this.status = await this.args.formValues.status;
     this.fractie = await this.args.formValues.fractie;
-    this.person = await this.args.formValues.isBestuurlijkeAliasVan;
     this.replacementMandataris =
       (await this.args.formValues.tijdelijkeVervangingen)?.[0] || null;
     this.replacementPerson =
@@ -62,12 +61,13 @@ export default class MandatarisEditFormComponent extends Component {
 
   get hasChanges() {
     return (
-      this.status?.id !== this.args.formValues.status?.id ||
-      !moment(this.startDate).isSame(moment(this.args.formValues.start)) ||
-      !moment(this.endDate).isSame(moment(this.args.formValues.einde)) ||
-      this.fractie?.id !== this.args.formValues.fractie?.id ||
-      this.rangorde !== this.args.formValues.rangorde ||
-      this.replacementPerson?.id !== this.person.id
+      this.status?.id !== this.args.mandataris.status?.id ||
+      !moment(this.startDate).isSame(moment(this.args.mandataris.start)) ||
+      !moment(this.endDate).isSame(moment(this.args.mandataris.einde)) ||
+      this.fractie?.id !==
+        this.args.mandataris.get('heeftLidmaatschap.binnenFractie.id') ||
+      this.rangorde !== this.args.mandataris.rangorde ||
+      this.args.originalReplacementPerson?.id !== this.replacementPerson?.id
     );
   }
 
@@ -133,14 +133,11 @@ export default class MandatarisEditFormComponent extends Component {
       ];
     }
 
-    this.args.onFormIsValid?.(
-      !this.formHasErrors && !this.disabled && this.hasChanges,
-      {
-        mandataris: this.args.formValues,
-        replacementPerson: this.replacementPerson,
-        replacementMandataris: this.replacementMandataris,
-      }
-    );
+    this.args.onFormIsValid?.(!this.formHasErrors && !this.disabled, {
+      mandataris: this.args.formValues,
+      replacementPerson: this.replacementPerson,
+      replacementMandataris: this.replacementMandataris,
+    });
   }
 
   @action

--- a/app/components/mandataris/edit/replacement-form.hbs
+++ b/app/components/mandataris/edit/replacement-form.hbs
@@ -1,10 +1,9 @@
 <div class="au-u-flex au-u-flex--column au-o-flow">
-  {{! TODO show the current replacement }}
   <Mandataris::Edit::StartEndDate
     @startDate={{this.startDate}}
     @endDate={{this.endDate}}
-    @from={{@prefillStart}}
-    @to={{@bestuursorgaanIT.bindingEinde}}
+    @from={{@limitFrom}}
+    @to={{@limitTo}}
     @onChange={{this.updateStartEndDate}}
     @onErrorStateUpdated={{this.updateErrorMap}}
   />

--- a/app/components/mandataris/edit/replacement-form.js
+++ b/app/components/mandataris/edit/replacement-form.js
@@ -34,12 +34,24 @@ export default class MandatarisEditReplacementForm extends Component {
   selectFractie(fractie) {
     this.fractie = fractie;
     this.updateErrorMap({ id: 'fractie', hasErrors: !fractie });
+    this.args.onChange({
+      start: this.startDate,
+      einde: this.endDate,
+      fractie: this.fractie,
+      rangorde: null,
+    });
   }
 
   @action
   updateStartEndDate(startDate, endDate) {
     this.startDate = startDate;
     this.endDate = endDate;
+    this.args.onChange({
+      start: this.startDate,
+      einde: this.endDate,
+      fractie: this.fractie,
+      rangorde: null,
+    });
   }
 
   get formHasErrors() {
@@ -52,11 +64,6 @@ export default class MandatarisEditReplacementForm extends Component {
   async updateErrorMap({ id, hasErrors }) {
     this.errorMap.set(id, !!hasErrors);
     this.errorMap = new Map(this.errorMap);
-    this.args.onFormIsValid?.(!this.formHasErrors, {
-      start: this.startDate,
-      einde: this.endDate,
-      fractie: this.fractie,
-      rangorde: null,
-    });
+    this.args.onFormIsValid?.(!this.formHasErrors);
   }
 }

--- a/app/components/mandataris/edit/start-end-date.js
+++ b/app/components/mandataris/edit/start-end-date.js
@@ -14,6 +14,35 @@ export default class MandatarisEditStartEndDate extends Component {
   @tracked startErrorMessage;
   @tracked endErrorMessage;
 
+  constructor() {
+    super(...arguments);
+    setTimeout(() => {
+      const oldStartErrorMessage = this.startErrorMessage;
+      const oldEndErrorMessage = this.endErrorMessage;
+      this.startErrorMessage = this.getErrorMessage(
+        this.args.startDate,
+        this.startDateLabel
+      );
+      this.endErrorMessage = this.getErrorMessage(
+        this.args.endDate,
+        this.endDateLabel
+      );
+      if (
+        oldStartErrorMessage !== this.startErrorMessage ||
+        oldEndErrorMessage !== this.endErrorMessage
+      ) {
+        this.args.onErrorStateUpdated?.({
+          id: 'startDate',
+          hasErrors: !!this.startErrorMessage,
+        });
+        this.args.onErrorStateUpdated?.({
+          id: 'endDate',
+          hasErrors: !!this.endErrorMessage,
+        });
+      }
+    });
+  }
+
   get hardMinDate() {
     return isValidDate(this.args.from) ? this.args.from : null;
   }

--- a/app/components/mandataris/edit/wizard.hbs
+++ b/app/components/mandataris/edit/wizard.hbs
@@ -1,6 +1,6 @@
 <AuModal
   class="wizard-modal"
-  @modalOpen={{@isWizardOpen}}
+  @modalOpen={{true}}
   @closable={{true}}
   @closeModal={{this.closeWizardSafely}}
 >
@@ -18,6 +18,8 @@
         @onChange={{this.updateMandatarisFormValues}}
         @onReplacementChange={{this.updateReplacement}}
         @mandataris={{@mandataris}}
+        @replacementPerson={{this.replacementPerson}}
+        @originalReplacementPerson={{this.originalReplacementPerson}}
       />
     {{/if}}
 
@@ -25,11 +27,14 @@
       <Mandataris::Edit::ReplacementForm
         @person={{this.replacementPerson}}
         @prefillStart={{this.startForReplacement}}
+        @limitFrom={{this.formValues.start}}
+        @limitTo={{this.replacementLimitTo}}
         @prefillEinde={{this.endForReplacement}}
         @prefillFractie={{this.fractieForReplacement}}
         @bestuursorgaanIT={{@bestuursorgaanIT}}
         @bestuurseenheid={{@bestuurseenheid}}
-        @onFormIsValid={{this.updateReplacementStepCompleted}}
+        @onFormIsValid={{this.updateReplacementStepValid}}
+        @onChange={{this.updateReplacementFormValues}}
       />
     {{/if}}
 

--- a/app/components/mandatarissen/fractie-selector.js
+++ b/app/components/mandatarissen/fractie-selector.js
@@ -97,7 +97,7 @@ export default class MandatenbeheerFractieSelectorComponent extends Component {
         return true;
       }
       const response = await fetch(
-        `/mandataris-api/personen/${this.person.id}/check-fraction`,
+        `/mandataris-api/personen/${this.args.person.id}/check-fraction`,
         {
           method: 'POST',
           headers: {

--- a/app/components/rdf-input-fields/mandataris-replacement-selector.hbs
+++ b/app/components/rdf-input-fields/mandataris-replacement-selector.hbs
@@ -2,12 +2,12 @@
   <div>
     <AuLabel for="replacement">{{this.title}}</AuLabel>
     {{#if this.initialized}}
-      <PowerSelectMultiple
+      <PowerSelect
         @triggerId="replacement"
         @allowClear={{true}}
         @disabled={{this.disabled}}
         @search={{perform this.search}}
-        @selected={{this.replacements}}
+        @selected={{this.replacement}}
         @onChange={{this.selectReplacement}}
         @loadingMessage="Aan het laden..."
         @searchEnabled={{true}}
@@ -26,7 +26,7 @@
             {{moment-format mandataris.displayEinde "DD-MM-YYYY"}}
           {{/if}}
         </span>
-      </PowerSelectMultiple>
+      </PowerSelect>
     {{else}}
       <p class="skeleton-input-full au-u-margin-top"></p>
     {{/if}}

--- a/app/components/rdf-input-fields/mandataris-replacement-selector.js
+++ b/app/components/rdf-input-fields/mandataris-replacement-selector.js
@@ -53,6 +53,7 @@ export default class MandatarisReplacementSelector extends InputFieldComponent {
       }
 
       this.loadMandaat();
+      this.refreshPersonFromForm();
       this.checkIfShouldRender();
     };
     this.storeOptions.store.registerObserver(onFormUpdate);
@@ -83,7 +84,6 @@ export default class MandatarisReplacementSelector extends InputFieldComponent {
     return this.args.field?.label || 'Tijdelijk vervangen door';
   }
 
-  // todo need to watch store and refresh every time
   async loadMandaat() {
     const forkingStore = this.storeOptions.store;
     const mandaatUri = forkingStore.any(
@@ -100,6 +100,26 @@ export default class MandatarisReplacementSelector extends InputFieldComponent {
     this.mandaat = (
       await this.store.query('mandaat', {
         'filter[:uri:]': mandaatUri,
+      })
+    )[0];
+  }
+
+  async refreshPersonFromForm() {
+    const forkingStore = this.storeOptions.store;
+    const persoonUri = forkingStore.any(
+      this.storeOptions.sourceNode,
+      MANDAAT('isBestuurlijkeAliasVan'),
+      null,
+      this.storeOptions.sourceGraph
+    )?.value;
+
+    if (!persoonUri || this.mandatarisPerson?.uri === persoonUri) {
+      return;
+    }
+
+    this.mandatarisPerson = (
+      await this.store.query('persoon', {
+        'filter[:uri:]': persoonUri,
       })
     )[0];
   }

--- a/app/components/rdf-input-fields/mandataris-replacement-selector.js
+++ b/app/components/rdf-input-fields/mandataris-replacement-selector.js
@@ -175,8 +175,7 @@ export default class MandatarisReplacementSelector extends InputFieldComponent {
 
     // Cleanup old value(s) in the store
     matches
-      .filter((m) => mandataris.uri !== m.value )
-
+      .filter((m) => mandataris.uri !== m.value)
       .forEach((m) => updateSimpleFormValue(this.storeOptions, undefined, m));
 
     // Insert new value in the store

--- a/app/components/rdf-input-fields/mandataris-replacement-selector.js
+++ b/app/components/rdf-input-fields/mandataris-replacement-selector.js
@@ -175,7 +175,8 @@ export default class MandatarisReplacementSelector extends InputFieldComponent {
 
     // Cleanup old value(s) in the store
     matches
-      .filter((m) => ![mandataris].find((opt) => m.value == opt.uri))
+      .filter((m) => mandataris.uri !== m.value )
+
       .forEach((m) => updateSimpleFormValue(this.storeOptions, undefined, m));
 
     // Insert new value in the store

--- a/app/components/rdf-input-fields/mandataris-replacement-selector.js
+++ b/app/components/rdf-input-fields/mandataris-replacement-selector.js
@@ -24,7 +24,7 @@ export default class MandatarisReplacementSelector extends InputFieldComponent {
   @service store;
   @service multiUriFetcher;
 
-  @tracked replacements = null;
+  @tracked replacement = null;
   @tracked initialized = false;
   @tracked mandaat = null;
   @tracked shouldRender = false;
@@ -74,9 +74,9 @@ export default class MandatarisReplacementSelector extends InputFieldComponent {
         new NamedNode(MANDATARIS_TITELVOEREND_STATE),
         this.storeOptions.sourceGraph
       );
-    if (!this.shouldRender && this.replacements?.length > 0) {
+    if (!this.shouldRender && this.replacement) {
       // without timeout, the form ttl doesn't update immediately
-      setTimeout(() => this.selectReplacement([]), 100);
+      setTimeout(() => this.selectReplacement(null), 100);
     }
   }
 
@@ -145,7 +145,7 @@ export default class MandatarisReplacementSelector extends InputFieldComponent {
       'mandataris',
       replacementUris
     );
-    this.replacements = matches;
+    this.replacement = matches?.[0];
   }
 
   search = task({ keepLatest: true }, async (searchData) => {
@@ -164,24 +164,22 @@ export default class MandatarisReplacementSelector extends InputFieldComponent {
   });
 
   @action
-  selectReplacement(mandatarises) {
+  selectReplacement(mandataris) {
     if (this.isDestroyed || this.isDestroying) {
       return;
     }
-    this.replacements = mandatarises;
+    this.replacement = mandataris;
 
     // Retrieve options in store
     const matches = triplesForPath(this.storeOptions, true).values;
 
     // Cleanup old value(s) in the store
     matches
-      .filter((m) => !mandatarises.find((opt) => m.value == opt.uri))
+      .filter((m) => ![mandataris].find((opt) => m.value == opt.uri))
       .forEach((m) => updateSimpleFormValue(this.storeOptions, undefined, m));
 
     // Insert new value in the store
-    mandatarises.forEach((mandataris) =>
-      updateSimpleFormValue(this.storeOptions, new NamedNode(mandataris.uri))
-    );
+    updateSimpleFormValue(this.storeOptions, new NamedNode(mandataris.uri));
 
     this.hasBeenFocused = true;
     super.updateValidations();

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -90,16 +90,17 @@
 
 </div>
 
-<Mandataris::Edit::Wizard
-  @isWizardOpen={{this.isEditModalOpen}}
-  @closeWizard={{this.closeWizard}}
-  @bestuurseenheid={{@model.bestuurseenheid}}
-  @bestuursorgaanIT={{get @model.bestuursorganen 0}}
-  @mandataris={{@model.mandataris}}
-  @mandatarisFormValues={{this.mandatarisFormValues}}
-  @isFractieRequired={{this.model.isFractieRequired}}
-  @showOCMWLinkedMandatarisWarning={{this.showOCMWLinkedMandatarisWarning}}
-/>
+{{#if this.isEditModalOpen}}
+  <Mandataris::Edit::Wizard
+    @closeWizard={{this.closeWizard}}
+    @bestuurseenheid={{@model.bestuurseenheid}}
+    @bestuursorgaanIT={{get @model.bestuursorganen 0}}
+    @mandataris={{@model.mandataris}}
+    @mandatarisFormValues={{this.mandatarisFormValues}}
+    @isFractieRequired={{this.model.isFractieRequired}}
+    @showOCMWLinkedMandatarisWarning={{this.showOCMWLinkedMandatarisWarning}}
+  />
+{{/if}}
 
 <Mandatarissen::DeleteModal
   @isOpen={{this.isDeleteModalOpen}}


### PR DESCRIPTION
## Description

allow selecting vervanger when a verhinder mandataris is being created
also fix the forms being inconsistent when going forward and back through the steps
## How to test

create a mandataris, mark as verhinderd immediately on create, select a replacement

also edit mandatarissen with replacments, go forward and back through the forms and check the saved state
