### PR TITLE
lmb-1761 | timeline card errors are now warnings

### DIFF
--- a/app/components/mandatarissen/timeline-card.hbs
+++ b/app/components/mandatarissen/timeline-card.hbs
@@ -60,12 +60,12 @@
     <Mandatarissen::TimelineDiff @event={{@event}} />
     {{#if this.hasOverlapWithNext}}
       <AuAlert
-        @skin="error"
+        @skin="warning"
         @size="tiny"
         @closable={{false}}
         class="au-u-padding-tiny au-u-margin-bottom-none au-u-margin-top-tiny au-u-para-small"
       >
-        <p class="au-u-error"><AuIcon @icon="alert-triangle" />
+        <p class="au-u-warning"><AuIcon @icon="alert-triangle" />
           Dit mandaat loopt door tot
           {{moment-format @event.mandataris.einde "DD-MM-YYYY"}}, dat is na de
           startdatum van het volgende mandaat.</p>
@@ -74,12 +74,12 @@
 
     {{#if this.hasGapUntilNext}}
       <AuAlert
-        @skin="error"
+        @skin="warning"
         @size="tiny"
         @closable={{false}}
         class="au-u-padding-tiny au-u-margin-bottom-none au-u-margin-top-tiny au-u-para-small"
       >
-        <p class="au-u-error"><AuIcon @icon="alert-triangle" />
+        <p class="au-u-warning"><AuIcon @icon="alert-triangle" />
           Dit mandaat eindigt op
           {{moment-format @event.mandataris.einde "DD-MM-YYYY"}}, dat is voor
           het begin van het volgende mandaat.</p>


### PR DESCRIPTION
## Description

We do not want to show a big red card when there is overlap with the other mandatarissen. Make the skin warning

## How to test

Go to Alex as in the ticket and see that it is now orange (warning) instead of red (error)


## Attachments

<img width="1257" height="411" alt="image" src="https://github.com/user-attachments/assets/471a61ca-7bb6-4286-b8c2-718d15b8e373" />
