### PR TITLE
lmb-1634: fix show text in sidebar when clicking on  a standard field

### DIFF
--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -13,6 +13,7 @@ import { API } from 'frontend-lmb/utils/constants';
 import { showErrorToast } from 'frontend-lmb/utils/toasts';
 import { SOURCE_GRAPH } from 'frontend-lmb/utils/constants';
 import { isCustomForm } from 'frontend-lmb/utils/form-properties';
+import { isCustomDisplayType } from 'frontend-lmb/models/display-type';
 
 export default class EditableFormComponent extends Component {
   @use(getFieldsForForm) getFieldsForForm;
@@ -54,10 +55,13 @@ export default class EditableFormComponent extends Component {
   }
 
   @action
-  setClickedField(fieldModel) {
-    if (this.args.onFieldSelected) {
-      this.args.onFieldSelected(fieldModel);
+  async setClickedField(fieldModel) {
+    let field = fieldModel;
+    if (isCustomDisplayType(fieldModel?.displayType)) {
+      await this.getFieldsForForm.retry();
+      field = this.fields.filter((f) => f.uri === fieldModel.uri?.value)[0];
     }
+    this.args.onFieldSelected?.(field);
   }
 
   get editableFormsEnabled() {

--- a/app/templates/custom-forms/index.hbs
+++ b/app/templates/custom-forms/index.hbs
@@ -57,7 +57,7 @@
         </LinkTo>
       </td>
       <td>
-        {{form.id}}
+        {{form.description}}
       </td>
       <td class="au-u-1-5">{{form.displayCreatedDate}}</td>
       <td class="au-u-1-5">{{form.displayModifiedDate}}</td>


### PR DESCRIPTION
## Description

When clicking the standard field is should show a text that it is not editable. Previous code broke deleting a custom form. This is fixed.

## How to test

Test out the edit form of a form extension

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/581
