### PR TITLE
LMB-1521 | check if the the rijksregister number is already used

### DIFF
--- a/app/components/rdf-input-fields/rijksregister-input.hbs
+++ b/app/components/rdf-input-fields/rijksregister-input.hbs
@@ -23,6 +23,6 @@
   <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
 {{/each}}
 
-{{#each this.warnings as |warning|}}
+{{#each this.allWarnings as |warning|}}
   <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
 {{/each}}

--- a/app/components/rdf-input-fields/rijksregister-input.hbs
+++ b/app/components/rdf-input-fields/rijksregister-input.hbs
@@ -23,6 +23,6 @@
   <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
 {{/each}}
 
-{{#each this.allWarnings as |warning|}}
+{{#each this.warnings as |warning|}}
   <AuHelpText @warning={{true}}>{{warning.resultMessage}}</AuHelpText>
 {{/each}}

--- a/app/components/rdf-input-fields/rijksregister-input.js
+++ b/app/components/rdf-input-fields/rijksregister-input.js
@@ -62,7 +62,17 @@ export default class RDFRijksRegisterInput extends InputFieldComponent {
     this.hasBeenFocused = true;
   }
 
+  get shouldCheckOnDuplicateRrn() {
+    return !!this.constraints.find(
+      (c) => c.type?.value === 'http://mu.semte.ch/vocabularies/ext/IsUniqueRrn'
+    );
+  }
+
   async checkForDuplicates(rrn) {
+    if (!this.shouldCheckOnDuplicateRrn) {
+      return;
+    }
+
     const duplicateRrns = await this.store.query('identificator', {
       'filter[:exact:identificator]': rrn,
     });

--- a/app/components/rdf-input-fields/rijksregister-input.js
+++ b/app/components/rdf-input-fields/rijksregister-input.js
@@ -38,8 +38,7 @@ export default class RDFRijksRegisterInput extends InputFieldComponent {
 
     if (matches.values.length > 0) {
       this.rijksregisternummer = matches.values[0].value;
-      replaceSingleFormValue(this.storeOptions, this.rijksregisternummer);
-      await this.checkForDuplicates(this.rijksregisternummer);
+      await this.setFormValue(this.rijksregisternummer);
     }
   }
 
@@ -50,13 +49,7 @@ export default class RDFRijksRegisterInput extends InputFieldComponent {
     }
     const rijksregisternummer = event.target.value.trim();
     this.rijksregisternummer = rijksregisternummer;
-    let formValue = rijksregisternummer ? rijksregisternummer : null;
-
-    await this.checkForDuplicates(this.rijksregisternummer);
-    if (this.isDuplicate) {
-      formValue = null;
-    }
-    replaceSingleFormValue(this.storeOptions, formValue);
+    await this.setFormValue(this.rijksregisternummer);
 
     this.updateValidations();
     this.hasBeenFocused = true;
@@ -89,5 +82,15 @@ export default class RDFRijksRegisterInput extends InputFieldComponent {
     } else {
       this.duplicateErrorMessage = null;
     }
+  }
+
+  async setFormValue(rijksregisternummer) {
+    let formValue = rijksregisternummer ? rijksregisternummer : null;
+
+    await this.checkForDuplicates(this.rijksregisternummer);
+    if (this.isDuplicate) {
+      formValue = null;
+    }
+    replaceSingleFormValue(this.storeOptions, formValue);
   }
 }

--- a/app/utils/form-validations/register.js
+++ b/app/utils/form-validations/register.js
@@ -1,7 +1,7 @@
 import { registerCustomValidation } from '@lblod/submission-form-helpers';
 import {
   rijksregisternummerValidation,
-  warnWhenInputIsDuplicateRrn,
+  errorWhenInputIsDuplicateRrn,
 } from './rijksregisternummer';
 import { isValidRangorde } from './mandataris-rangorde';
 import { isValidMandatarisDate } from './mandataris-date-in-bestuursperiod';
@@ -15,8 +15,8 @@ export const registerCustomValidations = () => {
     rijksregisternummerValidation
   );
   registerCustomValidation(
-    'http://mu.semte.ch/vocabularies/ext/IsUniqueRrn',
-    warnWhenInputIsDuplicateRrn
+    'http://mu.semte.ch/vocabularies/ext/RijksregisternummerIsDuplicate',
+    errorWhenInputIsDuplicateRrn
   );
   registerCustomValidation(
     'http://mu.semte.ch/vocabularies/ext/ValidRangorde',

--- a/app/utils/form-validations/register.js
+++ b/app/utils/form-validations/register.js
@@ -1,5 +1,8 @@
 import { registerCustomValidation } from '@lblod/submission-form-helpers';
-import { rijksregisternummerValidation } from './rijksregisternummer';
+import {
+  rijksregisternummerValidation,
+  warnWhenInputIsDuplicateRrn,
+} from './rijksregisternummer';
 import { isValidRangorde } from './mandataris-rangorde';
 import { isValidMandatarisDate } from './mandataris-date-in-bestuursperiod';
 import { isRequiredWhenBestuursorgaanInList } from './required-constraint-for-bestuursorganen';
@@ -10,6 +13,10 @@ export const registerCustomValidations = () => {
   registerCustomValidation(
     'http://mu.semte.ch/vocabularies/ext/ValidRijksregisternummer',
     rijksregisternummerValidation
+  );
+  registerCustomValidation(
+    'http://mu.semte.ch/vocabularies/ext/IsUniqueRrn',
+    warnWhenInputIsDuplicateRrn
   );
   registerCustomValidation(
     'http://mu.semte.ch/vocabularies/ext/ValidRangorde',

--- a/app/utils/form-validations/rijksregisternummer.js
+++ b/app/utils/form-validations/rijksregisternummer.js
@@ -131,7 +131,7 @@ export function parse(nrn) {
 export const rijksregisternummerValidation = (value) =>
   isValidRijksregisternummer(value.value);
 
-export const warnWhenInputIsDuplicateRrn = () => {
-  // validation itself is done in the component as we do not have access to the ember-store in here
+export const errorWhenInputIsDuplicateRrn = () => {
+  // validation itself is done in the component as  validations are not asynchronious
   return true;
 };

--- a/app/utils/form-validations/rijksregisternummer.js
+++ b/app/utils/form-validations/rijksregisternummer.js
@@ -130,3 +130,8 @@ export function parse(nrn) {
 
 export const rijksregisternummerValidation = (value) =>
   isValidRijksregisternummer(value.value);
+
+export const warnWhenInputIsDuplicateRrn = () => {
+  // validation itself is done in the component as we do not have access to the ember-store in here
+  return true;
+};


### PR DESCRIPTION
## Description

We want to check if the creation of a person will lead to a duplicate rrn. Show a warning when the persons rrn is already in the current graph.

## How to test

1. GO to an OCMW and to BCSD
2. start the creation of a mandatris
3. search for a person and than click create a new person
4. the validation should have trigggered for duplicate when searching on the rrn

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/442

## Attachments

**LATEST**
![image](https://github.com/user-attachments/assets/5224c8fc-fde7-4ce1-aeed-9a831eee163c)


**OLD**
![image](https://github.com/user-attachments/assets/56fbb660-069d-4369-b310-a6e1ff7bad76)
