### PR TITLE
enable rangorde for districtsraadsleden

### DIFF
--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -11,6 +11,8 @@ import {
   BCSD_BESTUURSORGAAN_URI,
   BURGEMEESTER_BESTUURSORGAAN_URI,
   CBS_BESTUURSORGAAN_URI,
+  DISTRICTS_COLLEGE_BESTUURSORGAAN_URI,
+  DISTRICTSRAAD_BESTUURSORGAAN_URI,
   GEMEENTERAAD_BESTUURSORGAAN_URI,
   RMW_BESTUURSORGAAN_URI,
   VAST_BUREAU_BESTUURSORGAAN_URI,
@@ -142,6 +144,18 @@ export default class BestuursorgaanModel extends Model {
     return this.hasBestuursorgaanClassificatie(CBS_BESTUURSORGAAN_URI);
   }
 
+  get isDistrictsCollege() {
+    return this.hasBestuursorgaanClassificatie(
+      DISTRICTS_COLLEGE_BESTUURSORGAAN_URI
+    );
+  }
+
+  get isDistrictsraad() {
+    return this.hasBestuursorgaanClassificatie(
+      DISTRICTSRAAD_BESTUURSORGAAN_URI
+    );
+  }
+
   get isRMW() {
     return this.hasBestuursorgaanClassificatie(RMW_BESTUURSORGAAN_URI);
   }
@@ -155,7 +169,12 @@ export default class BestuursorgaanModel extends Model {
   }
 
   get hasRangorde() {
-    return Promise.all([this.isCBS, this.isGR]).then((promise) => {
+    return Promise.all([
+      this.isCBS,
+      this.isGR,
+      this.isDistrictsCollege,
+      this.isDistrictsraad,
+    ]).then((promise) => {
       return promise.some((value) => value);
     });
   }

--- a/app/models/mandaat.js
+++ b/app/models/mandaat.js
@@ -5,6 +5,7 @@ import {
   MANDAAT_AANGEWEZEN_BURGEMEESTER_CODE,
   MANDAAT_BURGEMEESTER_CODE,
   MANDAAT_DISTRICT_BURGEMEESTER_CODE,
+  MANDAAT_DISTRICT_RAADSLID_CODE,
   MANDAAT_DISTRICT_SCHEPEN_CODE,
   MANDAAT_GEDEPUTEERDE_CODE,
   MANDAAT_GEMEENTERAADSLID_CODE,
@@ -87,6 +88,11 @@ export default class MandaatModel extends Model {
       this.bestuursfunctie.get('uri')
     );
   }
+  get isDistrictsraadslid() {
+    return [MANDAAT_DISTRICT_RAADSLID_CODE].includes(
+      this.bestuursfunctie.get('uri')
+    );
+  }
 
   get isVoorzitter() {
     return this.bestuursfunctie.get('isVoorzitter');
@@ -97,7 +103,9 @@ export default class MandaatModel extends Model {
   }
 
   get hasRangorde() {
-    return this.isSchepen || this.isGemeenteraadslid;
+    return (
+      this.isSchepen || this.isGemeenteraadslid || this.isDistrictsraadslid
+    );
   }
 
   get allowsNonElectedPersons() {

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -42,6 +42,10 @@ export const VAST_BUREAU_BESTUURSORGAAN_URI =
   'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008';
 export const BCSD_BESTUURSORGAAN_URI =
   'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009';
+export const DISTRICTS_COLLEGE_BESTUURSORGAAN_URI =
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000b';
+export const DISTRICTSRAAD_BESTUURSORGAAN_URI =
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a';
 
 export const MANDAAT_GEMEENTERAADSLID_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000011';

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -63,6 +63,8 @@ export const MANDAAT_AANGEWEZEN_BURGEMEESTER_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/7b038cc40bba10bec833ecfe6f15bc7a';
 export const MANDAAT_DISTRICT_BURGEMEESTER_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001d';
+export const MANDAAT_DISTRICT_RAADSLID_CODE =
+  'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001b';
 export const MANDAAT_SCHEPEN_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000014';
 export const MANDAAT_TOEGEVOEGDE_SCHEPEN_CODE =


### PR DESCRIPTION
## Description

enables rangorde for districtsraadsleden and enabled updating rangorde for those organs (e.g. borgerhout)


## How to test

create and edit a districtsraadslid with rangorde, update rangorde in bulk for that organ
