### PR TITLE
lmb-1593 | dissalow deleting the custom form when it has usage

### DIFF
--- a/app/controllers/custom-forms/instances/index.js
+++ b/app/controllers/custom-forms/instances/index.js
@@ -93,9 +93,16 @@ export default class CustomFormsInstancesIndexController extends Controller {
     this.formToDelete = null;
   }
 
+  get formUsageLabels() {
+    if (this.model.customFormConfigurationUsage.hasUsage) {
+      return this.model.customFormConfigurationUsage.formLabels;
+    }
+    return null;
+  }
+
   get removeFormModalText() {
-    if (this.model.isUsedInCustomFormConfiguration) {
-      return 'Dit type formulier wordt gebruikt in de configuratie van een extensie of eigen formulier. Hierdoor kan je dit formulier niet verwijderen.';
+    if (this.model.customFormConfigurationUsage.hasUsage) {
+      return `Dit type formulier wordt gebruikt in de configuratie van een extensie of eigen formulier. Hierdoor kan je dit formulier niet verwijderen.`;
     }
 
     if (this.model.usage.hasUsage) {

--- a/app/controllers/custom-forms/instances/index.js
+++ b/app/controllers/custom-forms/instances/index.js
@@ -107,16 +107,16 @@ export default class CustomFormsInstancesIndexController extends Controller {
 
     if (this.model.usage.hasUsage) {
       const postFix =
-        'Door verder te gaan zal deze definitie met zijn implementaties definitief verwijderd worden.';
-      let countText = `Er werd ${this.model.usage.count} implementatie gevonden. `;
+        'Door verder te gaan zullen alle formulieren definitief verwijderd worden.';
+      let countText = `Er werd ${this.model.usage.count} formulier(en) gevonden. `;
 
       if (this.model.usage.count > 1) {
-        countText = `Er werden ${this.model.usage.count} implementaties gevonden. `;
+        countText = `Er werden ${this.model.usage.count} formulier(en) gevonden. `;
       }
 
       return countText + postFix;
     }
 
-    return 'Door verder te gaan zal deze form-definitie definitief verwijderd worden.';
+    return 'Door verder te gaan zal dit formulier definitief verwijderd worden.';
   }
 }

--- a/app/controllers/custom-forms/instances/index.js
+++ b/app/controllers/custom-forms/instances/index.js
@@ -94,6 +94,10 @@ export default class CustomFormsInstancesIndexController extends Controller {
   }
 
   get removeFormModalText() {
+    if (this.model.isUsedInCustomFormConfiguration) {
+      return 'Dit type formulier wordt gebruikt in de configuratie van een extensie of eigen formulier. Hierdoor kan je dit formulier niet verwijderen.';
+    }
+
     if (this.model.usage.hasUsage) {
       const postFix =
         'Door verder te gaan zal deze definitie met zijn implementaties definitief verwijderd worden.';

--- a/app/routes/custom-forms/instances.js
+++ b/app/routes/custom-forms/instances.js
@@ -19,11 +19,14 @@ export default class CustomFormsInstancesIndexRoute extends Route {
     const formDefinition =
       await this.semanticFormRepository.getFormDefinition(id);
     const usage = await this.customForms.getFormDefinitionUsageCount(id);
+    const isUsedInCustomFormConfiguration =
+      await this.customForms.isFormDefinitionUsedInCustomFormConfiguration(id);
 
     return {
       form,
       formDefinition,
       usage,
+      isUsedInCustomFormConfiguration,
     };
   }
 }

--- a/app/routes/custom-forms/instances.js
+++ b/app/routes/custom-forms/instances.js
@@ -19,14 +19,14 @@ export default class CustomFormsInstancesIndexRoute extends Route {
     const formDefinition =
       await this.semanticFormRepository.getFormDefinition(id);
     const usage = await this.customForms.getFormDefinitionUsageCount(id);
-    const isUsedInCustomFormConfiguration =
+    const customFormConfigurationUsage =
       await this.customForms.isFormDefinitionUsedInCustomFormConfiguration(id);
 
     return {
       form,
       formDefinition,
       usage,
-      isUsedInCustomFormConfiguration,
+      customFormConfigurationUsage,
     };
   }
 }

--- a/app/services/custom-forms.js
+++ b/app/services/custom-forms.js
@@ -60,7 +60,10 @@ export default class CustomFormsService extends Service {
       console.error({ jsonResponse });
     }
 
-    return jsonResponse;
+    return {
+      hasUsage: !!jsonResponse.hasUsage,
+      formLabels: jsonResponse.formLabels,
+    };
   }
 
   async getInstanceUsage(instanceUri) {

--- a/app/services/custom-forms.js
+++ b/app/services/custom-forms.js
@@ -91,7 +91,6 @@ export default class CustomFormsService extends Service {
       const jsonResponse = await response.json();
       console.error({ jsonResponse });
     }
-    await form.destroyRecord();
     await timeout(RESOURCE_CACHE_TIMEOUT);
   }
 

--- a/app/services/custom-forms.js
+++ b/app/services/custom-forms.js
@@ -50,6 +50,19 @@ export default class CustomFormsService extends Service {
     };
   }
 
