### PR TITLE
LMB-1653 | Library field option in edit custom field

### DIFF
--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -32,6 +32,7 @@
       <AuFormRow class="au-form-row-full-width">
         <AuLabel @required={{true}} for="library-entry">Uit bibliotheek</AuLabel>
         <PowerSelect
+          @disabled={{this.isLoadingLibraryFieldType}}
           @allowClear={{false}}
           @renderInPlace={{false}}
           @searchEnabled={{true}}
@@ -52,7 +53,10 @@
         <AuLabel @required={{true}} for="display-type">Type</AuLabel>
         <PowerSelect
           @allowClear={{false}}
-          @disabled={{not this.canSelectTypeForEntry}}
+          @disabled={{or
+            (not this.canSelectTypeForEntry)
+            this.isLoadingLibraryFieldType
+          }}
           @renderInPlace={{false}}
           @searchEnabled={{true}}
           @loadingMessage="Aan het laden..."

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -30,10 +30,29 @@
         {{/unless}}
       </AuFormRow>
       <AuFormRow class="au-form-row-full-width">
+        <AuLabel @required={{true}} for="library-entry">Uit bibliotheek</AuLabel>
+        <PowerSelect
+          @allowClear={{false}}
+          @renderInPlace={{false}}
+          @searchEnabled={{true}}
+          @loadingMessage="Aan het laden..."
+          @noMatchesMessage="Geen velden gevonden"
+          @searchMessage="Typ om te zoeken"
+          @searchField="name"
+          @options={{this.libraryFieldOptions}}
+          @selected={{this.libraryFieldType}}
+          @onChange={{this.updateLibraryFieldType}}
+          id="library-entry"
+          as |selected|
+        >
+          {{selected.name}}
+        </PowerSelect>
+      </AuFormRow>
+      <AuFormRow class="au-form-row-full-width">
         <AuLabel @required={{true}} for="display-type">Type</AuLabel>
         <PowerSelect
           @allowClear={{false}}
-          @disabled={{not this.selectedField}}
+          @disabled={{not this.canSelectTypeForEntry}}
           @renderInPlace={{false}}
           @searchEnabled={{true}}
           @loadingMessage="Aan het laden..."

--- a/app/components/custom-form/edit-custom-field.hbs
+++ b/app/components/custom-form/edit-custom-field.hbs
@@ -32,7 +32,7 @@
       <AuFormRow class="au-form-row-full-width">
         <AuLabel @required={{true}} for="library-entry">Uit bibliotheek</AuLabel>
         <PowerSelect
-          @disabled={{this.isLoadingLibraryFieldType}}
+          @disabled={{this.isLoadingLibraryEntries}}
           @allowClear={{false}}
           @renderInPlace={{false}}
           @searchEnabled={{true}}
@@ -55,7 +55,7 @@
           @allowClear={{false}}
           @disabled={{or
             (not this.canSelectTypeForEntry)
-            this.isLoadingLibraryFieldType
+            this.isLoadingLibraryEntries
           }}
           @renderInPlace={{false}}
           @searchEnabled={{true}}

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -290,11 +290,14 @@ function getLibraryFieldOptions() {
         sort: 'name',
         include: 'display-type',
       });
+      const availableOptions = allOptions.filter((o) => {
+        if (this.args.selectedField?.libraryEntryUri === o.uri) {
+          return true;
+        }
+        return !fieldsLibraryEntryUris.includes(o?.uri);
+      });
 
