### PR TITLE
Ben/lmb 1633 show confirmation window when making person independent

### DIFF
--- a/app/components/shared/confirmation-modal.hbs
+++ b/app/components/shared/confirmation-modal.hbs
@@ -9,7 +9,7 @@
     <AuToolbar as |Group|>
       <Group class="flex-grow">
         <AuButtonGroup>
-          <AuButton {{on "click" @confirm}}>
+          <AuButton @loading={{@loading}} {{on "click" @confirm}}>
             Bevestig
           </AuButton>
           <AuButton @skin="secondary" {{on "click" @cancel}}>

--- a/app/components/shared/confirmation-modal.hbs
+++ b/app/components/shared/confirmation-modal.hbs
@@ -12,6 +12,7 @@
           <AuButton
             @loading={{@loading}}
             @loadingMessage="Opslaan"
+            @disabled={{@disabled}}
             {{on "click" @confirm}}
           >
             Bevestig

--- a/app/components/shared/confirmation-modal.hbs
+++ b/app/components/shared/confirmation-modal.hbs
@@ -9,7 +9,11 @@
     <AuToolbar as |Group|>
       <Group class="flex-grow">
         <AuButtonGroup>
-          <AuButton @loading={{@loading}} {{on "click" @confirm}}>
+          <AuButton
+            @loading={{@loading}}
+            @loadingMessage="Opslaan"
+            {{on "click" @confirm}}
+          >
             Bevestig
           </AuButton>
           <AuButton @skin="secondary" {{on "click" @cancel}}>

