### PR TITLE
fix validation count and list incorrect after login

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -27,7 +27,14 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
       if (
         arguments[1] &&
         arguments[1].method != 'GET' &&
-        arguments[0].indexOf('validation-report-api/reports/generate') < 0
+        [
+          'validation-report-api/reports/generate',
+          '/mock/sessions',
+          '/mock/sessions/current',
+          '/sessions/current',
+          '/sessions',
+        ].indexOf(arguments[0]) < 0 &&
+        arguments[0].indexOf('http') !== 0
       ) {
         validatie.queueValidatie.perform();
       }

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 
 export default class LoketSessionService extends SessionService {
   @service currentSession;
+  @service validatie;
 
   get isMockLoginSession() {
     return this.isAuthenticated
@@ -14,6 +15,7 @@ export default class LoketSessionService extends SessionService {
   async handleAuthentication(routeAfterAuthentication) {
     // We wait for the currentSession to load before navigating. This fixes the empty index page since the data might not be loaded yet.
     await this.currentSession.load();
+    await this.validatie.setup();
     super.handleAuthentication(routeAfterAuthentication);
   }
 


### PR DESCRIPTION
## Description

re-setup validations after login success. also limit the calls that trigger validations

## How to test

(on firefox) login using mock login or general login in eenheid with validation issues. see that validation issues are present
refresh page, issues are still present
log out
log in again, validation issues are still there
wait a while, there should be no calls to get a new report unless you did actual updates
do updates, wait 20 seconds. there now should be a call to regenerate the report