### PR TITLE
LMB-1655 |  hide publication status for eigen organen

### DIFF
--- a/app/components/mandataris/edit/replacement-form.js
+++ b/app/components/mandataris/edit/replacement-form.js
@@ -22,6 +22,15 @@ export default class MandatarisEditReplacementForm extends Component {
     this.fractie = this.args.prefillFractie;
   }
 
+  willDestroy() {
+    this.args.onChange({
+      start: this.startDate,
+      einde: this.endDate,
+      fractie: this.fractie,
+    });
+    super.willDestroy(...arguments);
+  }
+
   get isFractieRequired() {
     return isRequiredForBestuursorgaan(this.args.bestuursorgaanIT);
   }

--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -17,44 +17,46 @@
         />
       </div>
     </div>
-    <div class="au-o-grid__item au-u-1-2">
-      <div class="au-c-description-label">Publicatie status</div>
-      <div class="au-c-description-value au-u-margin-top-tiny">
-        {{#if this.editingStatus}}
-          <Mandatarissen::Mandataris::PublicationStatusSelector
-            @mandataris={{@mandataris}}
-            @onUpdate={{this.stopEditingStatus}}
-          />
-        {{else}}
-          <Shared::Tooltip
-            @showTooltip={{not this.canEditPublicationStatus}}
-            @tooltipText={{this.lastStatusTooltipText}}
-            @alignment="left"
-          >
-            <div class="au-u-flex">
-              <Mandaat::PublicatieStatusPill
-                @mandataris={{@mandataris}}
-                @showInfoText={{true}}
-                @showBekijkBewijs={{true}}
-              />
-              {{#if this.showEditPublicationStatus}}
-                <AuButton
-                  {{on "click" this.editStatus}}
-                  @icon="pencil"
-                  @skin="link-secondary"
-                  @size="small"
-                  class="au-u-margin-left-tiny"
-                  @hideText={{true}}
-                  @disabled={{not this.canEditPublicationStatus}}
-                >
-                  edit
-                </AuButton>
-              {{/if}}
-            </div>
-          </Shared::Tooltip>
-        {{/if}}
+    {{#unless @hidePublicationStatus}}
+      <div class="au-o-grid__item au-u-1-2">
+        <div class="au-c-description-label">Publicatie status</div>
+        <div class="au-c-description-value au-u-margin-top-tiny">
+          {{#if this.editingStatus}}
+            <Mandatarissen::Mandataris::PublicationStatusSelector
+              @mandataris={{@mandataris}}
+              @onUpdate={{this.stopEditingStatus}}
+            />
+          {{else}}
+            <Shared::Tooltip
+              @showTooltip={{not this.canEditPublicationStatus}}
+              @tooltipText={{this.lastStatusTooltipText}}
+              @alignment="left"
+            >
+              <div class="au-u-flex">
+                <Mandaat::PublicatieStatusPill
+                  @mandataris={{@mandataris}}
+                  @showInfoText={{true}}
+                  @showBekijkBewijs={{true}}
+                />
+                {{#if this.showEditPublicationStatus}}
+                  <AuButton
+                    {{on "click" this.editStatus}}
+                    @icon="pencil"
+                    @skin="link-secondary"
+                    @size="small"
+                    class="au-u-margin-left-tiny"
+                    @hideText={{true}}
+                    @disabled={{not this.canEditPublicationStatus}}
+                  >
+                    edit
+                  </AuButton>
+                {{/if}}
+              </div>
+            </Shared::Tooltip>
+          {{/if}}
+        </div>
       </div>
-    </div>
+    {{/unless}}
     {{#if @mandataris.bekleedt.hasRangorde}}
       <div class="au-o-grid__item au-u-1-2">
         <div class="au-c-description-label">Rangorde</div>

--- a/app/components/organen/mandataris-table.js
+++ b/app/components/organen/mandataris-table.js
@@ -5,10 +5,12 @@ export default class OrganenMandatarisTableComponent extends Component {
     return this.args.bestuursorgaan.containsPoliticalMandates;
   }
   get hidePublicationStatus() {
-    return (
-      !this.args.bestuursorgaan.isDecretaal ||
-      this.args.bestuursorgaan.isPolitieraad
-    );
+    return Promise.all([
+      this.args.bestuursorgaan.isDecretaal,
+      this.args.bestuursorgaan.isPolitieraad,
+    ]).then(([isDecretaal, isPolitieRaad]) => {
+      return !isDecretaal || isPolitieRaad;
+    });
   }
   get showOwnership() {
     return this.args.bestuursorgaan.isPolitieraad;

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -93,6 +93,7 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
       isMostRecentVersion,
       bestuursorganen,
       firstBestuursorgaanInTijd,
+      isInEigenOrgaan: !(await firstBestuursorgaanInTijd.isDecretaal),
       periodeHasLegislatuur,
       behandeldeVergaderingen,
       linkedMandataris,

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -68,6 +68,7 @@
       @legislatuurInBehandeling={{this.isDisabledBecauseLegislatuur}}
       @effectiefIsLastPublicationStatus={{this.model.effectiefIsLastPublicationStatus}}
       @canEdit={{not this.notOwnedByUs}}
+      @hidePublicationStatus={{this.model.isInEigenOrgaan}}
     />
   </div>
 


### PR DESCRIPTION
## Description

Eigen organen should not show publicatie status in mandataris card and overview mandatarisTbale.

## How to test

1. it is hidden in the mandataris card
2. the column is hidden in the mandataris table of an orgaan
3. extra fix when selecting a replacement and not filling in any fields and just going to the next step the values are passed on on exit of the component so a start date is set (first try it on master and see that it misses a start date)