-      return [
-        customFieldEntry,
-        ...allOptions.filter((o) => !fieldsLibraryEntryUris.includes(o?.uri)),
-      ];
+      return [customFieldEntry, ...availableOptions];
     }
 
     return [customFieldEntry];

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -265,7 +265,7 @@ function getLibraryFieldType() {
   return trackedFunction(async () => {
     let fieldType = this.fakeLibraryEntry;
     if (this.libraryEntryUri) {
-      fieldType = queryRecord(this.store, 'library-entry', {
+      fieldType = await queryRecord(this.store, 'library-entry', {
         'filter[:uri:]': this.libraryEntryUri,
       });
     }

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -202,7 +202,7 @@ export default class CustomFormEditCustomField extends Component {
       {
         label: this.label,
         displayTypeUri: this.displayType?.get('uri'),
-        libraryEntryUri: this.libraryEntryUri?.uri,
+        libraryEntryUri: this.libraryEntryUri,
         conceptSchemeUri: this.conceptScheme?.uri,
         isRequired: this.isRequired,
         isShownInSummary: this.isShownInSummary,

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -156,8 +156,8 @@ export default class CustomFormEditCustomField extends Component {
 
   @action
   updateLibraryFieldType(libraryEntry) {
-    this.libraryFieldType = libraryEntry;
     this.libraryEntryUri = libraryEntry?.uri;
+    this.getLibraryFieldType.retry(); // Should have triggerd the tracked function, not sure why not..
     this.displayType =
       this.displayTypes.find(
         (t) => t?.uri === libraryEntry.get('displayType.uri')

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -191,8 +191,7 @@ export default class CustomFormEditCustomField extends Component {
   @action
   async saveFieldChanges() {
     this.isSaving = true;
-
-    if (this.isLinkFormTypeSelected) {
+    if (this.displayType?.get('isLinkToForm')) {
       this.isShownInSummary = false;
     }
 

--- a/app/components/custom-form/edit-custom-field.js
+++ b/app/components/custom-form/edit-custom-field.js
@@ -70,6 +70,10 @@ export default class CustomFormEditCustomField extends Component {
     return this.getLibraryFieldType?.value || this.fakeLibraryEntry;
   }
 
+  get isLoadingLibraryFieldType() {
+    return !this.getLibraryFieldType?.isFinished;
+  }
+
   @cached
   get conceptSchemes() {
     return this.getConceptSchemes?.value || [];
@@ -260,13 +264,14 @@ function setSelectedField() {
 
 function getLibraryFieldType() {
   return trackedFunction(async () => {
+    let fieldType = this.fakeLibraryEntry;
     if (this.libraryEntryUri) {
-      return queryRecord(this.store, 'library-entry', {
+      fieldType = queryRecord(this.store, 'library-entry', {
         'filter[:uri:]': this.libraryEntryUri,
       });
-    } else {
-      return this.fakeLibraryEntry;
     }
+
+    return fieldType;
   });
 }
 

--- a/app/components/editable-form.js
+++ b/app/components/editable-form.js
@@ -28,7 +28,6 @@ export default class EditableFormComponent extends Component {
 
   constructor() {
     super(...arguments);
-    this.setClickedField(null);
     this.updateForm();
   }
 

--- a/app/controllers/custom-forms/instances/definition.js
+++ b/app/controllers/custom-forms/instances/definition.js
@@ -4,13 +4,10 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-import { consume } from 'ember-provide-consume-context';
 import { timeout } from 'ember-concurrency';
 import { isCustomDisplayType } from 'frontend-lmb/models/display-type';
 
 export default class CustomFormsInstancesDefinitionController extends Controller {
-  @consume('form-context') formContext;
-
   @service router;
 
   @tracked isEditFormModalOpen;

--- a/app/services/custom-forms.js
+++ b/app/services/custom-forms.js
@@ -117,7 +117,7 @@ export default class CustomFormsService extends Service {
         body: JSON.stringify({
           field: fieldUri,
           displayType: displayTypeUri,
-          libraryEntryUri: libraryEntryUri,
+          libraryEntryUri,
           name: label,
           isRequired: !!isRequired,
           showInSummary: !!isShownInSummary,

--- a/app/services/custom-forms.js
+++ b/app/services/custom-forms.js
@@ -99,6 +99,7 @@ export default class CustomFormsService extends Service {
     fieldUri,
     {
       label,
+      libraryEntryUri,
       displayTypeUri,
       conceptSchemeUri,
       isRequired,
@@ -116,6 +117,7 @@ export default class CustomFormsService extends Service {
         body: JSON.stringify({
           field: fieldUri,
           displayType: displayTypeUri,
+          libraryEntryUri: libraryEntryUri,
           name: label,
           isRequired: !!isRequired,
           showInSummary: !!isShownInSummary,


### PR DESCRIPTION
## Description

When adding a new custom field to a custom form we can select a field type from the library. When editing that same field this option is not available atm. Make it possible to select a different field type when editing a field.

## How to test

1. Add a "eigen veld" to the form
2. Change the bibliotheek type to "verblijfplaats" (path + displaytype is different)
3. Make the field required so it has the basis valdiations + the required validation
4. Create a form from the template and the data should be correct

## Links to other PR's

- https://github.com/lblod/form-content-service/pull/87