+  async isFormDefinitionUsedInCustomFormConfiguration(formDefinitionId) {
+    const response = await fetch(
+      `${API.FORM_CONTENT_SERVICE}/definition/${formDefinitionId}/used-in-custom-form-configuration`
+    );
+    const jsonResponse = await response.json();
+
+    if (response.status !== STATUS_CODE.OK) {
+      console.error({ jsonResponse });
+    }
+
+    return jsonResponse;
+  }
+
   async getInstanceUsage(instanceUri) {
     const response = await fetch(
       `${API.FORM_CONTENT_SERVICE}/custom-form/find-usage?instanceUri=${encodeURIComponent(instanceUri)}`

--- a/app/templates/custom-forms/instances/index.hbs
+++ b/app/templates/custom-forms/instances/index.hbs
@@ -50,6 +50,15 @@
 >
   <:body>
     <p>{{this.removeFormModalText}}</p>
+    {{#if this.formUsageLabels}}
+      <p class="au-u-margin-top">Verwijder eerst de link naar dit formulier uit
+        volgende formulieren:</p>
+      <ul>
+        {{#each this.formUsageLabels as |label|}}
+          <li>- {{label}}</li>
+        {{/each}}
+      </ul>
+    {{/if}}
   </:body>
   <:footer>
     <AuButtonGroup
@@ -59,7 +68,7 @@
         @alert={{true}}
         @disabled={{or
           this.isDeleting
-          this.model.isUsedInCustomFormConfiguration
+          this.model.customFormConfigurationUsage.hasUsage
         }}
         @loading={{this.isDeleting}}
         @loadingMessage="Formulier en instanties worden verwijderd"

--- a/app/templates/custom-forms/instances/index.hbs
+++ b/app/templates/custom-forms/instances/index.hbs
@@ -57,7 +57,10 @@
     >
       <AuButton
         @alert={{true}}
-        @disabled={{this.isDeleting}}
+        @disabled={{or
+          this.isDeleting
+          this.model.isUsedInCustomFormConfiguration
+        }}
         @loading={{this.isDeleting}}
         @loadingMessage="Formulier en instanties worden verwijderd"
         {{on "click" this.deleteForm}}

--- a/app/templates/custom-forms/instances/index.hbs
+++ b/app/templates/custom-forms/instances/index.hbs
@@ -71,7 +71,7 @@
           this.model.customFormConfigurationUsage.hasUsage
         }}
         @loading={{this.isDeleting}}
-        @loadingMessage="Formulier en instanties worden verwijderd"
+        @loadingMessage="Formulieren worden verwijderd"
         {{on "click" this.deleteForm}}
       >Verwijder</AuButton>
       <AuButton


### PR DESCRIPTION
## Description

We do not want the form to be removed when it is used somewhere.

## How to test

1. Create an custom form
2. Link to this form from an extension of other custom form
3. Try deleting the form from step 1
4. You should only be able to close the delete modal
5. When deleting an instance of the form it can be deleted when there are implementations BUT these will be removed from the implementations when done (existing code)

## Links to other PR's

- https://github.com/lblod/form-content-service/pull/85

## Attachments

![image](https://github.com/user-attachments/assets/5687fec5-08d2-4c24-9c69-5713b1b146b7)

