### PR TITLE
LMB-1923 | Custom forms "eigen veld" option should be behind a feature flag

### DIFF
--- a/app/components/rdf-input-fields/crud-custom-field-modal.js
+++ b/app/components/rdf-input-fields/crud-custom-field-modal.js
@@ -30,6 +30,7 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
   @service toaster;
   @service formReplacements;
   @service customForms;
+  @service features;
 
   @tracked isRemovingField;
   @tracked isFieldRequired;
@@ -51,7 +52,9 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
   constructor() {
     super(...arguments);
 
-    this.libraryFieldType = LibraryEntryModel.ensureFakeEntry(this.store);
+    if (this.canCreateCustomField) {
+      this.libraryFieldType = LibraryEntryModel.ensureFakeEntry(this.store);
+    }
 
     let withValue = TEXT_CUSTOM_DISPLAY_TYPE;
     if (!this.args.isCreating) {
@@ -383,7 +386,15 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
     return this.fieldName && this.fieldName.trim().length > 1;
   }
 
+  get canCreateCustomField() {
+    return this.features.isEnabled('can-create-custom-form-field');
+  }
+
   get canSelectTypeForEntry() {
+    if (!this.canCreateCustomField) {
+      return false;
+    }
+
     if (this.args.isCreating) {
       return this.libraryFieldType.isNew; // so the fake one we created
     }
@@ -410,7 +421,6 @@ export default class RdfInputFieldCrudCustomFieldModalComponent extends Componen
 
 function getLibraryFieldOptions() {
   return trackedFunction(async () => {
-    const customFieldEntry = LibraryEntryModel.ensureFakeEntry(this.store);
     const allOptions = await this.store.query('library-entry', {
       sort: 'name',
       include: 'display-type',
@@ -418,9 +428,15 @@ function getLibraryFieldOptions() {
     const usedOptions = this.forkingStore
       .match(null, PROV('wasDerivedFrom'), null, SOURCE_GRAPH)
       .map((triple) => triple.object.value);
-    const unused = allOptions.filter((entry) => {
+    const unusedFields = allOptions.filter((entry) => {
       return entry.uri && usedOptions.indexOf(entry.uri) < 0;
     });
-    return [customFieldEntry, ...unused];
+
+    if (this.features.isEnabled('can-create-custom-form-field')) {
+      const customFieldEntry = LibraryEntryModel.ensureFakeEntry(this.store);
+      return [customFieldEntry, ...unusedFields];
+    } else {
+      return unusedFields;
+    }
   });
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -36,6 +36,7 @@ module.exports = function (environment) {
       'custom-organen': false,
       politieraad: false,
       'editable-forms': false,
+      'can-create-custom-form-field': false,
       'shacl-report': true,
     },
     lpdcUrl: '{{LPDC_URL}}',


### PR DESCRIPTION
## Description

We do not want everyone to start creating their own custom fields, push them to using library fields so we can control the sh:path of the field

## How to test

1. The feature flag is `can-create-custom-form-field` is disabled by default
2. Go to a custom form and try to add an "eigen-veld" (this should not be possible)
3. The field will be empty for the field TYPE
4. Enable the feature by add `?feature-can-create-custom-form-field=true` to the url
5. Everything should work as before

## Attachments

<img width="799" height="675" alt="image" src="https://github.com/user-attachments/assets/e3e09d1f-440c-4df9-9513-7969c7ad9a01" />

**When empty**
<img width="799" height="675" alt="image" src="https://github.com/user-attachments/assets/4bc46710-6f10-4e1c-9c73-ff2cd243fa15" />


