### PR TITLE
LMB-1728 | Mandataris created for overlapping mandataris

### DIFF
--- a/app/services/mandataris.js
+++ b/app/services/mandataris.js
@@ -31,10 +31,10 @@ export default class MandatarisService extends Service {
     let dateToCompare;
     if (startDate) {
       dateToCompare = moment(startDate);
-    } else if (moment().isAfter(mandataris.start)) {
-      dateToCompare = moment();
-    } else {
+    } else if (mandataris.start) {
       dateToCompare = moment(mandataris.start);
+    } else {
+      dateToCompare = moment();
     }
 
     while ((current = toCheck.pop())) {


### PR DESCRIPTION
## Description

A new mandataris was created because the check for overlapping mandates used todays date when the mandataris start date was before today.

## How to test

1. Go to Harelbeke 
2. Check out mandataris Lise-marie
3. Check out andre 
4. Lise should be the verhinderde and Andre will will in its place
5. When selecting Andre as the verhinderde it should use the existing mandataris instead of creating a new one
6. Noraml verhindering should also be possible