### PR TITLE
force selection of data for rangorde

### DIFF
--- a/app/components/date-input.hbs
+++ b/app/components/date-input.hbs
@@ -22,6 +22,7 @@
       placeholder="dd-mm-yyyy"
       {{au-inputmask options=(hash mask="99-99-9999" placeholder="_")}}
       {{on "blur" (perform this.onChange)}}
+      {{on "input" this.onInput}}
       @disabled={{@disabled}}
     />
   {{/if}}

--- a/app/components/date-input.js
+++ b/app/components/date-input.js
@@ -12,6 +12,7 @@ import {
   isDateInRange,
   isValidDate,
 } from 'frontend-lmb/utils/date-manipulation';
+import { action } from '@ember/object';
 
 export default class DateInputComponent extends Component {
   elementId = `date-${guidFor(this)}`;
@@ -112,5 +113,16 @@ export default class DateInputComponent extends Component {
 
   get errorMessages() {
     return `${this.errorMessage ?? ''}`;
+  }
+
+  @action
+  onInput(event) {
+    // format is 31-01-2025 but can have placeolders as _ so 31-0_-____
+    if (
+      event.target?.value &&
+      event.target.value.split('_').join('').length === 10
+    ) {
+      this.onChange.perform(event);
+    }
   }
 }

--- a/app/controllers/organen/orgaan/edit-rangorde.js
+++ b/app/controllers/organen/orgaan/edit-rangorde.js
@@ -14,7 +14,7 @@ export default class EditRangordeController extends Controller {
   @tracked loading = false;
   @tracked modalOpen = false;
   @tracked correcting = false;
-  @tracked date = new Date();
+  @tracked date = null;
   @tracked orderedMandatarissen = [];
   @tracked interceptedTransition = null;
 
@@ -43,7 +43,7 @@ export default class EditRangordeController extends Controller {
   }
 
   get momentizedDate() {
-    return moment(this.date).toDate();
+    return this.date && moment(this.date).toDate();
   }
 
   get openModalDisabled() {

--- a/app/routes/organen/orgaan/edit-rangorde.js
+++ b/app/routes/organen/orgaan/edit-rangorde.js
@@ -65,6 +65,8 @@ export default class EditRangordeRoute extends Route {
     ) {
       controller.interceptedTransition = transition;
       transition.abort();
+    } else if (transition.to.name != 'organen.orgaan.edit-rangorde') {
+      controller.date = null;
     }
   }
 }

--- a/app/templates/organen/orgaan/edit-rangorde.hbs
+++ b/app/templates/organen/orgaan/edit-rangorde.hbs
@@ -53,14 +53,22 @@
     @onChange={{fn (mut this.date)}}
     @isRequired={{true}}
   />
+
 </div>
 
-<Organen::EditMandatarisRangordeTable
-  @mandatarissen={{@model.mandatarisStruct}}
-  @orderedMandatarissen={{this.orderedMandatarissen}}
-  @updateMandatarisList={{this.updateOrderedMandatarisList}}
-  @bestuursperiode={{@model.selectedBestuursperiode}}
-/>
+{{#if this.momentizedDate}}
+  <Organen::EditMandatarisRangordeTable
+    @mandatarissen={{@model.mandatarisStruct}}
+    @orderedMandatarissen={{this.orderedMandatarissen}}
+    @updateMandatarisList={{this.updateOrderedMandatarisList}}
+    @bestuursperiode={{@model.selectedBestuursperiode}}
+  />
+{{else}}
+  <div class="au-u-padding au-u-padding-top-none">
+    <p>Voor je de rangordes kan aanpassen moet je eerst de datum kiezen waarop
+      je de wijziging wil laten ingaan!</p>
+  </div>
+{{/if}}
 
 {{outlet}}
 


### PR DESCRIPTION
## Description

force users to select a date before changing the rangorde of mandatarissen. they don't read the text otherwise.

this also changes the date input so it triggers an onchange if the input is the right length (without placeholders)
## How to test

change rangord
go to another route
go to the rangorde route again, the date should be empty again (but it will be filled if you use the back functionality of the browser, which is fine)
also check if you can still update a date elsewhere in the application