### PR TITLE
LMB-1691 | Hide fractie from bcsd

### DIFF
--- a/app/components/mandatarissen/mandataris-card.hbs
+++ b/app/components/mandatarissen/mandataris-card.hbs
@@ -76,15 +76,17 @@
         {{moment-format @mandataris.start "DD-MM-YYYY"}}
       </div>
     </div>
-    <div class="au-o-grid__item au-u-1-2">
-      <div class="au-c-description-label">Fractie</div>
-      <div
-        class="au-c-description-value au-u-margin-top-tiny
-          {{unless this.fractie 'au-u-muted'}}"
-      >
-        {{if this.fractie this.fractie "Niet beschikbaar"}}
+    {{#unless @isFractieHidden}}
+      <div class="au-o-grid__item au-u-1-2">
+        <div class="au-c-description-label">Fractie</div>
+        <div
+          class="au-c-description-value au-u-margin-top-tiny
+            {{unless this.fractie 'au-u-muted'}}"
+        >
+          {{if this.fractie this.fractie "Niet beschikbaar"}}
+        </div>
       </div>
-    </div>
+    {{/unless}}
     <div class="au-o-grid__item au-u-1-2">
       <div class="au-c-description-label">Einde periode</div>
       <div class="au-c-description-value au-u-margin-top-tiny">

--- a/app/components/organen/bekrachtig-mandataris-table.hbs
+++ b/app/components/organen/bekrachtig-mandataris-table.hbs
@@ -28,11 +28,13 @@
         @currentSorting={{@sort}}
         @label="Familienaam"
       />
-      <AuDataTableThSortable
-        @field="heeftLidmaatschap.binnenFractie.naam"
-        @currentSorting={{@sort}}
-        @label="Fractie"
-      />
+      {{#unless @isFractieColumnHidden}}
+        <AuDataTableThSortable
+          @field="heeftLidmaatschap.binnenFractie.naam"
+          @currentSorting={{@sort}}
+          @label="Fractie"
+        />
+      {{/unless}}
       <AuDataTableThSortable
         @field="status.label"
         @currentSorting={{@sort}}
@@ -73,13 +75,15 @@
       <td>
         {{row.mandataris.isBestuurlijkeAliasVan.achternaam}}
       </td>
-      <td>
-        {{if
-          row.mandataris.heeftLidmaatschap.binnenFractie
-          row.mandataris.heeftLidmaatschap.binnenFractie.naam
-          "Niet beschikbaar"
-        }}
-      </td>
+      {{#unless @isFractieColumnHidden}}
+        <td>
+          {{if
+            row.mandataris.heeftLidmaatschap.binnenFractie
+            row.mandataris.heeftLidmaatschap.binnenFractie.naam
+            "Niet beschikbaar"
+          }}
+        </td>
+      {{/unless}}
       <td>
         <Mandaat::MandatarisStatusPill @mandataris={{row.mandataris}} />
       </td>

--- a/app/components/organen/mandataris-table.js
+++ b/app/components/organen/mandataris-table.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { isDisabledForBestuursorgaan } from 'frontend-lmb/utils/is-fractie-selector-required';
 
 import { service } from '@ember/service';
 
@@ -8,9 +9,9 @@ export default class OrganenMandatarisTableComponent extends Component {
   get showFractie() {
     return Promise.all([
       this.args.bestuursorgaan.containsPoliticalMandates,
-      this.args.bestuursorgaan.isBCSD,
-    ]).then(([isPolitical, isBCSD]) => {
-      return isPolitical && !isBCSD;
+      isDisabledForBestuursorgaan(this.args.bestuursorgaanInTijd),
+    ]).then(([isPolitical, isFractieDisabled]) => {
+      return isPolitical && !isFractieDisabled;
     });
   }
   get hidePublicationStatus() {

--- a/app/components/organen/mandataris-table.js
+++ b/app/components/organen/mandataris-table.js
@@ -6,7 +6,12 @@ export default class OrganenMandatarisTableComponent extends Component {
   @service currentSession;
 
   get showFractie() {
-    return this.args.bestuursorgaan.containsPoliticalMandates;
+    return Promise.all([
+      this.args.bestuursorgaan.containsPoliticalMandates,
+      this.args.bestuursorgaan.isBCSD,
+    ]).then(([isPolitical, isBCSD]) => {
+      return isPolitical && !isBCSD;
+    });
   }
   get hidePublicationStatus() {
     return Promise.all([

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -37,8 +37,10 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
       );
 
     const bestuursorganen = await mandaat.bevatIn;
-    const selectedBestuursperiode =
-      await bestuursorganen[0]?.heeftBestuursperiode;
+    const periodes = await Promise.all(
+      bestuursorganen.map((o) => o.heeftBestuursperiode)
+    );
+    const selectedBestuursperiode = periodes.filter((isValue) => isValue)[0];
     const periodeHasLegislatuur =
       (await selectedBestuursperiode.installatievergaderingen)?.length >= 1;
     const behandeldeVergaderingen = await this.store.query(

--- a/app/routes/mandatarissen/persoon/mandataris.js
+++ b/app/routes/mandatarissen/persoon/mandataris.js
@@ -3,7 +3,10 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 import { effectiefIsLastPublicationStatus } from 'frontend-lmb/utils/effectief-is-last-publication-status';
-import { isRequiredForBestuursorgaan } from 'frontend-lmb/utils/is-fractie-selector-required';
+import {
+  isDisabledForBestuursorgaan,
+  isRequiredForBestuursorgaan,
+} from 'frontend-lmb/utils/is-fractie-selector-required';
 import {
   MANDATARIS_EDIT_FORM_ID,
   MANDATARIS_EXTRA_INFO_FORM_ID,
@@ -98,6 +101,9 @@ export default class MandatarissenPersoonMandatarisRoute extends Route {
       bestuursorganen,
       firstBestuursorgaanInTijd,
       isPublicationStatusHidden,
+      isFractieHidden: await isDisabledForBestuursorgaan(
+        firstBestuursorgaanInTijd
+      ),
       periodeHasLegislatuur,
       behandeldeVergaderingen,
       linkedMandataris,

--- a/app/routes/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/routes/organen/orgaan/bulk-bekrachtiging.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 
 import { service } from '@ember/service';
+import { isDisabledForBestuursorgaan } from 'frontend-lmb/utils/is-fractie-selector-required';
 
 import {
   MANDATARIS_BEKRACHTIGD_PUBLICATION_STATE,
@@ -72,7 +73,9 @@ export default class BulkBekrachtigingRoute extends Route {
       currentBestuursorgaan: currentBestuursorgaan,
       publicationStatussen,
       hidePublicationStatus: this.currentSession.group.isOCMW && !isBcsdOrgaan,
-      isFractieColumnHidden: await parentModel.bestuursorgaan.isBCSD,
+      isFractieColumnHidden: await isDisabledForBestuursorgaan(
+        currentBestuursorgaan
+      ),
     };
   }
 }

--- a/app/routes/organen/orgaan/bulk-bekrachtiging.js
+++ b/app/routes/organen/orgaan/bulk-bekrachtiging.js
@@ -72,6 +72,7 @@ export default class BulkBekrachtigingRoute extends Route {
       currentBestuursorgaan: currentBestuursorgaan,
       publicationStatussen,
       hidePublicationStatus: this.currentSession.group.isOCMW && !isBcsdOrgaan,
+      isFractieColumnHidden: await parentModel.bestuursorgaan.isBCSD,
     };
   }
 }

--- a/app/templates/mandatarissen/persoon/mandataris.hbs
+++ b/app/templates/mandatarissen/persoon/mandataris.hbs
@@ -69,6 +69,7 @@
       @effectiefIsLastPublicationStatus={{this.model.effectiefIsLastPublicationStatus}}
       @canEdit={{not this.notOwnedByUs}}
       @hidePublicationStatus={{this.model.isPublicationStatusHidden}}
+      @isFractieHidden={{@model.isFractieHidden}}
     />
   </div>
 

--- a/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
+++ b/app/templates/organen/orgaan/bulk-bekrachtiging.hbs
@@ -55,6 +55,7 @@
   @checkAll={{this.checkAll}}
   @checkedByDefault={{this.allChecked}}
   @hasMandatarissenToEdit={{this.hasMandatarissenToEdit}}
+  @isFractieColumnHidden={{@model.isFractieColumnHidden}}
 />
 
 {{outlet}}

--- a/app/templates/organen/orgaan/mandatarissen.hbs
+++ b/app/templates/organen/orgaan/mandatarissen.hbs
@@ -139,6 +139,7 @@
   @page={{this.page}}
   @size={{this.size}}
   @bestuursorgaan={{this.model.bestuursorgaan}}
+  @bestuursorgaanInTijd={{@model.bestuursorgaanInTijd}}
   @personRoute="mandatarissen.persoon.mandaten"
   @mandaatRoute="mandatarissen.persoon.mandataris"
   @showRangorde={{await @model.bestuursorgaan.hasRangorde}}

--- a/app/utils/is-fractie-selector-required.js
+++ b/app/utils/is-fractie-selector-required.js
@@ -18,5 +18,9 @@ export async function isDisabledForBestuursorgaan(bestuursorgaanInTijd) {
   }
 
   const bestuursorgaan = await bestuursorgaanInTijd.isTijdsspecialisatieVan;
-  return bestuursorgaan.isPolitieraad;
+  const [isPolitieraad, isBCSD] = await Promise.all([
+    bestuursorgaan.isPolitieraad,
+    bestuursorgaan.isBCSD,
+  ]);
+  return isPolitieraad || isBCSD;
 }


### PR DESCRIPTION
## Description

BCSD mnandatarissen should not have fracties. Hide the columns, values in the mandataris card when the mandataris or orgaan is BCSD.

## How to test

1. Check the mandatarissen for an OCWM BCSD orgaan
2. Fractie should be present in the mandataris card + tables (orgaan/mandatarissen + bulk bekrachtiging)
3. Run the migration from the APP 
4. All fracties should be removed and the fractie column should be hidden in the frontend 

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/458
