### PR TITLE
fix beleidsdomein diff in timeline

### DIFF
--- a/app/components/mandatarissen/timeline-diff.js
+++ b/app/components/mandatarissen/timeline-diff.js
@@ -10,7 +10,11 @@ const fieldsToDiff = [
   {
     label: 'beleidsdomeinen',
     path: 'beleidsdomein',
-    valueFormatter: (codes) => codes.map((code) => code.label).join(', '),
+    valueFormatter: (codes) => {
+      const sortedCodes = [...(codes || [])];
+      sortedCodes.sort((a, b) => (a.id > b.id ? -1 : 1));
+      return sortedCodes.map((code) => code.label).join(', ');
+    },
   },
 ];
 


### PR DESCRIPTION
## Description

fixes the beleidsdomeinen always being marked as changed because the sorting can be different
<img width="1330" height="532" alt="image" src="https://github.com/user-attachments/assets/7a0f7cb3-592f-4547-bf47-0ce17a990cc8" />

## How to test

go to a mandataris with beleidsdomeinen and see that they don't normally change
update a beleidsdomein, the change should now be visible
remove the change again, it should no longer be marked as different