### PR TITLE
fold publication status too and keep the niet-bekrachtigd ones

### DIFF
--- a/app/components/mandaat/publicatie-status-pill.js
+++ b/app/components/mandaat/publicatie-status-pill.js
@@ -18,7 +18,9 @@ export default class MandaatPublicatieStatusPillComponent extends Component {
   }
 
   get status() {
-    return this.args.mandataris.publicationStatus;
+    return (
+      this.args.publicationStatus || this.args.mandataris.publicationStatus
+    );
   }
 
   async getSkinForPill(statusPromise) {

--- a/app/components/organen/mandataris-table.hbs
+++ b/app/components/organen/mandataris-table.hbs
@@ -138,6 +138,7 @@
         <td>
           <Mandaat::PublicatieStatusPill
             @mandataris={{row.mandataris}}
+            @publicationStatus={{row.publicationStatus}}
             @showBekijkBewijs={{false}}
           />
         </td>

--- a/app/utils/fold-mandatarisses.js
+++ b/app/utils/fold-mandatarisses.js
@@ -28,11 +28,18 @@ export async function fold(mandatarissen, validatie) {
     })
   );
   return Object.values(persoonMandaatData).map(
-    ({ foldedStart, foldedEnd, mandataris, validationErrors }) => {
+    ({
+      foldedStart,
+      foldedEnd,
+      mandataris,
+      validationErrors,
+      publicationStatus,
+    }) => {
       return {
         foldedStart,
         foldedEnd,
         mandataris,
+        publicationStatus,
         validationErrors,
       };
     }
@@ -107,6 +114,7 @@ function updateFoldedMandataris(
 ) {
   updateFoldedStart(mandataris, foldedMandataris);
   updateFoldedEnd(mandataris, foldedMandataris);
+  updatePublicationStatus(mandataris, foldedMandataris);
   updateMandataris(mandataris, foldedMandataris);
   if (validationResults && !foldedMandataris.validationErrors) {
     const hasIssues = !!validationResults.find(
@@ -128,6 +136,7 @@ function buildFoldedMandataris(mandataris, validationResults) {
   return {
     foldedStart: mandataris.start,
     foldedEnd: mandataris.displayEinde,
+    publicationStatus: mandataris.publicationStatus,
     validationErrors,
     mandataris,
   };
@@ -163,5 +172,14 @@ function updateMandataris(mandataris, foldedMandataris) {
     !mandataris.einde
   ) {
     foldedMandataris.mandataris = mandataris;
+  }
+}
+
+function updatePublicationStatus(mandataris, foldedMandataris) {
+  if (
+    !mandataris.publicationStatus ||
+    !mandataris.get('publicationStatus.isBekrachtigd')
+  ) {
+    foldedMandataris.publicationStatus = mandataris.publicationStatus;
   }
 }


### PR DESCRIPTION
## Description
Mandataris instances in the orgaan view were shown as bekrachtigd even if they had an item in their timeline that was not bekrachtigd. This confused users and made them reach out to the helpdesk.
## How to test

Go to any mandataris, add a niet bekrachtigd mandate not overlapping with the current date. The list should now show 'niet-bekrachtigd' instead of bekrachtigd. This helps users find issues in their data.
