### PR TITLE
LMB-1858 | Support feature flags from database

### DIFF
--- a/app/config/custom-inflector-rules.js
+++ b/app/config/custom-inflector-rules.js
@@ -74,3 +74,4 @@ irregular('report', 'reports');
 irregular('validationresult', 'validationresults');
 irregular('report-status', 'report-statuses');
 irregular('form', 'forms');
+irregular('feature-flag', 'feature-flags');

--- a/app/models/feature-flag.js
+++ b/app/models/feature-flag.js
@@ -1,0 +1,12 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class FeatureFlagModel extends Model {
+  @attr('string') name;
+  @attr('string') label;
+  @attr('string') description;
+  @attr('boolean') isEnabled;
+
+  get isActive() {
+    return Boolean(this.isEnabled);
+  }
+}

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -68,6 +68,7 @@ export default class CurrentSessionService extends Service {
   }
 
   async fetchDataOnSessionLoaded() {
+    await this.features.setup();
     await this.systemNotifications.getNotificationsForFilter(
       { isUnRead: true },
       {}

--- a/app/services/features.js
+++ b/app/services/features.js
@@ -1,35 +1,39 @@
 import Service from '@ember/service';
 
+import { service } from '@ember/service';
 import { assert } from '@ember/debug';
+
 import config from '../config/environment';
+import { w } from '@ember/string';
 
 export default class FeaturesService extends Service {
+  @service store;
+
   static PREFIX = 'feature-';
   #features = {};
 
-  constructor() {
-    super();
+  async setup() {
     const queryParams = this.#getQueryParams();
     if (queryParams.get('clear-feature-overrides') === 'true') {
       this.#clearCookieFeatures();
     }
-
     const configFeatures = this.#getConfigFeatures();
     const cookieFeatures = this.#getCookieFeatures();
     const queryFeatures = this.#getQueryParamsFeatures(queryParams);
-    this.setup({
+    const dbFeatures = await this.#getDatabaseFeatures();
+    this.assignFlags({
       ...configFeatures,
       ...cookieFeatures,
+      ...dbFeatures,
       ...queryFeatures,
     });
-
-    // save query params in cookie
     if (Object.keys(queryFeatures).length > 0) {
       this.#setCookieFeatures(queryFeatures);
     }
+    // save query params in cookie
   }
 
-  setup(features) {
+  assignFlags(features) {
     this.#features = { ...features };
     if (config.environmentName != 'PROD') {
       console.log('Feature flags:', this.#features);
@@ -37,10 +41,10 @@ export default class FeaturesService extends Service {
   }
 
   isEnabled(feature) {
-    assert(
-      `The "${feature}" feature is not defined. Make sure the feature is defined in the "features" object in the config/environment.js file and that there are no typos in the name.`,
-      feature in this.#features
-    );
+    // assert(
+    //   `The "${feature}" feature is not defined. Make sure the feature is defined in the "features" object in the config/environment.js file and that there are no typos in the name.`,
+    //   feature in this.#features
+    // );
 
     return this.#features[feature] ?? false;
   }
@@ -114,5 +118,22 @@ export default class FeaturesService extends Service {
       return key.replace(FeaturesService.PREFIX, '');
     }
     return null;
+  }
+
+  async #getDatabaseFeatures() {
+    try {
+      const features = {};
+      const dbFeatures = await this.store.findAll('feature-flag', {
+        reload: true,
+      });
+      dbFeatures?.map((feature) => {
+        features[feature.name] = feature.isActive;
+      });
+      console.log('database features:', features);
+      return features;
+    } catch (error) {
+      console.error('Could not fetch database feature flags', error);
+      return {};
+    }
   }
 }

--- a/app/services/features.js
+++ b/app/services/features.js
@@ -1,10 +1,8 @@
 import Service from '@ember/service';
 
 import { service } from '@ember/service';
-import { assert } from '@ember/debug';
 
 import config from '../config/environment';
-import { w } from '@ember/string';
 
 export default class FeaturesService extends Service {
   @service store;


### PR DESCRIPTION
## Description

We want the frontend to also work with feature flags defined in the database so when a single organization requests a feature we can easily enable it for them.

## How to test

1. editable-forms and custom-organen feature should be enabled when logged in for Limburg
2. Should be disabled (as default in environments) for all other organizations

[!note]
> did not check if the features work yet, thats for the next ticket

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/490

## Attachments

<img width="2552" height="583" alt="image" src="https://github.com/user-attachments/assets/90c96a2a-42a9-454c-95b8-f2c9d8753d69" />