--- a/app/components/shared/confirmation-modal.hbs
+++ b/app/components/shared/confirmation-modal.hbs
@@ -1,0 +1,22 @@
+<AuModal @modalOpen={{@isModalOpen}} @closable={{true}} @closeModal={{@cancel}}>
+  <:title>
+    {{@title}}
+  </:title>
+  <:body>
+    {{yield}}
+  </:body>
+  <:footer>
+    <AuToolbar as |Group|>
+      <Group class="flex-grow">
+        <AuButtonGroup>
+          <AuButton {{on "click" @confirm}}>
+            Bevestig
+          </AuButton>
+          <AuButton @skin="secondary" {{on "click" @cancel}}>
+            Annuleer
+          </AuButton>
+        </AuButtonGroup>
+      </Group>
+    </AuToolbar>
+  </:footer>
+</AuModal>

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -25,6 +25,7 @@ export default class MandatarissenPersoonMandatenController extends Controller {
   @tracked size = 20;
   @tracked canBecomeOnafhankelijk;
   @tracked currentNonOnafhankelijkeMandatarissen = [];
+  @tracked isIndependentModalOpen = false;
   @tracked isModalOpen = false;
   @tracked isEndMandatesModalOpen = false;
   @tracked selectedBestuursorgaan = null;

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -34,16 +34,18 @@ export default class MandatarissenPersoonMandatenController extends Controller {
   sort = 'is-bestuurlijke-alias-van.achternaam';
 
   @action
-  closeModal() {
+  resetModals() {
     this.isCreatingModalOpen = false;
     this.isEndMandatesModalOpen = false;
+    this.isIndependentModalOpen = false;
     this.selectedBestuursorgaan = null;
+    this.date = new Date();
   }
 
   @action
   createMandataris() {
     const bestuursorgaan = this.selectedBestuursorgaan;
-    this.closeModal();
+    this.resetModals();
     this.router.transitionTo(
       'organen.orgaan.mandataris.new',
       bestuursorgaan.id,
@@ -129,7 +131,7 @@ export default class MandatarissenPersoonMandatenController extends Controller {
       await mandataris.save();
     }
 
-    this.isIndependentModalOpen = false;
+    this.resetModals();
     this.router.refresh();
   });
 
@@ -143,7 +145,7 @@ export default class MandatarissenPersoonMandatenController extends Controller {
       `Active mandatatarissen beëindigd voor ${this.model.persoon.naam}`
     );
     this.activeOnly = false;
-    this.isEndMandatesModalOpen = false;
+    this.resetModals();
     this.router.refresh();
   });
 

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -30,7 +30,7 @@ export default class MandatarissenPersoonMandatenController extends Controller {
   @tracked isEndMandatesModalOpen = false;
   @tracked selectedBestuursorgaan = null;
   @tracked activeOnly = true;
-  @tracked date = endOfDay(new Date());
+  @tracked date = new Date();
   sort = 'is-bestuurlijke-alias-van.achternaam';
 
   @action
@@ -105,11 +105,10 @@ export default class MandatarissenPersoonMandatenController extends Controller {
         );
       await onafhankelijkeFractie.save();
 
-      const dateNow = new Date();
       const newMandatarisProps = await this.mandatarisService.createNewProps(
         mandataris,
         {
-          start: dateNow,
+          start: this.date,
           publicationStatus: await getNietBekrachtigdPublicationStatus(
             this.store
           ),
@@ -131,7 +130,7 @@ export default class MandatarissenPersoonMandatenController extends Controller {
         newMandataris.id
       );
 
-      mandataris.einde = endOfDay(dateNow);
+      mandataris.einde = endOfDay(this.date);
       await mandataris.save();
     }
 

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -26,7 +26,7 @@ export default class MandatarissenPersoonMandatenController extends Controller {
   @tracked canBecomeOnafhankelijk;
   @tracked currentNonOnafhankelijkeMandatarissen = [];
   @tracked isIndependentModalOpen = false;
-  @tracked isModalOpen = false;
+  @tracked isCreatingModalOpen = false;
   @tracked isEndMandatesModalOpen = false;
   @tracked selectedBestuursorgaan = null;
   @tracked activeOnly = true;
@@ -35,12 +35,12 @@ export default class MandatarissenPersoonMandatenController extends Controller {
 
   @action
   toggleModal() {
-    this.isModalOpen = !this.isModalOpen;
+    this.isCreatingModalOpen = !this.isCreatingModalOpen;
   }
 
   @action
   closeModal() {
-    this.isModalOpen = false;
+    this.isCreatingModalOpen = false;
     this.isEndMandatesModalOpen = false;
     this.selectedBestuursorgaan = null;
   }

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -8,7 +8,7 @@ import { task } from 'ember-concurrency';
 import { getNietBekrachtigdPublicationStatus } from 'frontend-lmb/utils/get-mandataris-status';
 import { showSuccessToast } from 'frontend-lmb/utils/toasts';
 
-import { endOfDay } from 'frontend-lmb/utils/date-manipulation';
+import { startOfDay, endOfDay } from 'frontend-lmb/utils/date-manipulation';
 
 export default class MandatarissenPersoonMandatenController extends Controller {
   @service router;
@@ -105,7 +105,7 @@ export default class MandatarissenPersoonMandatenController extends Controller {
       const newMandatarisProps = await this.mandatarisService.createNewProps(
         mandataris,
         {
-          start: this.date,
+          start: startOfDay(this.date),
           publicationStatus: await getNietBekrachtigdPublicationStatus(
             this.store
           ),

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -112,10 +112,10 @@ export default class MandatarissenPersoonMandatenController extends Controller {
           fractie: onafhankelijkeFractie,
         }
       );
-      const newMandataris = await this.store.createRecord(
-        'mandataris',
-        newMandatarisProps
-      );
+      const newMandataris = await this.store.createRecord('mandataris', {
+        ...newMandatarisProps,
+        rangorde: mandataris.rangorde,
+      });
       await newMandataris.save();
 
       await this.mandatarisService.createNewLidmaatschap(

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -34,11 +34,6 @@ export default class MandatarissenPersoonMandatenController extends Controller {
   sort = 'is-bestuurlijke-alias-van.achternaam';
 
   @action
-  toggleModal() {
-    this.isCreatingModalOpen = !this.isCreatingModalOpen;
-  }
-
-  @action
   closeModal() {
     this.isCreatingModalOpen = false;
     this.isEndMandatesModalOpen = false;

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -135,6 +135,7 @@ export default class MandatarissenPersoonMandatenController extends Controller {
       await mandataris.save();
     }
 
+    this.isIndependentModalOpen = false;
     this.router.refresh();
   });
 

--- a/app/controllers/mandatarissen/persoon/mandaten.js
+++ b/app/controllers/mandatarissen/persoon/mandaten.js
@@ -153,7 +153,7 @@ export default class MandatarissenPersoonMandatenController extends Controller {
     return 'Deze persoon is reeds onafhankelijk.';
   }
 
-  get endMandatarissenDisabled() {
+  get noDateSelected() {
     return !this.date;
   }
 }

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -157,7 +157,7 @@
 
 <AuModal
   @title="Selecteer orgaan"
-  @modalOpen={{this.isModalOpen}}
+  @modalOpen={{this.isCreatingModalOpen}}
   @closeModal={{this.closeModal}}
   as |Modal|
 >

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -250,7 +250,7 @@
   @loading={{this.becomeOnafhankelijk.isRunning}}
 >
   <div>
-    Ben je zeker dat je deze persoon onafhankelijk wil maken?
+    Ben je zeker dat je deze persoon onafhankelijk wilt maken?
   </div>
   <div>
     Dit betekent dat alle mandaten van deze persoon aangepast zullen worden. De

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -207,7 +207,7 @@
   @loading={{this.endActiveMandaten.isRunning}}
   @disabled={{this.noDateSelected}}
 >
-  <div>
+  <div class="au-u-margin-bottom-small">
     Door verder te gaan, worden de einddatums van de actieve mandaten van deze
     persoon, in de huidige bestuursperiode aangepast, waardoor deze mandaten
     beëindigd worden. Opgelet dit geld ook voor verhinderde mandaten, hun
@@ -229,10 +229,10 @@
   @loading={{this.becomeOnafhankelijk.isRunning}}
   @disabled={{this.noDateSelected}}
 >
-  <div>
+  <div class="au-u-margin-bottom-small">
     Ben je zeker dat je deze persoon onafhankelijk wilt maken?
   </div>
-  <div>
+  <div class="au-u-margin-bottom-small">
     Dit betekent dat alle mandaten van deze persoon aangepast zullen worden. De
     persoon zal niet langer tot een fractie behoren en zal in al zijn mandaten
     als onafhankelijk beschouwd worden.

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -219,7 +219,6 @@
         @value={{this.date}}
         @onChange={{fn (mut this.date)}}
         @isRequired={{true}}
-        @endOfDay={{true}}
       />
     </div>
   </Modal.Body>
@@ -257,4 +256,10 @@
     persoon zal niet langer tot een fractie behoren en zal in al zijn mandaten
     als onafhankelijk beschouwd worden.
   </div>
+  <DateInput
+    @label="Datum wijziging"
+    @value={{this.date}}
+    @onChange={{fn (mut this.date)}}
+    @isRequired={{true}}
+  />
 </Shared::ConfirmationModal>

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -242,39 +242,18 @@
   </Modal.Footer>
 </AuModal>
 
-<AuModal
-  @modalOpen={{this.isIndependentModalOpen}}
-  @closable={{true}}
-  @closeModal={{fn (mut this.isIndependentModalOpen) false}}
+<Shared::ConfirmationModal
+  @title="Onafhankelijk worden"
+  @isModalOpen={{this.isIndependentModalOpen}}
+  @confirm={{perform this.becomeOnafhankelijk}}
+  @cancel={{fn (mut this.isIndependentModalOpen) false}}
 >
-  <:title>
-    Onafhankelijk worden
-  </:title>
-  <:body>
-    <div>
-      Ben je zeker dat je deze persoon onafhankelijk wil maken?
-    </div>
-    <div>
-      Dit betekent dat alle mandaten van deze persoon aangepast zullen worden.
-      De persoon zal niet langer tot een fractie behoren en zal in al zijn
-      mandaten als onafhankelijk beschouwd worden.
-    </div>
-  </:body>
-  <:footer>
-    <AuToolbar as |Group|>
-      <Group class="flex-grow">
-        <AuButtonGroup>
-          <AuButton {{on "click" (perform this.becomeOnafhankelijk)}}>
-            Bevestig
-          </AuButton>
-          <AuButton
-            @skin="secondary"
-            {{on "click" (fn (mut this.isIndependentModalOpen) false)}}
-          >
-            Annuleer
-          </AuButton>
-        </AuButtonGroup>
-      </Group>
-    </AuToolbar>
-  </:footer>
-</AuModal>
+  <div>
+    Ben je zeker dat je deze persoon onafhankelijk wil maken?
+  </div>
+  <div>
+    Dit betekent dat alle mandaten van deze persoon aangepast zullen worden. De
+    persoon zal niet langer tot een fractie behoren en zal in al zijn mandaten
+    als onafhankelijk beschouwd worden.
+  </div>
+</Shared::ConfirmationModal>

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -35,7 +35,7 @@
         }}
         @loadingMessage="Onafhankelijk worden"
         @disabled={{not this.canBecomeOnafhankelijk}}
-        {{on "click" (perform this.becomeOnafhankelijk)}}
+        {{on "click" (fn (mut this.isIndependentModalOpen) true)}}
       >
         Onafhankelijk worden
       </AuButton>
@@ -240,4 +240,41 @@
       </Group>
     </AuToolbar>
   </Modal.Footer>
+</AuModal>
+
+<AuModal
+  @modalOpen={{this.isIndependentModalOpen}}
+  @closable={{true}}
+  @closeModal={{fn (mut this.isIndependentModalOpen) false}}
+>
+  <:title>
+    Onafhankelijk worden
+  </:title>
+  <:body>
+    <div>
+      Ben je zeker dat je deze persoon onafhankelijk wil maken?
+    </div>
+    <div>
+      Dit betekent dat alle mandaten van deze persoon aangepast zullen worden.
+      De persoon zal niet langer tot een fractie behoren en zal in al zijn
+      mandaten als onafhankelijk beschouwd worden.
+    </div>
+  </:body>
+  <:footer>
+    <AuToolbar as |Group|>
+      <Group class="flex-grow">
+        <AuButtonGroup>
+          <AuButton {{on "click" (perform this.becomeOnafhankelijk)}}>
+            Bevestig
+          </AuButton>
+          <AuButton
+            @skin="secondary"
+            {{on "click" (fn (mut this.isIndependentModalOpen) false)}}
+          >
+            Annuleer
+          </AuButton>
+        </AuButtonGroup>
+      </Group>
+    </AuToolbar>
+  </:footer>
 </AuModal>

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -199,47 +199,27 @@
   </Modal.Footer>
 </AuModal>
 
-<AuModal
+<Shared::ConfirmationModal
   @title="Beëindig actieve mandaten"
-  @modalOpen={{this.isEndMandatesModalOpen}}
-  @closeModal={{this.resetModals}}
-  as |Modal|
+  @isModalOpen={{this.isEndMandatesModalOpen}}
+  @confirm={{perform this.endActiveMandaten}}
+  @cancel={{this.resetModals}}
+  @loading={{this.endActiveMandaten.isRunning}}
+  @disabled={{this.noDateSelected}}
 >
-  <Modal.Body>
-    <div class="au-o-box au-o-flow">
-      <div>
-        Door verder te gaan, worden de einddatums van de actieve mandaten van
-        deze persoon, in de huidige bestuursperiode aangepast, waardoor deze
-        mandaten beëindigd worden. Opgelet dit geld ook voor verhinderde
-        mandaten, hun einddatum wordt dan ook aangepast naar de ingevoerde
-        datum.
-      </div>
-      <DateInput
-        @label="Einddatum"
-        @value={{this.date}}
-        @onChange={{fn (mut this.date)}}
-        @isRequired={{true}}
-      />
-    </div>
-  </Modal.Body>
-  <Modal.Footer>
-    <AuToolbar as |Group|>
-      <Group>
-        <AuButton
-          @loading={{this.endActiveMandaten.isRunning}}
-          @loadingMessage="Actieve mandaten worden beëindigd"
-          @disabled={{this.endMandatarissenDisabled}}
-          {{on "click" (perform this.endActiveMandaten)}}
-        >
-          Beëindig mandatarissen
-        </AuButton>
-        <AuButton @skin="secondary" {{on "click" this.resetModals}}>
-          Annuleer
-        </AuButton>
-      </Group>
-    </AuToolbar>
-  </Modal.Footer>
-</AuModal>
+  <div>
+    Door verder te gaan, worden de einddatums van de actieve mandaten van deze
+    persoon, in de huidige bestuursperiode aangepast, waardoor deze mandaten
+    beëindigd worden. Opgelet dit geld ook voor verhinderde mandaten, hun
+    einddatum wordt dan ook aangepast naar de ingevoerde datum.
+  </div>
+  <DateInput
+    @label="Einddatum"
+    @value={{this.date}}
+    @onChange={{fn (mut this.date)}}
+    @isRequired={{true}}
+  />
+</Shared::ConfirmationModal>
 
 <Shared::ConfirmationModal
   @title="Onafhankelijk worden"

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -227,6 +227,7 @@
   @confirm={{perform this.becomeOnafhankelijk}}
   @cancel={{this.resetModals}}
   @loading={{this.becomeOnafhankelijk.isRunning}}
+  @disabled={{this.noDateSelected}}
 >
   <div>
     Ben je zeker dat je deze persoon onafhankelijk wilt maken?

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -247,6 +247,7 @@
   @isModalOpen={{this.isIndependentModalOpen}}
   @confirm={{perform this.becomeOnafhankelijk}}
   @cancel={{fn (mut this.isIndependentModalOpen) false}}
+  @loading={{this.becomeOnafhankelijk.isRunning}}
 >
   <div>
     Ben je zeker dat je deze persoon onafhankelijk wil maken?

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -40,7 +40,7 @@
         Onafhankelijk worden
       </AuButton>
     </Shared::Tooltip>
-    <AuButton {{on "click" this.toggleModal}}>
+    <AuButton {{on "click" (fn (mut this.isCreatingModalOpen) true)}}>
       Voeg nieuw mandaat toe
     </AuButton>
   </Group>

--- a/app/templates/mandatarissen/persoon/mandaten.hbs
+++ b/app/templates/mandatarissen/persoon/mandaten.hbs
@@ -158,7 +158,7 @@
 <AuModal
   @title="Selecteer orgaan"
   @modalOpen={{this.isCreatingModalOpen}}
-  @closeModal={{this.closeModal}}
+  @closeModal={{this.resetModals}}
   as |Modal|
 >
   <Modal.Body>
@@ -191,7 +191,7 @@
         >
           Voeg nieuw mandaat toe
         </AuButton>
-        <AuButton @skin="secondary" {{on "click" this.closeModal}}>
+        <AuButton @skin="secondary" {{on "click" this.resetModals}}>
           Annuleer
         </AuButton>
       </Group>
@@ -202,7 +202,7 @@
 <AuModal
   @title="Beëindig actieve mandaten"
   @modalOpen={{this.isEndMandatesModalOpen}}
-  @closeModal={{this.closeModal}}
+  @closeModal={{this.resetModals}}
   as |Modal|
 >
   <Modal.Body>
@@ -233,7 +233,7 @@
         >
           Beëindig mandatarissen
         </AuButton>
-        <AuButton @skin="secondary" {{on "click" this.closeModal}}>
+        <AuButton @skin="secondary" {{on "click" this.resetModals}}>
           Annuleer
         </AuButton>
       </Group>
@@ -245,7 +245,7 @@
   @title="Onafhankelijk worden"
   @isModalOpen={{this.isIndependentModalOpen}}
   @confirm={{perform this.becomeOnafhankelijk}}
-  @cancel={{fn (mut this.isIndependentModalOpen) false}}
+  @cancel={{this.resetModals}}
   @loading={{this.becomeOnafhankelijk.isRunning}}
 >
   <div>

--- a/app/utils/date-manipulation.js
+++ b/app/utils/date-manipulation.js
@@ -1,6 +1,14 @@
 import moment from 'moment';
 import { NULL_DATE } from './constants';
 
+export function startOfDay(date) {
+  if (date) {
+    return moment(date).startOf('day').utc().toDate();
+  } else {
+    return moment().startOf('day').utc().toDate();
+  }
+}
+
 export function endOfDay(date) {
   if (date) {
     return moment(date)


### PR DESCRIPTION
## Description

When making a person independent a confirmation modal is shown.
This window also allows selecting a specific date when the change should happen.

<img width="869" alt="Screenshot 2025-06-18 at 14 14 11" src="https://github.com/user-attachments/assets/a06d02a2-9c3d-4b31-950a-db34df9e72bf" />

## How to test

Go to the mandaten page of a person and check if the "become onafhankelijk" shows a modal with an input field and if the different actions work as expected. 
Also check if the create mandataris and the beeindig still work as expected. 
