### PR TITLE
LMB-1925 | Make rangorde toggleable for custom organen

### DIFF
--- a/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
+++ b/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
@@ -13,6 +13,9 @@
           <th>Min aantal houders</th>
         {{/if}}
         <th>Max Aantal houders</th>
+        {{#unless (await @bestuursorgaanIT.isDecretaal)}}
+          <th>Heeft rangorde?</th>
+        {{/unless}}
         <th></th>
       </c.header>
       <c.body as |mandaat|>
@@ -43,6 +46,15 @@
             {{mandaat.aantalHouders}}
           {{/if}}
         </td>
+        {{#unless (await @bestuursorgaanIT.isDecretaal)}}
+          <td>
+            {{#if mandaat.withRangorde}}
+              Ja
+            {{else}}
+              Nee
+            {{/if}}
+          </td>
+        {{/unless}}
         <td>
           {{#if (eq this.editMandaat.id mandaat.id)}}
             <AuButton

--- a/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
+++ b/app/components/mandatenbeheer/bestuursorgaan-mandaten.hbs
@@ -48,10 +48,17 @@
         </td>
         {{#unless (await @bestuursorgaanIT.isDecretaal)}}
           <td>
-            {{#if mandaat.withRangorde}}
-              Ja
+            {{#if (eq this.editMandaat.id mandaat.id)}}
+              <AuToggleSwitch
+                @checked={{this.withRangorde}}
+                @onChange={{this.updateWithRangorde}}
+              >{{this.label}}</AuToggleSwitch>
             {{else}}
-              Nee
+              {{#if mandaat.withRangorde}}
+                Ja
+              {{else}}
+                Nee
+              {{/if}}
             {{/if}}
           </td>
         {{/unless}}
@@ -59,7 +66,7 @@
           {{#if (eq this.editMandaat.id mandaat.id)}}
             <AuButton
               {{on "click" this.saveMandaat}}
-              @disabled={{not this.aantalHouders}}
+              @disabled={{this.disabled}}
             >
               Bewaar
             </AuButton>

--- a/app/components/mandatenbeheer/bestuursorgaan-mandaten.js
+++ b/app/components/mandatenbeheer/bestuursorgaan-mandaten.js
@@ -19,6 +19,7 @@ export default class MandatenbeheerBestuursorgaanMandatenComponent extends Compo
   @tracked removingMandaatId = null;
 
   @tracked editMandaat = null;
+  @tracked withRangorde = null;
   @tracked aantalHouders;
   @tracked errorMessageAantalHouders;
   @tracked showMinMax = false;
@@ -90,6 +91,7 @@ export default class MandatenbeheerBestuursorgaanMandatenComponent extends Compo
   @action
   startEditMandaat(mandaat) {
     this.editMandaat = mandaat;
+    this.withRangorde = mandaat.withRangorde;
   }
   @action
   updateAantalHouders(event) {
@@ -106,9 +108,16 @@ export default class MandatenbeheerBestuursorgaanMandatenComponent extends Compo
 
     this.aantalHouders = aantal;
   }
+
+  @action
+  updateWithRangorde(hasRangorde) {
+    this.withRangorde = Boolean(hasRangorde);
+  }
+
   @action
   async saveMandaat() {
     this.editMandaat.aantalHouders = this.aantalHouders;
+    this.editMandaat.withRangorde = this.withRangorde;
     await this.editMandaat.save();
     this.aantalHouders = null;
     this.editMandaat = null;
@@ -116,6 +125,7 @@ export default class MandatenbeheerBestuursorgaanMandatenComponent extends Compo
   @action
   cancelEditMandaat() {
     this.aantalHouders = null;
+    this.withRangorde = null;
     this.editMandaat = false;
   }
 
@@ -125,7 +135,11 @@ export default class MandatenbeheerBestuursorgaanMandatenComponent extends Compo
   }
 
   get disabled() {
-    return !this.aantalHouders || !this.isPositiveNumber(this.aantalHouders);
+    const withRangordeChanged =
+      this.withRangorde !== this.editMandaat.withRangorde;
+    const aantalHoudersValid =
+      this.aantalHouders && this.isPositiveNumber(this.aantalHouders);
+    return !aantalHoudersValid && !withRangordeChanged;
   }
 
   get toolTipText() {

--- a/app/components/mandatenbeheer/bestuursorgaan-mandaten.js
+++ b/app/components/mandatenbeheer/bestuursorgaan-mandaten.js
@@ -27,9 +27,6 @@ export default class MandatenbeheerBestuursorgaanMandatenComponent extends Compo
   constructor() {
     super(...arguments);
     this.selectedBestuursfunctie = this.args.availableBestuursfuncties[0];
-    this.showMinMax = this.args.orderedMandaten.some(
-      (obj) => obj.minAantalHouders !== undefined
-    );
   }
 
   createMandaat = task({ drop: true }, async () => {

--- a/app/models/bestuursorgaan.js
+++ b/app/models/bestuursorgaan.js
@@ -14,6 +14,7 @@ import {
   DISTRICTS_COLLEGE_BESTUURSORGAAN_URI,
   DISTRICTSRAAD_BESTUURSORGAAN_URI,
   GEMEENTERAAD_BESTUURSORGAAN_URI,
+  LB_ORGAAN_CLASSIFICATIE_URIS,
   RMW_BESTUURSORGAAN_URI,
   VAST_BUREAU_BESTUURSORGAAN_URI,
 } from 'frontend-lmb/utils/well-known-uris';
@@ -130,9 +131,14 @@ export default class BestuursorgaanModel extends Model {
 
   get hasCustomBestuursorgaanClassificatie() {
     return this.classificatieUri().then((uri) => {
-      return uri.startsWith(
+      const isStartingWithCustomUri = uri.startsWith(
         'http://data.lblod.info/id/lb-orgaan-classificatiecode/'
       );
+      if (isStartingWithCustomUri) {
+        return true;
+      }
+
+      return LB_ORGAAN_CLASSIFICATIE_URIS.includes(uri);
     });
   }
 
@@ -183,8 +189,8 @@ export default class BestuursorgaanModel extends Model {
       this.isDistrictsCollege,
       this.isDistrictsraad,
       this.hasCustomBestuursorgaanClassificatie,
-    ]).then((promise) => {
-      return promise.some((value) => value);
+    ]).then((values) => {
+      return values.some((value) => value);
     });
   }
 

--- a/app/models/mandaat.js
+++ b/app/models/mandaat.js
@@ -1,7 +1,6 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { service } from '@ember/service';
 
-import { CUSTOM_ORGAAN_MANDAAT_IDS_WITH_RANGORDE } from 'frontend-lmb/utils/well-known-ids';
 import {
   MANDAAT_AANGEWEZEN_BURGEMEESTER_CODE,
   MANDAAT_BURGEMEESTER_CODE,
@@ -104,18 +103,11 @@ export default class MandaatModel extends Model {
     return this.bestuursfunctie.get('uri') == MANDAAT_GOUVERNEUR_CODE;
   }
 
-  get isCustomOrgaanMandaatWithRangorde() {
-    return CUSTOM_ORGAAN_MANDAAT_IDS_WITH_RANGORDE.includes(
-      this.bestuursfunctie.get('id')
-    );
-  }
-
   get hasRangorde() {
     const defaultMandatesWithRangorde = [
       this.isSchepen,
       this.isGemeenteraadslid,
       this.isDistrictsraadslid,
-      this.isCustomOrgaanMandaatWithRangorde,
     ];
 
     if (defaultMandatesWithRangorde.some((hasRangorde) => hasRangorde)) {

--- a/app/models/mandaat.js
+++ b/app/models/mandaat.js
@@ -20,6 +20,7 @@ const identity = Boolean;
 export default class MandaatModel extends Model {
   @attr uri;
   @attr aantalHouders;
+  @attr('boolean') withRangorde;
 
   get maxAantalHouders() {
     return this.aantalHouders;
@@ -110,12 +111,18 @@ export default class MandaatModel extends Model {
   }
 
   get hasRangorde() {
-    return (
-      this.isSchepen ||
-      this.isGemeenteraadslid ||
-      this.isDistrictsraadslid ||
-      this.isCustomOrgaanMandaatWithRangorde
-    );
+    const defaultMandatesWithRangorde = [
+      this.isSchepen,
+      this.isGemeenteraadslid,
+      this.isDistrictsraadslid,
+      this.isCustomOrgaanMandaatWithRangorde,
+    ];
+
+    if (defaultMandatesWithRangorde.some((hasRangorde) => hasRangorde)) {
+      return true;
+    }
+
+    return this.withRangorde;
   }
 
   get allowsNonElectedPersons() {

--- a/app/routes/organen/orgaan/index.js
+++ b/app/routes/organen/orgaan/index.js
@@ -17,7 +17,11 @@ export default class OrganenOrgaanIndexRoute extends Route {
     const parentModel = this.modelFor('organen.orgaan');
 
     const currentBestuursorgaan = await parentModel.currentBestuursorgaan;
-    const mandaten = await currentBestuursorgaan.bevat;
+    const mandaten = await this.store.query(`mandaat`, {
+      'filter[bevat-in][id]': currentBestuursorgaan.id,
+      page: { size: 100 },
+      sort: 'bestuursfunctie.label',
+    });
     const [orderedMandaten, availableBestuursfuncties] = await Promise.all([
       this.orderMandaten(mandaten),
       this.computeBestuursfuncties(mandaten),

--- a/app/utils/well-known-ids.js
+++ b/app/utils/well-known-ids.js
@@ -73,14 +73,6 @@ export const VB_ORGANEN_VOEREN_EN_RAND = [
 ];
 export const POLITIERAAD_CODE_ID = '1afce932-53c1-46d8-8aab-90dcc331e67d';
 
-export const CUSTOM_ORGAAN_MANDAAT_IDS_WITH_RANGORDE = [
-  '28d0ed76-e1a3-4c90-89df-4d11587390b3', // Lid
-  '22da4572-4818-454b-bbd4-28a9ea97856c', // Voorzitter
-  '9f4dbcea-f543-4b63-8b23-b5d543933ee1', // Ondervoorzitter
-  'c5506328-6187-4986-960c-38f87fe9fa7d', // Secretaris
-  '9e8110c8-7c98-42ad-ab96-6cc33cfd10cd', // Plaatsvervangend lid
-];
-
 export const OVERIGE_BESTUURSPERIODE_ID =
   '9486222f-2696-4811-bde1-fef9dc4b5f68';
 export const FAKE_ALLE_BESTUURSPERIODE_ID =

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -46,6 +46,13 @@ export const DISTRICTS_COLLEGE_BESTUURSORGAAN_URI =
   'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000b';
 export const DISTRICTSRAAD_BESTUURSORGAAN_URI =
   'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a';
+// These lb-orgaan-classificatie uris are also in the custom orgaan list but they have a known uri
+export const LB_ORGAAN_CLASSIFICATIE_URIS = [
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5733254e-73ff-4844-8d43-7afb7ec726e8', // Directiecomité
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528', // Algemene vergadering
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943', // Raad van bestuur
+  'http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/17e76b36-64a1-4db1-8927-def3064b4bf1', // Regionaal bestuurscomité
+];
 
 export const MANDAAT_GEMEENTERAADSLID_CODE =
   'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000011';


### PR DESCRIPTION
## Description

We want the user to be able to toggle rangorde field for custom orgaan mandate types

## How to test

1. Go to a decretaal orgaan => no rangorde column
2. Go to a custom orgaan detail page => rangorde column
3. Ja or Nee is shown when they have rangorde or not
4. Can toggle the ja nee when clicking bewerk
5. Places where rangorde value can be defined should be avaliable for all places (mandataris, bewerk rangorde bulk)

**Note:** I had to add an array of lb-orgaan-classificatie because there are 4 concept schemes that are also in the custom orgaan list that otherwise did not get the function to bulk edit the rangorde.

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/505

## Attachments

**added column when niet-decretaal**
<img width="1234" height="801" alt="image" src="https://github.com/user-attachments/assets/19730107-fc5a-45a5-9f76-8da98ac0a9d8" />

**mandataris for mandaat with rangorde toggled on**
<img width="1234" height="801" alt="image" src="https://github.com/user-attachments/assets/8895a9d7-bfd2-45e9-9901-43e8bc41540a" />

<img width="2035" height="308" alt="image" src="https://github.com/user-attachments/assets/fea8e74e-c125-4a92-90de-7c98d2bf3256" />

** change bulk rangorde**
<img width="1645" height="602" alt="image" src="https://github.com/user-attachments/assets/68f176cf-4bae-4fa7-9ea2-f19850c4649d" />


