### PR TITLE
Lmb 1532 | summary fields should be ordered

### DIFF
--- a/app/routes/custom-forms/instances.js
+++ b/app/routes/custom-forms/instances.js
@@ -23,7 +23,6 @@ export default class CustomFormsInstancesIndexRoute extends Route {
     return {
       form,
       formDefinition,
-      headerLabels: await this.semanticFormRepository.getHeaderLabels(form.id),
       usage,
     };
   }

--- a/app/styles/project/_c-edit-form-definition.scss
+++ b/app/styles/project/_c-edit-form-definition.scss
@@ -4,7 +4,7 @@
   flex-direction: row;
   gap: 1rem;
   padding: 2rem;
-  height: 100%;
+  flex-grow: 1;
 }
 
 @media (max-width: 750px) {

--- a/app/templates/custom-forms/instances/index.hbs
+++ b/app/templates/custom-forms/instances/index.hbs
@@ -12,7 +12,6 @@
           @page={{this.page}}
           @size={{this.size}}
           @filter={{this.filter}}
-          @labels={{this.model.headerLabels}}
           @showDownloadButton={{true}}
           @search={{this.search}}
           @form={{this.model.form}}


### PR DESCRIPTION
## Description

In the application the labels shown in tables or configuration of forms should always have the summary labels ordered by field. If the users uses the table label configurator this should ofcourse follow the manual input.

## How to test

1. Create a custom form with fields with show in summary active
2. This order of the fields should be the same order displayed in the table
3. when changing the order or showing hiding fields with the table configurator it should be reflected in the table aswell
4. Download an instance table, the headers should be the same as in the instance table and in the same order aswell

## Links to other PR's

- https://github.com/lblod/ember-semantic-forms/pull/9
- https://github.com/lblod/form-content-service/pull/86
