### PR TITLE
lmb-1710: return the OG replacement when it did not change

### DIFF
--- a/app/components/mandataris/edit/wizard.js
+++ b/app/components/mandataris/edit/wizard.js
@@ -567,7 +567,11 @@ export default class MandatarisEditWizard extends Component {
       return null; // No replacement selected
     }
     if (this.isReplacementSameAsOrginal) {
-      return null;
+      const originalReplacementMandataris = (
+        await this.args.mandataris.tijdelijkeVervangingen
+      )[0];
+
+      return originalReplacementMandataris;
     }
 
     let replacer = null;


### PR DESCRIPTION
## Description

The replacement is removed when correcting the end date of the mandataris.

## How to test

1. set status to verhinderd
2. select replacement for that mandataris UPDATE-STATE
3. Open the wizard again and change the end date
4. The replacement should still be added
